### PR TITLE
Support needed for TOSS3

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -158,6 +158,9 @@
 /* install prefix */
 #undef LMON_PREFIX
 
+/* Enable a workaround to cope with additional SIGCONT sent by slurmstepd */
+#undef LMON_SLURM_MPAO_WR
+
 /* Define to header that first defines elf. */
 #undef LOCATION_OF_LIBELFHEADER
 

--- a/config/x_ac_platform_compat.m4
+++ b/config/x_ac_platform_compat.m4
@@ -1,0 +1,46 @@
+# $Header: $
+#
+# x_ac_testnnodes.m4
+#
+# --------------------------------------------------------------------------------
+# Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+# the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
+# LLNL-CODE-409469 All rights reserved.
+#
+#  This file is part of LaunchMON. For details, see
+#  https://computing.llnl.gov/?set=resources&page=os_projects
+#
+#  Please also read LICENSE -- Our Notice and GNU Lesser General Public License.
+#
+#
+#  This program is free software; you can redistribute it and/or modify it under the
+#  terms of the GNU General Public License (as published by the Free Software
+#  Foundation) version 2.1 dated February 1999.
+#
+#  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License along
+#  with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+#  Place, Suite 330, Boston, MA 02111-1307 USA
+# --------------------------------------------------------------------------------
+#
+#   Update Log:
+#         May 06 2016 DHA: File created
+#
+
+AC_DEFUN([X_AC_SLURM_MPAO_WR], [
+  AC_MSG_CHECKING([whether to turn on a workaround for slurm's MPIR_partitial_attach_ok bug])
+  AC_ARG_ENABLE([slurm-mpao-workaround],
+    AS_HELP_STRING(--enable-slurm-mpao-workaround, enables a fix that works around slurm's MPIR_partitial_attach_ok bug),
+    [enable_mpao_workaround=$enableval],
+    [enable_mpao_workaround=no])
+
+  if test "x$enable_mpao_workaround" = "xyes"; then
+    AC_DEFINE(LMON_SLURM_MPAO_WR, 1,
+      [Enable a workaround to cope with additional SIGCONT sent by slurmstepd])
+  fi
+  AC_MSG_RESULT($enable_mpao_workaround)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,7 @@ dnl -----------------------------------------------
 dnl Checks for the OS/CPU/RM type
 dnl -----------------------------------------------
 X_AC_PLATFORM
+X_AC_SLURM_MPAO_WR
 
 dnl -----------------------------------------------
 dnl enable debug support

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.cxx
@@ -242,9 +242,13 @@ LMON_be_procctl_initdone_ptrace ( MPIR_PROCDESC_EXT* ptab,
   int i;
   int status;
 
+#ifdef LMON_SLURM_MPAO_WR
   //
-  // initdone need to harvest a trap event due to SIGCONT 
-  // sent to the target process by the RM controller first 
+  // initdone need to harvest a trap event due to SIGCONT
+  // sent to the target process by the RM controller first.
+  //
+  // This can happen on a system because of a brittle code
+  // desribed in Issue #16.
   //
   for ( i = 0; i < psize; ++i )
     {
@@ -262,6 +266,8 @@ LMON_be_procctl_initdone_ptrace ( MPIR_PROCDESC_EXT* ptab,
           rc = LMON_EINVAL;
         }
     }
+
+#endif
 
   //
   // Send a SIGSTOP for the target processes so that you 

--- a/launchmon/src/linux/sdbg_linux_launchmon.cxx
+++ b/launchmon/src/linux/sdbg_linux_launchmon.cxx
@@ -617,12 +617,9 @@ linux_launchmon_t::launch_tool_daemons (
         {
           hnstream << pos->first;
           count++;
-          if (count < get_proctable_copy().size())
-            {
-              hnstream << "\n";
-            } 
+          hnstream << "\n";
         }
-
+      hnstream.flush();
       hnstream.close();
 
       p.rmgr()->set_paramset(


### PR DESCRIPTION
This PR contains some support needed for TOSS3 support. Some of the contexts are described in Issue #16. 

Add `--enable-slurm-mpao-workaround` support so that one can turn on the code that can work around a bug within SLURM's `MPIR_partial_attach_ok` support.

Add a fix for hostlist file generation.