### PR TITLE
manpage: Fix a typo

### DIFF
--- a/launchmon/man/LMON_fe_launchAndSpawnDaemons.3
+++ b/launchmon/man/LMON_fe_launchAndSpawnDaemons.3
@@ -95,7 +95,7 @@ An error encountered while waiting on some events from other dependent component
 
 .SH ENVIRONMENT VARIABLES
 .TP
-.B LMON_VERBOSE
+.B LMON_VERBOSITY
 overwrites the verbose level: [0-3] (default: 0).
 .TP
 .B LMON_FE_ENGINE_TIMEOUT


### PR DESCRIPTION
Change LMON_VERBOSE to LMON_VERBOSITY as it should. (reported by James Southern <jsouthern@sgi.com>