### PR TITLE
Cleanup and coding style changes

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,321 +1,321 @@
-OUR NOTICE AND TERMS AND CONDITIONS OF THE GNU 
+OUR NOTICE AND TERMS AND CONDITIONS OF THE GNU
 GENERAL PUBLIC LICENSE
 
 Our Preamble Notice
 
-A. This notice is required to be provided under our contract with the U.S. 
-Department of Energy (DOE). This work was produced at the Lawrence Livermore 
+A. This notice is required to be provided under our contract with the U.S.
+Department of Energy (DOE). This work was produced at the Lawrence Livermore
 National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
 
-B. Neither the United States Government nor Lawrence Livermore National Security, 
-LLC nor any of their employees, makes any warranty, express or implied, or assumes 
-any liability or responsibility for the accuracy, completeness, or usefulness of any 
-information, apparatus, product, or process disclosed, or represents that its use would not 
+B. Neither the United States Government nor Lawrence Livermore National Security,
+LLC nor any of their employees, makes any warranty, express or implied, or assumes
+any liability or responsibility for the accuracy, completeness, or usefulness of any
+information, apparatus, product, or process disclosed, or represents that its use would not
 infringe privately-owned rights.
 
-C. Also, reference herein to any specific commercial products, process, or services by trade 
-name, trademark, manufacturer or otherwise does not necessarily constitute or imply 
-its endorsement, recommendation, or favoring by the United States Government or Lawrence 
-Livermore National Security, LLC. The views and opinions of authors expressed herein do 
-not necessarily state or reflect those of the United States Government or Lawrence 
-Livermore National Security, LLC, and shall not be used for advertising or product 
+C. Also, reference herein to any specific commercial products, process, or services by trade
+name, trademark, manufacturer or otherwise does not necessarily constitute or imply
+its endorsement, recommendation, or favoring by the United States Government or Lawrence
+Livermore National Security, LLC. The views and opinions of authors expressed herein do
+not necessarily state or reflect those of the United States Government or Lawrence
+Livermore National Security, LLC, and shall not be used for advertising or product
 endorsement purposes.
 
-The precise terms and conditions for copying, distribution and modification 
+The precise terms and conditions for copying, distribution and modification
 follows.
 
 GNU Lesser GPL terms and Conditions for Copying, Distribution, and Modification
 
-0. This License Agreement applies to any software library or other program which 
-contains a notice placed by the copyright holder or other authorized party saying it 
-may be distributed under the terms of this Lesser General Public License (also called 
+0. This License Agreement applies to any software library or other program which
+contains a notice placed by the copyright holder or other authorized party saying it
+may be distributed under the terms of this Lesser General Public License (also called
 "this License"). Each licensee is addressed as "you".
 
-A "library" means a collection of software functions and/or data prepared so as to be 
-conveniently linked with application programs (which use some of those functions and 
+A "library" means a collection of software functions and/or data prepared so as to be
+conveniently linked with application programs (which use some of those functions and
 data) to form executables.
 
-The "Library", below, refers to any such software library or work which has been 
-distributed under these terms. A "work based on the Library" means either the Library 
-or any derivative work under copyright law: that is to say, a work containing the 
-Library or a portion of it, either verbatim or with modifications and/or translated 
-straightforwardly into another language. (Hereinafter, translation is included without 
+The "Library", below, refers to any such software library or work which has been
+distributed under these terms. A "work based on the Library" means either the Library
+or any derivative work under copyright law: that is to say, a work containing the
+Library or a portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language. (Hereinafter, translation is included without
 limitation in the term "modification".)
 
-"Source code" for a work means the preferred form of the work for making 
-modifications to it. For a library, complete source code means all the source code for all 
-modules it contains, plus any associated interface definition files, plus the scripts used 
+"Source code" for a work means the preferred form of the work for making
+modifications to it. For a library, complete source code means all the source code for all
+modules it contains, plus any associated interface definition files, plus the scripts used
 to control compilation and installation of the library.
-Activities other than copying, distribution and modification are not covered by this 
-License; they are outside its scope. The act of running a program using the Library is 
-not restricted, and output from such a program is covered only if its contents constitute 
-a work based on the Library (independent of the use of the Library in a tool for writing 
-it). Whether that is true depends on what the Library does and what the program that 
+Activities other than copying, distribution and modification are not covered by this
+License; they are outside its scope. The act of running a program using the Library is
+not restricted, and output from such a program is covered only if its contents constitute
+a work based on the Library (independent of the use of the Library in a tool for writing
+it). Whether that is true depends on what the Library does and what the program that
 uses the Library does.
 
 1. You may copy and distribute verbatim copies of the Library~s complete source
-code as you receive it, in any medium, provided that you conspicuously and 
-appropriately publish on each copy an appropriate copyright notice and disclaimer of 
-warranty; keep intact all the notices that refer to this License and to the absence of any 
+code as you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and disclaimer of
+warranty; keep intact all the notices that refer to this License and to the absence of any
 warranty; and distribute a copy of this License along with the Library.
 
-You may charge a fee for the physical act of transferring a copy, and you may at 
+You may charge a fee for the physical act of transferring a copy, and you may at
 your option offer warranty protection in exchange for a fee.
 
-2 You may modify your copy or copies of the Library or any portion of it, thus 
-forming a work based on the Library, and copy and distribute such modifications or 
-work under the terms of Section 1 above, provided that you also meet all of these 
+2 You may modify your copy or copies of the Library or any portion of it, thus
+forming a work based on the Library, and copy and distribute such modifications or
+work under the terms of Section 1 above, provided that you also meet all of these
 conditions:
 
 a) The modified work must itself be a software library.
 
-b) You must cause the files modified to carry prominent notices stating that you 
+b) You must cause the files modified to carry prominent notices stating that you
 changed the files and the date of any change.
 
-c) You must cause the whole of the work to be licensed at no charge to all third 
+c) You must cause the whole of the work to be licensed at no charge to all third
 parties under the terms of this License.
 
-d) If a facility in the modified Library refers to a function or a table of data to be 
-supplied by an application program that uses the facility, other than as an 
-argument passed when the facility is invoked, then you must make a good faith 
-effort to ensure that, in the event an application does not supply such function or 
-table, the facility still operates, and performs whatever part of its purpose 
+d) If a facility in the modified Library refers to a function or a table of data to be
+supplied by an application program that uses the facility, other than as an
+argument passed when the facility is invoked, then you must make a good faith
+effort to ensure that, in the event an application does not supply such function or
+table, the facility still operates, and performs whatever part of its purpose
 remains meaningful.
-(For example, a function in a library to compute square roots has a purpose that 
-is entirely well-defined independent of the application. Therefore, Subsection 2d 
-requires that any application-supplied function or table used by this function 
-must be optional: if the application does not supply it, the square root function 
+(For example, a function in a library to compute square roots has a purpose that
+is entirely well-defined independent of the application. Therefore, Subsection 2d
+requires that any application-supplied function or table used by this function
+must be optional: if the application does not supply it, the square root function
 must still compute square roots.)
 
-These requirements apply to the modified work as a whole. If identifiable 
-sections of that work are not derived from the Library, and can be reasonably 
-considered independent and separate works in themselves, then this License, 
-and its terms, do not apply to those sections when you distribute them as 
-separate works. But when you distribute the same sections as part of a whole 
-which is a work based on the Library, the distribution of the whole must be on 
-the terms of this License, whose permissions for other licensees extend to the 
+These requirements apply to the modified work as a whole. If identifiable
+sections of that work are not derived from the Library, and can be reasonably
+considered independent and separate works in themselves, then this License,
+and its terms, do not apply to those sections when you distribute them as
+separate works. But when you distribute the same sections as part of a whole
+which is a work based on the Library, the distribution of the whole must be on
+the terms of this License, whose permissions for other licensees extend to the
 entire whole, and thus to each and every part regardless of who wrote it.
 
-Thus, it is not the intent of this section to claim rights or contest your rights to 
-work written entirely by you; rather, the intent is to exercise the right to control 
+Thus, it is not the intent of this section to claim rights or contest your rights to
+work written entirely by you; rather, the intent is to exercise the right to control
 the distribution of derivative or collective works based on the Library.
 
-In addition, mere aggregation of another work not based on the Library with the 
-Library (or with a work based on the Library) on a volume of a storage or 
-distribution medium does not bring the other work under the scope of this 
+In addition, mere aggregation of another work not based on the Library with the
+Library (or with a work based on the Library) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
 License.
 
-3. You may opt to apply the terms of the ordinary GNU General Public License instead 
-of this License to a given copy of the Library. To do this, you must alter all the notices 
-that refer to this License, so that they refer to the ordinary GNU General Public License, 
-version 2, instead of to this License. (If a newer version than version 2 of the ordinary 
-GNU General Public License has appeared, then you can specify that version instead if 
+3. You may opt to apply the terms of the ordinary GNU General Public License instead
+of this License to a given copy of the Library. To do this, you must alter all the notices
+that refer to this License, so that they refer to the ordinary GNU General Public License,
+version 2, instead of to this License. (If a newer version than version 2 of the ordinary
+GNU General Public License has appeared, then you can specify that version instead if
 you wish.) Do not make any other change in these notices.
 
-Once this change is made in a given copy, it is irreversible for that copy, so the ordinary 
-GNU General Public License applies to all subsequent copies and derivative works 
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary
+GNU General Public License applies to all subsequent copies and derivative works
 made from that copy.
 
-This option is useful when you wish to copy part of the code of the Library into a 
+This option is useful when you wish to copy part of the code of the Library into a
 program that is not a library.
 
-4. You may copy and distribute the Library (or a portion or derivative of it, 
-under Section 2) in object code or executable form under the terms of Sections 1 and 2 
-above provided that you accompany it with the complete corresponding machine-readable 
-source code, which must be distributed under the terms of Sections 1 and 2 above 
+4. You may copy and distribute the Library (or a portion or derivative of it,
+under Section 2) in object code or executable form under the terms of Sections 1 and 2
+above provided that you accompany it with the complete corresponding machine-readable
+source code, which must be distributed under the terms of Sections 1 and 2 above
 on a medium customarily used for software interchange.
 
-If distribution of object code is made by offering access to copy 
-from a designated place, then offering equivalent access to copy the source code from 
-the same place satisfies the requirement to distribute the source code, even though 
+If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source code from
+the same place satisfies the requirement to distribute the source code, even though
 third parties are not compelled to copy the source along with the object code.
 
-2 A program that contains no derivative of any portion of the Library, but is designed 
-to work with the Library by being compiled or linked with it, is called a 
-"work that uses the Library". Such a work, in isolation, is not a derivative work 
+2 A program that contains no derivative of any portion of the Library, but is designed
+to work with the Library by being compiled or linked with it, is called a
+"work that uses the Library". Such a work, in isolation, is not a derivative work
 of the Library, and therefore falls outside the scope of this License.
 
-However, linking a "work that uses the Library" with the Library creates an executable 
-that is a derivative of the Library (because it contains portions of the Library), rather 
-than a "work that uses the library". The executable is therefore covered by this License. 
+However, linking a "work that uses the Library" with the Library creates an executable
+that is a derivative of the Library (because it contains portions of the Library), rather
+than a "work that uses the library". The executable is therefore covered by this License.
 Section 6 states terms for distribution of such executables.
 
-When a "work that uses the Library" uses material from a header file that is part of the 
-Library, the object code for the work may be a derivative work of the Library even 
-though the source code is not. Whether this is true is especially significant if the work 
-can be linked without the Library, or if the work is itself a library. The threshold for this 
+When a "work that uses the Library" uses material from a header file that is part of the
+Library, the object code for the work may be a derivative work of the Library even
+though the source code is not. Whether this is true is especially significant if the work
+can be linked without the Library, or if the work is itself a library. The threshold for this
 to be true is not precisely defined by law.
 
-If such an object file uses only numerical parameters, data structure layouts and 
-accessors, and small macros and small inline functions (ten lines or less in length), then 
-the use of the object file is unrestricted, regardless of whether it is legally a derivative 
-work. (Executables containing this object code plus portions of the Library will still fall 
+If such an object file uses only numerical parameters, data structure layouts and
+accessors, and small macros and small inline functions (ten lines or less in length), then
+the use of the object file is unrestricted, regardless of whether it is legally a derivative
+work. (Executables containing this object code plus portions of the Library will still fall
 under section 6.)
 
-Otherwise, if the work is a derivative of the Library, you may distribute the object code 
-for the work under the terms of Section 6. Any executables containing that work also 
+Otherwise, if the work is a derivative of the Library, you may distribute the object code
+for the work under the terms of Section 6. Any executables containing that work also
 fall under Section 6, whether or not they are linked directly with the Library itself.
 
-6. As an exception to the Sections above, you may also combine or link a "work that 
-uses the Library" with the Library to produce a work containing portions of the 
-Library, and distribute that work under terms of your choice, provided that the terms 
-permit modification of the work for the customer~s own use and reverse engineering 
+6. As an exception to the Sections above, you may also combine or link a "work that
+uses the Library" with the Library to produce a work containing portions of the
+Library, and distribute that work under terms of your choice, provided that the terms
+permit modification of the work for the customer~s own use and reverse engineering
 for debugging such modifications.
 
-You must give prominent notice with each copy of the work that the Library is used in 
-it and that the Library and its use are covered by this License. You must supply a copy 
-of this License. If the work during execution displays copyright notices, you must 
-include the copyright notice for the Library among them, as well as a reference directing 
+You must give prominent notice with each copy of the work that the Library is used in
+it and that the Library and its use are covered by this License. You must supply a copy
+of this License. If the work during execution displays copyright notices, you must
+include the copyright notice for the Library among them, as well as a reference directing
 the user to the copy of this License. Also, you must do one of these things:
 
-a) Accompany the work with the complete corresponding machine-readable 
-source code for the Library including whatever changes were used in the work 
-(which must be distributed under Sections 1 and 2 above); and, if the work is 
-an executable liked with the Library, with the complete machine-readable 
-"work that uses the Library", as object code and/or source code, so that the user 
-can modify the Library and then relink to produce a modified executable containing 
-the modified Library. (It is understood that the user who changes the contents 
-of definitions files in the Library will not necessarily be able to recompile 
+a) Accompany the work with the complete corresponding machine-readable
+source code for the Library including whatever changes were used in the work
+(which must be distributed under Sections 1 and 2 above); and, if the work is
+an executable liked with the Library, with the complete machine-readable
+"work that uses the Library", as object code and/or source code, so that the user
+can modify the Library and then relink to produce a modified executable containing
+the modified Library. (It is understood that the user who changes the contents
+of definitions files in the Library will not necessarily be able to recompile
 the application to use the modified definitions.)
 
-b) Use a suitable shared library mechanism for linking with the Library. A 
+b) Use a suitable shared library mechanism for linking with the Library. A
 suitable mechanism is one that (1) uses at run time a copy of the library already
-present on the user~s computer system, rather than copying library functions 
-into the executable, and (2) will operate properly with a modified version 
-of the library, if the user installs one, as long as the modified version 
+present on the user~s computer system, rather than copying library functions
+into the executable, and (2) will operate properly with a modified version
+of the library, if the user installs one, as long as the modified version
 is interface-compatible with the version that the work was made with.
 
-c) Accompany the work with a written offer, valid for at least three years, to give 
-the same user the materials specified in Subsection 6a, above, for a charge no 
+c) Accompany the work with a written offer, valid for at least three years, to give
+the same user the materials specified in Subsection 6a, above, for a charge no
 more than the cost of performing this distribution.
 
-d) If distribution of the work is made by offering access to copy from a 
-designated place, offer equivalent access to copy the above specified materials 
+d) If distribution of the work is made by offering access to copy from a
+designated place, offer equivalent access to copy the above specified materials
 from the same place.
 
-e) Verify that the user has already received a copy of these materials or that you 
+e) Verify that the user has already received a copy of these materials or that you
 have already sent this user a copy.
 
-For an executable, the required form of the "work that uses the Library" must include 
-any data and utility programs needed for reproducing the executable from it. However, 
-as a special exception, the materials to be distributed need not include anything that is 
-normally distributed (in either source or binary form) with the major components 
-(compiler, kernel, and so on) of the operating system on which the executable runs, 
+For an executable, the required form of the "work that uses the Library" must include
+any data and utility programs needed for reproducing the executable from it. However,
+as a special exception, the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major components
+(compiler, kernel, and so on) of the operating system on which the executable runs,
 unless that component itself accompanies the executable.
 
-It may happen that this requirement contradicts the license restrictions of other 
-propriety libraries that do not normally accompany the operating system. Such a 
-contradiction means you cannot use both them and the Library together in an 
+It may happen that this requirement contradicts the license restrictions of other
+propriety libraries that do not normally accompany the operating system. Such a
+contradiction means you cannot use both them and the Library together in an
 executable that you distribute.
 
-7. You may place library facilities that are a work based on the Library side-by-side in a 
-single library together with other library facilities not covered by this License, and 
-distribute such a combined library, provided that the separate distribution of the work 
-based on the Library and of the other library facilities is otherwise permitted, and 
+7. You may place library facilities that are a work based on the Library side-by-side in a
+single library together with other library facilities not covered by this License, and
+distribute such a combined library, provided that the separate distribution of the work
+based on the Library and of the other library facilities is otherwise permitted, and
 provided that you do these two things:
 
-a) Accompany the combined library with a copy of the same work based on the 
-Library, uncombined with any other library facilities. This must be distributed 
+a) Accompany the combined library with a copy of the same work based on the
+Library, uncombined with any other library facilities. This must be distributed
 under the terms of the Sections above.
 
-b) Give prominent notice with the combined library of the fact that part of it is 
-a work based on the Library, and explaining where to find the accompanying uncombined 
+b) Give prominent notice with the combined library of the fact that part of it is
+a work based on the Library, and explaining where to find the accompanying uncombined
 form of the same work.
 
-1 You may not copy, modify, sublicense, link with, or distribute the Library except 
-as expressly provided under this License. Any attempt otherwise to copy, modify, 
-sublicense, link with, or distribute the Library is void, and will automatically terminate 
-your rights under this License. However, parties who have received copies, or rights, 
-from you under this License will not have their licenses terminated so long as such 
+1 You may not copy, modify, sublicense, link with, or distribute the Library except
+as expressly provided under this License. Any attempt otherwise to copy, modify,
+sublicense, link with, or distribute the Library is void, and will automatically terminate
+your rights under this License. However, parties who have received copies, or rights,
+from you under this License will not have their licenses terminated so long as such
 parties remain in full compliance.
 
-2 You are not required to accept this License, since you have not signed it. 
-However, nothing else grants you permission to modify or distribute the Library or 
-its derivative works. These actions are prohibited by law if you do not accept this 
-License. Therefore, by modifying or distributing the Library (or any work based 
-on the Library), you indicate your acceptance of this License to do so, and all 
-its terms and conditions for copying, distributing or modifying the Library or 
+2 You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Library or
+its derivative works. These actions are prohibited by law if you do not accept this
+License. Therefore, by modifying or distributing the Library (or any work based
+on the Library), you indicate your acceptance of this License to do so, and all
+its terms and conditions for copying, distributing or modifying the Library or
 works based on it.
 
-3 Each time you redistribute the Library (or any work based on the Library), 
-the recipient automatically receives a license from the original licensor to copy, 
-distribute, link with or modify the Library subject to these terms and conditions. 
-You may not impose any further restrictions on the recipients~ exercise of the rights 
-granted herein. You are not responsible for enforcing compliance by third parties 
+3 Each time you redistribute the Library (or any work based on the Library),
+the recipient automatically receives a license from the original licensor to copy,
+distribute, link with or modify the Library subject to these terms and conditions.
+You may not impose any further restrictions on the recipients~ exercise of the rights
+granted herein. You are not responsible for enforcing compliance by third parties
 with this License.
 
-4 If, as a consequence of a court judgment or allegation of patent infringement or 
-for any other reason (not limited to patent issues), conditions are imposed on you 
-(whether by court order, agreement or otherwise) that contradict the conditions 
-of this License, they do not excuse you from the conditions of this License. 
-If you cannot distribute so as to satisfy simultaneously your obligations 
-under this License and any other pertinent obligations, then as a consequence 
-you may not distribute the Library at all. For example, if a patent license would 
-not permit royalty-free redistribution of the Library by all those who receive copies 
-directly or indirectly through you, then the only way you could satisfy both 
+4 If, as a consequence of a court judgment or allegation of patent infringement or
+for any other reason (not limited to patent issues), conditions are imposed on you
+(whether by court order, agreement or otherwise) that contradict the conditions
+of this License, they do not excuse you from the conditions of this License.
+If you cannot distribute so as to satisfy simultaneously your obligations
+under this License and any other pertinent obligations, then as a consequence
+you may not distribute the Library at all. For example, if a patent license would
+not permit royalty-free redistribution of the Library by all those who receive copies
+directly or indirectly through you, then the only way you could satisfy both
 it and this License would be to refrain entirely from distribution of the Library.
 
-If any portion of this section is held invalid or unenforceable under any particular 
-circumstance, the balance of the section is intended to apply, and the section 
+If any portion of this section is held invalid or unenforceable under any particular
+circumstance, the balance of the section is intended to apply, and the section
 as a whole is intended to apply in other circumstances.
 
-It is not the purpose of this section to induce you to infringe any patents or 
+It is not the purpose of this section to induce you to infringe any patents or
 other property right claims or to contest validity of any such claims; this section has
-the sole purpose of protecting the integrity of the free software distribution system 
-which is implemented by public license practices. Many people have made generous 
-contributions to the wide range of software distributed through that system 
-in reliance on consistent application of that system; it is up to the author/donor 
-to decide if he or she is willing to distribute software through any other system 
+the sole purpose of protecting the integrity of the free software distribution system
+which is implemented by public license practices. Many people have made generous
+contributions to the wide range of software distributed through that system
+in reliance on consistent application of that system; it is up to the author/donor
+to decide if he or she is willing to distribute software through any other system
 and a licensee cannot impose that choice.
 
 This section is intended to make thoroughly clear what is believed to be a consequence
 of the rest of this License.
 
-1 If the distribution and/or use of the Library is restricted in certain countries 
-either by patents or by copyrighted interfaces, the original copyright holder who places 
-the Library under this License may add an explicit geographical distribution limitation 
-excluding those countries, so that distribution is permitted only in or among countries 
-not thus excluded. In such case, this License incorporates the limitation as if written 
+1 If the distribution and/or use of the Library is restricted in certain countries
+either by patents or by copyrighted interfaces, the original copyright holder who places
+the Library under this License may add an explicit geographical distribution limitation
+excluding those countries, so that distribution is permitted only in or among countries
+not thus excluded. In such case, this License incorporates the limitation as if written
 in the body of this License.
 
-13. The Free Software Foundation may publish revised and/or new versions of 
-the Lesser General Public License from time to time. Such new versions will be similar 
+13. The Free Software Foundation may publish revised and/or new versions of
+the Lesser General Public License from time to time. Such new versions will be similar
 in spirit to the present version, but may differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number. If the Library specifies a version 
-number of this License which applies to it and "any later version", you have the option 
-of following the terms and conditions either of that version or of any later version published 
-by the Free Software Foundation. If the Library does not specify a license version number, 
+Each version is given a distinguishing version number. If the Library specifies a version
+number of this License which applies to it and "any later version", you have the option
+of following the terms and conditions either of that version or of any later version published
+by the Free Software Foundation. If the Library does not specify a license version number,
 you may choose any version ever published by the Free Software Foundation.
 
-2 If you wish to incorporate parts of the Library into other free programs whose distribution 
+2 If you wish to incorporate parts of the Library into other free programs whose distribution
 conditions are incompatible with these,
 
-write to the author to ask for permission. For software which is copyrighted by the Free 
-Software Foundation, write to the Free Software Foundation; we sometimes make 
-exceptions for this. Our decision will be guided by the two goals of preserving the free 
-status of all derivatives of our free software and of promoting the sharing and reuse of 
+write to the author to ask for permission. For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes make
+exceptions for this. Our decision will be guided by the two goals of preserving the free
+status of all derivatives of our free software and of promoting the sharing and reuse of
 software generally.
 
 NO WARRANTY
 
-1 BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO 
-WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE 
-LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT 
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT 
-WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED INCLUDING, BUT 
-NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND 
-FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY 
-AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY 
-PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, 
+1 BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE
+LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT
+WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY
+AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY
+PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
 REPAIR OR CORRECTION.
-2 IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO 
-IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO 
+2 IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO
+IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO
 MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE
-LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, 
-INCIDENTAL OR CONSQUENTIAL DAMAGES ARISING OUT OF THE USE OR 
-INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF 
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY 
-YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH 
-ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN 
+LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL,
+INCIDENTAL OR CONSQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH
+ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,12 +8,12 @@
 	launchmon/src/sdbg_rm_map.hxx,
 	tools/alps/src/Makefile.am,
 	tools/alps/src/alps_fe_colocator.cxx:
-	Added Cray XE/XK/XC support. 
+	Added Cray XE/XK/XC support.
 
 2016-05-04 Dong H. Ahn <ahn1@llnl.gov>
 	* git show --stat 42a9e 37e25 3b491 \
 	bc791 fecc9 dac19 81dcf 07417 39efd 6727:
-	Modernize the use of autotools 
+	Modernize the use of autotools
 	    Drop support for bundling foreign library sources for easier packaging
 	    `make` now only builds the main binaries and libraries
 	    `make install` will install them but not the test codes/scripts
@@ -26,16 +26,16 @@
 2014-04-30 Matt LeGendre <legendre1@llnl.gov> Dong H. Ahn <ahn1@llnl.gov>
 	* configure.ac,
 	config/x_ac_handshake.m4,
-	tools/cobo/src/cobo.c, tools/cobo/src/Makefile.am, 
-	tools/handshake/handshake.c, 
-	tools/handshake/Makefile.am, 
-	tools/handshake/handshake.h, 
-	tools/Makefile.am, 
+	tools/cobo/src/cobo.c, tools/cobo/src/Makefile.am,
+	tools/handshake/handshake.c,
+	tools/handshake/Makefile.am,
+	tools/handshake/handshake.h,
+	tools/Makefile.am,
 	launchmon/src/linux/lmon_api/lmon_fe.cxx,
 	launchmon/src/linux/lmon_api/lmon_daemon_internal.cxx:
-	Enhanced security handshake protocol for COBO. 
+	Enhanced security handshake protocol for COBO.
 	Configure now supports munge- and file-based COBO
-	authentication. Munge is available at 
+	authentication. Munge is available at
 	https://code.google.com/p/munge/
 
 
@@ -52,9 +52,9 @@
 2014-04-11 Matt LeGendre <legendre1@llnl.gov>
 	* launchmon/src/linux/sdbg_linux_launchmon.cxx:
 	Suppressed a warning message about invalid MPIR state
-	transition, as the Spindle project works around 
-	an OpenMPI/Orterun issue by creating an unexpected 
-	MPIR state transition. Spindle is a new open-source 
+	transition, as the Spindle project works around
+	an OpenMPI/Orterun issue by creating an unexpected
+	MPIR state transition. Spindle is a new open-source
 	scalable dynamic loading capability that uses LaunchMON
 	(https://github.com/hpc/Spindle).
 
@@ -68,7 +68,7 @@
 2014-04-10 Dong H. Ahn <ahn1@llnl.gov>
 	* Many files:
 	Code clean-up -- Removed HAVE_XXX conditional macroes for
-	commonly found header files. 
+	commonly found header files.
 
 
 2014-04-03 Matt LeGendre <legendre1@llnl.gov>
@@ -83,7 +83,7 @@
 
 2012-05-31 Dong H. Ahn <ahn1@llnl.gov>
 	* tools/libgpg-error/src/gpg-error.c:
-	Fix a bug where libgpg-errors is complaining about LC_ALL 
+	Fix a bug where libgpg-errors is complaining about LC_ALL
 	not being previous (ID: 3024575). The patch is provided
 	by Dane Gardner of Krell Institute: <gardner@krellinst.org>
 
@@ -93,7 +93,7 @@
 	launchmon/src/linux/lmon_api/lmon_fe.cxx
 	launchmon/src/linux/lmon_api/lmon_lmonp_msg.cxx
 	launchmon/src/linux/lmon_api/lmon_be_comm.cxx:
-	Fix the problem with "non-desriptive" error message (ID: 3530680). 
+	Fix the problem with "non-desriptive" error message (ID: 3530680).
 
 
 2011-09-12 Dong H. Ahn <ahn1@llnl.gov>
@@ -106,26 +106,26 @@
 
 2010-11-10 Dong H. Ahn <ahn1@llnl.gov>
 	* test/src/Makefile.am:
-	Added support for testdir to install test files 
+	Added support for testdir to install test files
 	into a non-bin directory
 
 
 2010-11-09 Dong H. Ahn <ahn1@llnl.gov>
 	* launchmon/src/linux/sdbg_linux_launchmon.cxx:
 	Added a fix for a scalability bug. When launchmon puts
-	comma-separated hostnames in one line, srun's 
-	--node-list option fails with 
+	comma-separated hostnames in one line, srun's
+	--node-list option fails with
 	"srun: error: Line 1, of hostfile ...hostnamefn.31504 too long."
 	For Moe Jette's suggestion, the newline character
 	is used instead as the delimiter.
 
-	At 1334 Sierra nodes (16008 processes): Cold Start 
+	At 1334 Sierra nodes (16008 processes): Cold Start
 	The inclusive LMON overhead of bootstrapping the ICCL layer: 8.673522 secs
 	The exclusive LMON overhead of bootstrapping the ICCL layer: 0.050768 secs
 	LMON_fe_launchAndSpawnDaemons perf: 18 (1289347047 - 1289347029) seconds 568745 (648176 - 79431) usec
 	LMON_fe_getProctable perf: 0 (1289347047 - 1289347047) seconds 2813 (651002 - 648189) usec
 
-	At 1334 Sierra nodes (16008 processes): Warm Start 
+	At 1334 Sierra nodes (16008 processes): Warm Start
 	The inclusive LMON overhead of bootstrapping the ICCL layer: 1.128388 secs
 	The exclusive LMON overhead of bootstrapping the ICCL layer: 0.411942 secs
 	LMON_fe_launchAndSpawnDaemons perf: 3 (1289347052 - 1289347048) seconds 774304 (468822 - 694518) usec
@@ -158,9 +158,9 @@
 	tools/alps/src/CLE_2_2-dso.conf
 	tools/alps/src/CLE_3_1-dso.conf
 	tools/alps/src/Makefile.am:
-	Added support for excluding certain system DSOs from 
+	Added support for excluding certain system DSOs from
 	being broadcast. Credit to Andrew Gontarek at Cray
-	for providing DSO list for CLE3.1 and CLE2.2; 
+	for providing DSO list for CLE3.1 and CLE2.2;
 	Added Support for base executable relocation (ID: 3103796).
 
 
@@ -192,22 +192,22 @@
 
 2010-07-21 Dong H. Ahn <ahn1@llnl.gov>
 	* launchmon/src/linux/lmon_api/lmon_fe.cxx:
-	Removed a code rot from LMON_fe_getProctable. Credit to 
+	Removed a code rot from LMON_fe_getProctable. Credit to
 	Dane Gardner at LANL.
 
 
 2010-06-30 Dong H. Ahn <ahn1@llnl.gov>
 	* launchmon/src/sdbg_opt.hxx
-	launchmon/src/sdbg_opt.cxx 
+	launchmon/src/sdbg_opt.cxx
 	launchmon/src/sdbg_base_driver_impl.hxx
 	launchmon/src/lmon_api/lmon_lmonp_msg.h
-	launchmon/src/linux/sdbg_linux_launchmon.cxx:	
-	Added faster dection of LaunchMON engine parsing errors 
+	launchmon/src/linux/sdbg_linux_launchmon.cxx:
+	Added faster dection of LaunchMON engine parsing errors
 	in reponse to a feature request (ID: 2993295).
 
 
 2010-06-28 Dong H. Ahn <ahn1@llnl.gov>
-	* launchmon/man/Makefile.am 
+	* launchmon/man/Makefile.am
 	launchmon/man/LMON_fe_getRMInfo.3
 	launchmon/src/sdbg_base_launchmon_impl.hxx
 	launchmon/src/linux/sdbg_linux_launchmon.cxx
@@ -231,8 +231,8 @@
 	test/src/test.attach_2_uneven.in
 	test/src/test.attach_1_pdebugmax.in
 	test/src/test.attach_1.in:
-	Added OpenRTE suport and tested it under ORTE on SLURM 
-	environment. 
+	Added OpenRTE suport and tested it under ORTE on SLURM
+	environment.
 
 
 2010-06-12 Dong H. Ahn <ahn1@llnl.gov>
@@ -285,10 +285,10 @@
 
 
 2010-04-06 Dong H. Ahn <ahn1@llnl.gov>
-	* launchmon/src/linux/lmon_api/lmon_be.cxx: Added 
-	a new parser to parse /proc/personality.sh to 
-	fully work around the hostname resolution problem 
-	with ORNL Eugene's ION environment where gethostname returns 
+	* launchmon/src/linux/lmon_api/lmon_be.cxx: Added
+	a new parser to parse /proc/personality.sh to
+	fully work around the hostname resolution problem
+	with ORNL Eugene's ION environment where gethostname returns
 	a non-unique, non-standard BG rack-midplane-based hostname.
 
 
@@ -299,11 +299,11 @@
 	launchmon/src/sdbg_base_mach_impl.hxx
 	launchmon/src/sdbg_std.hxx
 	launchmon/src/sdbg_opt.cxx
-	launchmon/src/sdbg_base_mach.hxx: Rewrite some of the 
+	launchmon/src/sdbg_base_mach.hxx: Rewrite some of the
 	thread iterator callback routines
 	to handle an exception arising from Linux thread_db where
 	it provides a garbage value when a target thread within the
-	inferior process recently exited but is still in zombie state.  
+	inferior process recently exited but is still in zombie state.
 
 
 2010-02-05 Dong H. Ahn <ahn1@llnl.gov>
@@ -315,8 +315,8 @@
 	tools/pmgr_collective/src/pmgr_collective_client.h
 	tools/pmgr_collective/src/pmgr_collective_common.h
 	tools/pmgr_collective/src/pmgr_collective_client.c
-	man/LMON_fe_launchAndSpawnDaemons.3: Add support to address a problem 
-	where some systems like Eugene, the ORNL BGP sytsem, don't allow 
+	man/LMON_fe_launchAndSpawnDaemons.3: Add support to address a problem
+	where some systems like Eugene, the ORNL BGP sytsem, don't allow
 	resolving a hostname into an IP with gethostname and gethostbyname
 
 
@@ -331,7 +331,7 @@
 
 
 2009-12-22 Dong H. Ahn <ahn1@llnl.gov>
-	* launchmon/src/linux/sdbg_linux_symtab_impl.hxx: Bug fix 
+	* launchmon/src/linux/sdbg_linux_symtab_impl.hxx: Bug fix
 	* launchmon/src/linux/sdbg_linux_launchmon.cxx: Added auxillary
 	  vector support to discover the base load address of the system
 	  loader more accurately.
@@ -344,8 +344,8 @@
 2009-10-30 Dong H. Ahn <ahn1@llnl.gov>
 	* tools/ciod/debugger_interface.h: updated this with ciod debug
 	  interface version 4.
-	* test/src/be_jobsnap.cxx: added BGP port 
-	* launchmon/src/linux/sdbg_linux_ttracer.hxx: patch to work around 
+	* test/src/be_jobsnap.cxx: added BGP port
+	* launchmon/src/linux/sdbg_linux_ttracer.hxx: patch to work around
 	  a bug in NPTL thread debug library's td_thr_get_info call.
 
 
@@ -358,14 +358,14 @@
 
 2009-08-15 Dong H. Ahn <ahn1@llnl.gov>
 	* Yet another cut to enhance error handlings; better
-	P/T state tracking system is used to handle idiosyncrasy 
+	P/T state tracking system is used to handle idiosyncrasy
 	of Linux process control
 
 
 2009-06-03 Dong H. Ahn <ahn1@llnl.gov>
-	* Better enforcement of the error handling semantics. 
+	* Better enforcement of the error handling semantics.
 	* Added test.attach_4_kill for BlueGene.
-	* Made ptrace errors in tracer_detach "a soft error" 
+	* Made ptrace errors in tracer_detach "a soft error"
 	  instead of a hard error that throws an exception.
 
 
@@ -381,21 +381,21 @@
 
 2009-05-20 Dong H. Ahn <ahn1@llnl.gov>
 	* Added LMON_fe_regErrorCB support (ID2787962)
-	* Added a fix for the "re-attach" defect on BlueGene/P. 
+	* Added a fix for the "re-attach" defect on BlueGene/P.
 	  The fix requires the IBM efix27 or higher.
 	* Added a fix for the back-end and front-end [recv|send]UsrData functions
-	  to return correct error codes. Added a new error code 
+	  to return correct error codes. Added a new error code
 	  (LMON_ENEGCB) to lmon_api_std.h to deal with a
-	  negative code returning from user-provided 
-	  pack/unpack callback routines. (ID2787959) 
+	  negative code returning from user-provided
+	  pack/unpack callback routines. (ID2787959)
 	* Changed the library version to -version-info 1:0:1.
-	  It is because this revision added new API calls and 
+	  It is because this revision added new API calls and
 	  bug fixes for existing API calls.
 
 
 2009-03-11 Dong H. Ahn <ahn1@llnl.gov>
 	* Generalized the BlueGene support in support of BGP
-	  Configure's --with-rm option now takes "bgrm" instead of 
+	  Configure's --with-rm option now takes "bgrm" instead of
 	  bglrm or bgprm.
 	* Deprecated the GLUESYM support in favor of indirect
 	  breakpoint support.
@@ -405,52 +405,52 @@
 	  and deprecated the static configure check for
 	  that library defined in config/x_ac_thread_db.m4.
 	* Deprecated the library version of ciod_db as IBM
-	  open-sourced the CIOD debugger interface codes 
+	  open-sourced the CIOD debugger interface codes
 	  entire via a header file.
 	* configure.ac
 	  launchmon/src/linux/lmon_api/lmon_fe.cxx:
 	  Bug fix in the pthread_cond_timedwait
-	  return code checking logic for launchmon engine 
+	  return code checking logic for launchmon engine
 	  connection: the only correct return code
 	  from pthread condition wait is zero; there were
-	  are two call sites testing with the less-than-zero 
+	  are two call sites testing with the less-than-zero
 	  conditions for an error.
 	  Added comm_pair_e for readability
 	  Added configure check for env, ssh|rsh, and totalview.
-	  
+
 
 2008-12-12 Dong H. Ahn <ahn1@llnl.gov>
-	* added x_ac_testnnodes.m4 and modified test driver scripts 
+	* added x_ac_testnnodes.m4 and modified test driver scripts
 	  to make test cases more configurable. New options
 	  are supported through --with-testnnodes and
-	  --with-ncore-per-CN.  
+	  --with-ncore-per-CN.
 	* added x_ac_bootfabric.m4 and x_ac_rm.m4 to better
-	  support bootscraping comm. fabric and RM support 
+	  support bootscraping comm. fabric and RM support
 	* removed x_ac_pmgr_collective.m4, x_ac_slurm_srun.m4
-	  and x_ac_bgl_mpirun.m4 
+	  and x_ac_bgl_mpirun.m4
 	* changed several configuration options and their style
 	  --with-bootfabric[=FABRICTYPE]
 	  --with-gcrypt[=ARG]
 	  --with-rm[=RMTYPE]
 	  --with-rm-launcher[=LAUNCHERPATH]
 	  --enable-verbose[=LOGDIR]
-	* Made --with-bootfabric --with-rm --with-gcrypt mandatory 
+	* Made --with-bootfabric --with-rm --with-gcrypt mandatory
 	  options for simpler yet better confiration support
 
 2008-09-30 Dong H. Ahn <ahn1@llnl.gov>
 	* Enforced LaunchMON error handling semantics and update man pages
-	* Fixed an incompatibility issue introduced into the 2.6.18 
-	  Linux kernel's thread_db 
+	* Fixed an incompatibility issue introduced into the 2.6.18
+	  Linux kernel's thread_db
 	* Added a verbose mode with an ability to redirect the verbosity
-	  info into files 
+	  info into files
 	* Added two-phased polling scheme to the engine
 	* Bug fix for not handling BGL 64-bit mpirun's MPIR_Breakpoint
-	* Bug fix for a memory corruption in the handshape routine 
-	  at large scale 
-	* Added an LaunchMON handler that delivers signals (except for SIGSTOP) 
+	* Bug fix for a memory corruption in the handshape routine
+	  at large scale
+	* Added an LaunchMON handler that delivers signals (except for SIGSTOP)
 	  sent to the RM_job process back to the RM_Job process
-	* Added consistent return code support for LMON_be_sendUsrData 
-	  and LMON_be_recvUsrData for all calling back-end daemons 
+	* Added consistent return code support for LMON_be_sendUsrData
+	  and LMON_be_recvUsrData for all calling back-end daemons
 
 2008-06-18 Dong H. Ahn <ahn1@llnl.gov>
 	* Added GNU build system support and restructure the source tree.
@@ -459,32 +459,32 @@
 	* Added better support for LaunchMON engine to determine
 	  the return address of a breakpoint. Some architectures
 	  like POWERPC make this info visible via their register
-	  sets while others via the stack memory locations 
+	  sets while others via the stack memory locations
 
 2008-03-06 Dong H. Ahn <ahn1@llnl.gov>
 	* Added FE-engine FE-BE timeout support
-	* Added timeout support for fe_detach, fe_kill, 
-	  and fe_shutdownDaemons, too 
-	* Added better verbosity support for remote use of launchmon engine. 
+	* Added timeout support for fe_detach, fe_kill,
+	  and fe_shutdownDaemons, too
+	* Added better verbosity support for remote use of launchmon engine.
 	* Added test.attach_3_callsafterfail
 	  	test.attach_3_invalidpid
-		test.attach_3_invalidpid_remote	
+		test.attach_3_invalidpid_remote
 
 2008-02-21 Dong H. Ahn <ahn1@llnl.gov>
 	* Added man pages for the back-end API
 	* CHAOS4 packaging support
 	* Added LMON_fe_getProctabSize support
-	* Added LLNS copyright and LGPL terms and conditions 
+	* Added LLNS copyright and LGPL terms and conditions
 	* Added LMON_be_getMyProctabSize support to support STAT better
-	* Added local launchMON engine invocation in addition to remote 
-	  invocation method. This is a more general solution 
+	* Added local launchMON engine invocation in addition to remote
+	  invocation method. This is a more general solution
 	  Passing NULL to launchAndSpawn or attachAndSpaw now
-	  results in invoking the engine locally 
-	* Introduced a better shared data access policy 
+	  results in invoking the engine locally
+	* Introduced a better shared data access policy
 	  to the front-end API implementation, and enforced the
-	  policy to avoid race conditions 
+	  policy to avoid race conditions
 
 2008-02-06 Dong H. Ahn <ahn1@llnl.gov>
-	* Added man pages for the front end API 
+	* Added man pages for the front end API
 	* ChangeLog file created
 

--- a/NEWS
+++ b/NEWS
@@ -1,10 +1,10 @@
-2013-04-30 DHA Release 1.0.1 
+2013-04-30 DHA Release 1.0.1
 		o SLURM, OpenMPI/OpenRTE, and BlueGene/Q support
 		o Dropped support for BlueGene/L and /P
 		o Dynamic detection of resource management
-                o Limited support for LaunchMON middleware API 
+                o Limited support for LaunchMON middleware API
 		o Security enhancement for COBO handshaking
-		o Stability enhancement for LaunchMON engine 
+		o Stability enhancement for LaunchMON engine
 		o LaunchMON Middleware API support
 		o A bunch of bug fixes
 
@@ -14,31 +14,31 @@
 
 2010-10-15 DHA Release the official 0.7 version (0.7.2)
 
-2009-06-30 DHA Release a 0.7 beta version (0.7.2beta) 
-	        o Added new Cray XT4/5/6, OpenRTE and BlueGene/P 
-		  RM platform support in addition to existing 
+2009-06-30 DHA Release a 0.7 beta version (0.7.2beta)
+	        o Added new Cray XT4/5/6, OpenRTE and BlueGene/P
+		  RM platform support in addition to existing
 	     	  BlueGene/L and SLURM
-	        o Integrated the scalable version of PMGR, a.k.a. 
+	        o Integrated the scalable version of PMGR, a.k.a.
 		  COBO, and set it as the default bootfabric
-		o Ran scaling tests and validated the scalability 
-		  at over 100K MPI processes on BlueGene/P and 
+		o Ran scaling tests and validated the scalability
+		  at over 100K MPI processes on BlueGene/P and
 		  over 200K MPI processes on Cray XT5
-		o Augmented LMON FE API set while maintaining 
-	          backward compatibility of the existing API: 
+		o Augmented LMON FE API set while maintaining
+	          backward compatibility of the existing API:
 		   - LMON_fe_regErrorCB call
 		   - LMON_fe_getRMInfo call
-		   - LMON_DONT_STOP_APP environment variable	
-		o Added better performance and scalabilty testing 
+		   - LMON_DONT_STOP_APP environment variable
+		o Added better performance and scalabilty testing
 		  support with the --enable-tracing-cost config option
-		o Worked out the error handling semantics and enforced 
+		o Worked out the error handling semantics and enforced
 		  it on the supported RMs; the semantics is documented
 	  	  in README.ERROR_HANDLING as well as the man page
 		  of LMON_fe_[launch|attach]SpawnDaemons
-		o Added a two-phased priority polling scheme into 
+		o Added a two-phased priority polling scheme into
 		  the LaunchMON engine
-		o Better GNU AUTO build scripts and configure 
+		o Better GNU AUTO build scripts and configure
 		  parameters support
 		o Lots of bug fixes
-	
+
 2009-03-12 DHA Created 0.7 development branch
 

--- a/README.ERROR_HANDLING
+++ b/README.ERROR_HANDLING
@@ -1,6 +1,6 @@
-LaunchMON's Error Handling Semantics 
+LaunchMON's Error Handling Semantics
 
-A. When the LaunchMON engine fails, the cleanup semantics of LaunchMON is to 
+A. When the LaunchMON engine fails, the cleanup semantics of LaunchMON is to
    detach from the job while keeping the client tool running.
 
        A.1. The LaunchMON engine fails. Unless it  is  due  to  SIGKILL,  the
@@ -22,9 +22,9 @@ B.  FE  API  extension to be able to communciate a session's status to the to-
 
        The status is returned through the "status" argument.
 
- C. When a client tool component (whether it is FE or  daemons)  fails, the 
+ C. When a client tool component (whether it is FE or  daemons)  fails, the
     basic  semantics  of the LaunchMON cleanup procedure is to detach from th-
-    e target job, and kill the daemons (when FE  fails)  or  notify the tool 
+    e target job, and kill the daemons (when FE  fails)  or  notify the tool
     front-end client (when a daemon failure is detected).
 
        C.1. If the tool FE fails, the engine first detects the socket discon-
@@ -54,14 +54,14 @@ B.  FE  API  extension to be able to communciate a session's status to the to-
 
        [OpenRTE Note] Identical to the IBM BlueGene, RM_daemon is equal to RM_job
        on OpenRTE and the system control system does not offer a mechanism to
-       detect failures that occurred in the back-end daemons. Hence, LaunchMON 
+       detect failures that occurred in the back-end daemons. Hence, LaunchMON
        does not currently enforce this semantics on this platform.
 
        [Cray ALPS Note] The ALPS tool helper service currently does not offer
-       a mechanism to detect failures in the daemons; LaunchMON does not enforce 
+       a mechanism to detect failures in the daemons; LaunchMON does not enforce
        this semantics on this platform.
 
-D. When the job fails, the basic cleanup semantics of LaunchMON is  to notify 
+D. When the job fails, the basic cleanup semantics of LaunchMON is  to notify
    the FEN tool while keeping the daemons running.
 
        D.1.  The target job fails, and this fatal event first gets propagated

--- a/bootstrap
+++ b/bootstrap
@@ -27,7 +27,7 @@
 #--------------------------------------------------------------------------------
 #
 #  Update Log:
-#        Apr 28 2016 DHA: Added debug prints 
+#        Apr 28 2016 DHA: Added debug prints
 #        Mar 11 2008 DHA: Added rm -f tools/libgcrypt/Makefile
 #        Jun 06 2008 DHA: Created file.
 #
@@ -40,7 +40,7 @@ echo "Running autoheader ..."
 autoheader
 echo "Running automake ..."
 touch NEWS README AUTHORS ChangeLog
-automake --add-missing --copy 
+automake --add-missing --copy
 echo "Running autoconf ..."
 autoconf
 mv aclocal.m4 config/

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ dnl  Place, Suite 330, Boston, MA 02111-1307 USA
 dnl --------------------------------------------------------------------------------
 dnl
 dnl   Update Log:
-dnl         Apr 28 2016 DHA: Modernize autotool support 
+dnl         Apr 28 2016 DHA: Modernize autotool support
 dnl         Apr 01 2015 ADG/KMD: Added Cray CTI support.
 dnl         Feb 20 2015 andrewg@cray.com: Added Cray support.
 dnl         Apr 30 2014 DHA: Declare 1.0.1 -- this doesn't have Cray support though.
@@ -37,9 +37,9 @@ dnl         Mar 10 2014 MPL: Add secure handshake
 dnl         Aug 03 2010 DHA: Added X_AC_MW_HOSTLIST support
 dnl         Dec 28 2009 DHA: Deprecated X_AC_PREFIX_CONFIG_H to better support
 dnl                          binary distribution
-dnl         Mar 20 2009 DHA: Increase LMON_CURRENT by one as we've added 
+dnl         Mar 20 2009 DHA: Increase LMON_CURRENT by one as we've added
 dnl                          a few more API calls. Similarly, increase
-dnl                          LMON_AGE as this still supports 0th interface. 
+dnl                          LMON_AGE as this still supports 0th interface.
 dnl         Mar 11 2009 DHA: Added check for env, ssh|rsh, and totalview
 dnl         Mar 06 2009 DHA: Deprecate X_AC_THREAD_DB,
 dnl                          Added dlfcn.h presence check
@@ -48,21 +48,21 @@ dnl
 
 AC_PREREQ(2.59)
 
-dnl Users shouldn't bootstrap configure from the release tarball so 
+dnl Users shouldn't bootstrap configure from the release tarball so
 dnl this technique should be okay
 AC_INIT([LaunchMON],
-        m4_esyscmd([git describe --always | awk '/.*/ {printf "%s",$1; exit}'])) 
+        m4_esyscmd([git describe --always | awk '/.*/ {printf "%s",$1; exit}']))
 
 dnl
-dnl This implements 2nd LMON interface (increase current when the 
-dnl interface is changed, added, or removed.  
-dnl 
+dnl This implements 2nd LMON interface (increase current when the
+dnl interface is changed, added, or removed.
+dnl
 AC_SUBST(LMON_CURRENT, 2)
 
 dnl
-dnl This is the 1st revision (increase revision when the 
-dnl implementation has been changed but the interface stays the same) 
-dnl 
+dnl This is the 1st revision (increase revision when the
+dnl implementation has been changed but the interface stays the same)
+dnl
 AC_SUBST(LMON_REVISION, 0)
 
 dnl
@@ -71,13 +71,13 @@ dnl
 AC_SUBST(LMON_AGE, 1)
 
 dnl -----------------------------------------------
-dnl AC_CONFIG support 
+dnl AC_CONFIG support
 dnl -----------------------------------------------
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADER([config.h])
-dnl config.guess and config.sub must be distributed 
+dnl config.guess and config.sub must be distributed
 AC_CANONICAL_SYSTEM
 
 dnl
@@ -89,7 +89,7 @@ PKG_PROG_PKG_CONFIG
 dnl -----------------------------------------------
 dnl Automake support
 dnl -----------------------------------------------
-dnl The new form for AM_INIT_AUTOMAKE takes only one argument 
+dnl The new form for AM_INIT_AUTOMAKE takes only one argument
 AM_INIT_AUTOMAKE
 dnl If you don't want silent make, make V=1
 AM_SILENT_RULES([yes])
@@ -119,8 +119,8 @@ X_AC_ENABLE_VERBOSE
 
 dnl -----------------------------------------------
 dnl COBO is now the only comm. fab choice use to
-dnl bootstrap launchmon's 
-dnl distributed components  
+dnl bootstrap launchmon's
+dnl distributed components
 dnl -----------------------------------------------
 AC_DEFINE(COBO_BASED, 1, [Define 1 for COBO_BASED])
 AC_DEFINE(TEST_MORE_COLL, 1, [Define test more coll support])
@@ -163,13 +163,13 @@ AC_CHECK_HEADERS([sys/types.h])
 X_AC_HANDSHAKE
 
 dnl -----------------------------------------------
-dnl enable tracing cost measurement codes? 
+dnl enable tracing cost measurement codes?
 dnl -----------------------------------------------
 X_AC_TRACING_COST
 
 dnl -----------------------------------------------
-dnl Checks for NNODES and Ncores per node 
-dnl for testing 
+dnl Checks for NNODES and Ncores per node
+dnl for testing
 dnl -----------------------------------------------
 X_AC_TESTNNODES
 X_AC_NCORE_SMP
@@ -236,7 +236,7 @@ dnl -----------------------------------------------
 dnl Checks for header files.
 dnl Note: I don't think we made the code base conditionally
 dnl compiled depending on the existence of these checks.
-dnl But the code at least errors out during compililation 
+dnl But the code at least errors out during compililation
 dnl if they don't exist
 dnl -----------------------------------------------
 AC_LANG_PUSH([C++])
@@ -245,9 +245,9 @@ AC_LANG_POP([C++])
 AC_HEADER_SYS_WAIT
 
 dnl
-dnl Jun 07 2012 DHA TODO: We need to check boost/tokenizer.hpp; 
+dnl Jun 07 2012 DHA TODO: We need to check boost/tokenizer.hpp;
 dnl doing so generates whole lot of errors on some platforms
-dnl so I'm skipping that check for now. We need to 
+dnl so I'm skipping that check for now. We need to
 dnl revisit that issue.
 
 AC_CHECK_HEADERS([libelf.h libelf/libelf.h],[],[],
@@ -269,7 +269,7 @@ AC_HEADER_STDBOOL
 AC_C_CONST
 AC_TYPE_PID_T
 AC_HEADER_TIME
-AC_CHECK_TYPES([struct user_regs_struct, 
+AC_CHECK_TYPES([struct user_regs_struct,
                 struct user_pt_regs,
                 struct user_fpregs_struct,
                 struct user_fpsimd_struct,
@@ -289,7 +289,7 @@ AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([gettimeofday memset strdup])
 
 dnl -----------------------------------------------
-dnl configure's OUTPUTS 
+dnl configure's OUTPUTS
 dnl -----------------------------------------------
 AC_CONFIG_FILES([
   Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##
 ##--------------------------------------------------------------------------------
@@ -33,7 +33,7 @@
 ##        Apr 28 2016 DHA: Created file.
 ##
 
-SUBDIRS = pkg-specs 
+SUBDIRS = pkg-specs
 
 etcdir = ${prefix}/etc
 etc_SCRIPTS = \

--- a/etc/pkg-specs/Makefile.am
+++ b/etc/pkg-specs/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##
 ##--------------------------------------------------------------------------------

--- a/etc/pkg-specs/llnl/package.conf
+++ b/etc/pkg-specs/llnl/package.conf
@@ -8,18 +8,18 @@
 #
 # Update:
 #         Apr 30 2014 DHA: UPdated for 1.0.1
-#         Apr 15 2014 DHA: Updated for 1.0-beta2 
+#         Apr 15 2014 DHA: Updated for 1.0-beta2
 #         (actually downgrade in version number since no Cray support)
 #         PKG_VERSION=20
-#         Jun 07 2012 DHA: Updated for 1.0 release  
-#         Oct 27 2010 DHA: Updated for 0.7.2 official release  
+#         Jun 07 2012 DHA: Updated for 1.0 release
+#         Oct 27 2010 DHA: Updated for 0.7.2 official release
 #                          of 0.7
-#         Jul 21 2010 DHA: Updated for 0.7.2beta 
+#         Jul 21 2010 DHA: Updated for 0.7.2beta
 #         Mar 09 2008 DHA: Updated for 0.7.0 release including
-#                          BlueGene/P support     
-#         Dec 15 2008 DHA: Updated for 0.6.4 release which includes 
+#                          BlueGene/P support
+#         Dec 15 2008 DHA: Updated for 0.6.4 release which includes
 #                          fixes for software configuration problems
-#         Sep 28 2008 DHA: Updated for LaunchMON 0.6 release 
+#         Sep 28 2008 DHA: Updated for LaunchMON 0.6 release
 #
 #
 
@@ -27,10 +27,10 @@ _vers=1.0.1
 PKG_NAME=launchmon-${_vers}
 PKG_VERSION=21
 PKG_SECTION=tools
-PKG_SHORT_DESCRIPTION="LaunchMON: Tool daemon launching infrastructure v${_vers}"  
+PKG_SHORT_DESCRIPTION="LaunchMON: Tool daemon launching infrastructure v${_vers}"
 PKG_MAINTAINER="Dong H. Ahn <ahn1@llnl.gov>"
 PKG_BUILDREQUIRES="mvapich-gnu,icc,mvapich-intel"
-PKG_WRAPPERS=launchmon 
+PKG_WRAPPERS=launchmon
 
 # This could be the default install, otherwise comment this out
 #PKG_DEFAULT=launchmon
@@ -45,10 +45,10 @@ see man pages.\n\n"
 PKG_doc="LaunchMON doc: ${prefix}/share/man/man3/LMON_fe_launchAndSpawnDaemons.3"
 
 pkg_build()
-{ 
+{
 
   ./configure --prefix=$prefix --with-test-rm=slurm --with-test-nnodes=2 --with-test-ncore-per-CN=12 --with-sec-munge --with-test-mw-hostlist=sierra1620:sierra1626
-  make 
+  make
 
   return 0
 }
@@ -57,7 +57,7 @@ pkg_build()
 pkg_install()
 {
   mkdir -p $1${prefix}
-  make install DESTDIR=$1  
+  make install DESTDIR=$1
 
   return 0
 }

--- a/etc/rm_alps.conf
+++ b/etc/rm_alps.conf
@@ -34,8 +34,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_bglrm.conf
+++ b/etc/rm_bglrm.conf
@@ -34,7 +34,7 @@
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
 ## RM_launcher_id: the rule to get the launcher id
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_bgprm.conf
+++ b/etc/rm_bgprm.conf
@@ -28,14 +28,14 @@
 ##--------------------------------------------------------------------------------
 ##
 ##  Update Log:
-#*        Dec 14 2012 DHA: Updated the signiture for the launcher 
+#*        Dec 14 2012 DHA: Updated the signiture for the launcher
 ##        Oct 3  2011 DHA: Created file.
 ##
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
 ## RM_launcher_id: the rule to get the launcher id
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_bgq_slurm.conf
+++ b/etc/rm_bgq_slurm.conf
@@ -34,7 +34,7 @@
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
 ## RM_launcher_id: the rule to get the launcher id
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_bgqrm.conf
+++ b/etc/rm_bgqrm.conf
@@ -34,7 +34,7 @@
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
 ## RM_launcher_id: the rule to get the launcher id
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_cray.conf
+++ b/etc/rm_cray.conf
@@ -33,8 +33,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_gupc.conf
+++ b/etc/rm_gupc.conf
@@ -33,8 +33,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_mchecker.conf
+++ b/etc/rm_mchecker.conf
@@ -34,7 +34,7 @@
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
 ## RM_launcher_id: the rule to get the launcher id
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_mpiexec_hydra.conf
+++ b/etc/rm_mpiexec_hydra.conf
@@ -33,8 +33,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_openrte.conf
+++ b/etc/rm_openrte.conf
@@ -34,8 +34,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/etc/rm_slurm.conf
+++ b/etc/rm_slurm.conf
@@ -35,8 +35,8 @@
 ##
 ## RM: the name of Resource Manager
 ## RM_launcher: the name of the launcher command
-## RM_launcher_id: the rule to get the launcher id 
-## (e.g., RM_launcher|sym|srun says the launcher is identify by testing 
+## RM_launcher_id: the rule to get the launcher id
+## (e.g., RM_launcher|sym|srun says the launcher is identify by testing
 ##        RM_launcher's symbol by the name of srun)
 ## RM_jobid: the rule to get the target jobid
 ## (e.g., RM_jobid=RM_launcher|sym|totalview_jobid|string says

--- a/launchmon/src/linux/Makefile.am
+++ b/launchmon/src/linux/Makefile.am
@@ -5,26 +5,28 @@
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
-## the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
-## LLNL-CODE-409469. All rights reserved.
+## the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+## <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
 ##
 ## This file is part of LaunchMON. For details, see
 ## https://computing.llnl.gov/?set=resources&page=os_projects
 ##
-## Please also read LICENSE -- Our Notice and GNU Lesser General Public License.
+## Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+## License.
 ##
 ##
-## This program is free software; you can redistribute it and/or modify it under the
-## terms of the GNU General Public License (as published by the Free Software
-## Foundation) version 2.1 dated February 1999.
+## This program is free software; you can redistribute it and/or modify it under
+## the terms of the GNU General Public License (as published by the Free
+## Software Foundation) version 2.1 dated February 1999.
 ##
-## This program is distributed in the hope that it will be useful, but WITHOUT ANY
-## WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+## This program is distributed in the hope that it will be useful, but WITHOUT
+## ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
 ## FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
 ## General Public License for more details.
 ##
-## You should have received a copy of the GNU Lesser General Public License along
-## with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+## You should have received a copy of the GNU Lesser General Public License
+## along with this program; if not, write to the Free Software Foundation,
+## Inc., 59 Temple
 ## Place, Suite 330, Boston, MA 02111-1307 USA
 ##--------------------------------------------------------------------------------
 ##

--- a/launchmon/src/linux/lmon_api/Makefile.am
+++ b/launchmon/src/linux/lmon_api/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##
 ##--------------------------------------------------------------------------------
@@ -29,7 +29,7 @@
 ##--------------------------------------------------------------------------------
 ##
 ##  Update Log:
-##        Apr 28 2016 DHA: Modernize autotools and build support 
+##        Apr 28 2016 DHA: Modernize autotools and build support
 ##        Jun 01 2012 DHA: Merged with the 0.8-middleware-support branch.
 ##        Nov 28 2011 DHA: Added MPI-tool sync layer.
 ##        Jun 12 2008 DHA: Added header files to the dependency list
@@ -81,7 +81,7 @@ libmonfeapi_la_SOURCES = \
   $(BASE_SRC_DIR)/sdbg_opt.hxx \
   $(BASE_SRC_DIR)/sdbg_rm_map.hxx \
   $(BASE_SRC_DIR)/lmon_api/lmon_say_msg.hxx \
-  $(BASE_SRC_DIR)/sdbg_base_spawner.hxx 
+  $(BASE_SRC_DIR)/sdbg_base_spawner.hxx
 libmonfeapi_la_CFLAGS = $(AM_CFLAGS)
 libmonfeapi_la_CXXFLAGS = $(AM_CXXFLAGS)
 libmonfeapi_la_LDFLAGS = \
@@ -126,7 +126,7 @@ libmonbeapi_la_LDFLAGS = \
   @LMON_CURRENT@:@LMON_REVISION@:@LMON_AGE@
 libmonbeapi_la_LIBADD = \
   $(top_builddir)/@COMMLOC@/@LIBCOMM@ \
-  $(GCRYPT_LIBS) 
+  $(GCRYPT_LIBS)
 
 #####################################################
 # Middleware API
@@ -156,5 +156,5 @@ libmonmwapi_la_LDFLAGS = \
   @LMON_CURRENT@:@LMON_REVISION@:@LMON_AGE@
 libmonmwapi_la_LIBADD = \
   $(top_builddir)/@COMMLOC@/@LIBCOMM@ \
-  $(GCRYPT_LIBS) 
+  $(GCRYPT_LIBS)
 

--- a/launchmon/src/linux/lmon_api/lmon_be.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be.cxx
@@ -1,76 +1,82 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 - 2012, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
  *        Apr 01 2015 ADG: Added Cray CTI support.
- *        Dec 11 2012 DHA: Added mods to initialize process control before 
- *        		   MPIR_Breakpoint release.
- *        		   This fixes an apparent race where the early release 
- *        		   runs the target processes a bit before the proccontrol 
- *        		   init completion.
- *        Aug 06 2010 DHA: Added middleware support including LMON_be_assist_mw_coloc.
+ *        Dec 11 2012 DHA: Added mods to initialize process control before
+ *                         MPIR_Breakpoint release.  This fixes an apparent
+ *                         race where the early release runs the target
+ *                         processes a bit before the proccontrol init
+ *                         completion.
+ *        Aug 06 2010 DHA: Added middleware support including
+ *                         LMON_be_assist_mw_coloc.
  *        Nov 23 2011 DHA: Restructured MPI-Tool sync support to reduce
  *                         the complexity in this upper layer code.
  *                         Added Blue Gene /Q support.
- *        Apr 06 2010 DHA: It turned out the /etc/hosts trick works partially because
- *                         the entry returned by gethostname isn't unique on Eugene!
+ *        Apr 06 2010 DHA: It turned out the /etc/hosts trick works partially
+ *                         because the entry returned by gethostname
+ *                         isn't unique on Eugene!
  *                         Added a new parser to parse /proc/personality.sh to
  *                         fully work around the problem described below
  *        Feb 04 2010 DHA: Added /etc/hosts parser to work around a problem of
- *                         systems that are not capable of resolving the hostname
- *                         returned by gethostname into an IP.
- *        Feb 04 2010 DHA: Moved RM_BG_MPIRUN && VERBOSE && USE_VERBOSE_LOGDIR support
- *                         to an earlier execution point within LMON_be_init. The change 
- *                         is to capture as much error messages into files as possible 
- *                         Also, genericized this support by removing RM_BG_MPIRUN
- *        Dec 23 2009 DHA: Added explict config.h inclusion 
+ *                         systems that are not capable of resolving the
+ *                         hostname returned by gethostname into an IP.
+ *        Feb 04 2010 DHA: Moved RM_BG_MPIRUN && VERBOSE && USE_VERBOSE_LOGDIR
+ *                         support to an earlier execution point within
+ *                         LMON_be_init. The change is to capture as much
+ *                         error messages into files as possible
+ *                         Also, genericized this support by removing
+ *                         RM_BG_MPIRUN
+ *        Dec 23 2009 DHA: Added explict config.h inclusion
  *        Dec 11 2009 DHA: Deprecate the static LMON_be_parse_raw_RPDTAB_msg
- *                         function in favor of parse_raw_RPDTAB_msg designed 
+ *                         function in favor of parse_raw_RPDTAB_msg designed
  *                         to used broadly.
  *        May 19 2009 DHA: Added errorCB support (ID2787962).
- *        May 06 2009 DHA: Bug fix for ID2787959: LMON_be_recvUsrData not returning
- *                         a correct error code.
+ *        May 06 2009 DHA: Bug fix for ID2787959: LMON_be_recvUsrData not
+ *                         returning a correct error code.
  *        Mar 13 2009 DHA: Added large nTasks support
  *        Mar 04 2009 DHA: Added BlueGene/P support.
- *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN 
+ *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN
  *                         to genericize BlueGene Support
  *        Sep 23 2008 DHA: Added verbosity support
  *        Mar 20 2008 DHA: Added BlueGene/L support
- *        Feb 09 2008 DHA: Added LMON_be_getMyProctabSize support to better 
+ *        Feb 09 2008 DHA: Added LMON_be_getMyProctabSize support to better
  *                         support STAT
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Dec 07 2007 DHA: Added support for secure connection between
  *                         distributed software components
- *        Nov 07 2007 DHA: Added more rigorous error checking 
- *        Aug 10 2007 DHA: Added LMON_be_recvUsrData 
- *        Jul 25 2007 DHA: Added logic changes to the RPDTAB flow 
+ *        Nov 07 2007 DHA: Added more rigorous error checking
+ *        Aug 10 2007 DHA: Added LMON_be_recvUsrData
+ *        Jul 25 2007 DHA: Added logic changes to the RPDTAB flow
  *                         Reduced the numer of different
  *                         collective call types
- *        Dec 29 2006 DHA: Moved comm. dependent routines into 
+ *        Dec 29 2006 DHA: Moved comm. dependent routines into
  *                         lmon_be_comm.cxx
  *        Dec 20 2006 DHA: File created
  */
@@ -81,31 +87,30 @@
 #error This source file requires a LINUX-like OS
 #endif
 
-#include <cstdio>
-#include <cstdlib>
-#include <string.h>
-#include <iostream>
-#include <fstream>
+#include <arpa/inet.h>
 #include <signal.h>
-#include <map>
-#include <vector>
+#include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <vector>
 
 #include "gcrypt.h"
 
 #include <assert.h>
 #include <limits.h>
-#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_be.h"
 #include "lmon_api/lmon_lmonp_msg.h"
+#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
+#include "lmon_be_sync_mpi.hxx"
 #include "lmon_coloc_spawner.hxx"
 #include "lmon_daemon_internal.hxx"
-#include "lmon_be_sync_mpi.hxx"
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -123,51 +128,40 @@ static std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > proctab_cache;
 //
 //
 
-extern "C"
-lmon_rc_e
-LMON_be_tester_init ( )
-{
-  return LMON_daemon_internal_tester_init ( &bedata );
+extern "C" lmon_rc_e LMON_be_tester_init() {
+  return LMON_daemon_internal_tester_init(&bedata);
 }
-
 
 //! lmon_rc_e LMON_be_regErrorCB
 /*!
-  registers a callback function that gets 
-  invoked whenever an error message should 
+  registers a callback function that gets
+  invoked whenever an error message should
   go out.
 */
-extern "C"
-lmon_rc_e
-LMON_be_regErrorCB (int (*func) (const char *format, va_list ap))
-{
-  if ( func == NULL)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "an argument is invalid" );
+extern "C" lmon_rc_e LMON_be_regErrorCB(int (*func)(const char *format,
+                                                    va_list ap)) {
+  if (func == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( errorCB !=  NULL )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "previously registered error callback func will be invalidated" );
-    }
+  if (errorCB != NULL) {
+    LMON_say_msg(
+        LMON_BE_MSG_PREFIX, false,
+        "previously registered error callback func will be invalidated");
+  }
 
   errorCB = func;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_be_init
 /*!
     Please refer to the header file: lmon_be.h
 */
-extern "C" lmon_rc_e
-LMON_be_init ( int ver, int *argc, char ***argv )
-{
+extern "C" lmon_rc_e LMON_be_init(int ver, int *argc, char ***argv) {
   int rc;
   lmon_rc_e lrc;
   struct sockaddr_in servaddr;
@@ -175,568 +169,450 @@ LMON_be_init ( int ver, int *argc, char ***argv )
 
 #if VERBOSE && USE_VERBOSE_LOGDIR
   char local_hostname[PATH_MAX];
-  gethostname (local_hostname, PATH_MAX);
-  if ( (lrc = LMON_daemon_enable_verbose(VERBOSE_LOGDIR, local_hostname, is_be))
-         != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE fails to enable verbosity %d", lrc );
-    }
+  gethostname(local_hostname, PATH_MAX);
+  if ((lrc = LMON_daemon_enable_verbose(VERBOSE_LOGDIR, local_hostname,
+                                        is_be)) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON BE fails to enable verbosity %d", lrc);
+  }
 #elif SUB_ARCH_ALPS || SUB_ARCH_CRAY
   //
   // Without this, the no-verbose build will hang under ALPS
   //
-  if ( freopen ("/dev/null", "w", stdout) == NULL )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE fails to reopen stdouts");
+  if (freopen("/dev/null", "w", stdout) == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON BE fails to reopen stdouts");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( freopen ("/dev/null", "w", stderr) == NULL )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE fails to reopen stderr");
+  if (freopen("/dev/null", "w", stderr) == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON BE fails to reopen stderr");
 
-      return LMON_EINVAL;
-    }
-#endif // if SUB_ARCH_ALPS
+    return LMON_EINVAL;
+  }
+#endif  // if SUB_ARCH_ALPS
 
-  if ( ver != LMON_daemon_return_ver() ) 
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE API version mismatch" );
+  if (ver != LMON_daemon_return_ver()) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON BE API version mismatch");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   set_client_name(LMON_BE_MSG_PREFIX);
 
   //
   // Registering bedata.daemon_data.my_hostname and bedata.daemon_data.my_ip
   //
-  if ( LMON_daemon_gethostname(is_bluegene_ion(),
-                               bedata.daemon_data.my_hostname,
-                               LMON_DAEMON_HN_MAX,
-                               bedata.daemon_data.my_ip,
-                               LMON_DAEMON_HN_MAX,
-                               bedata.daemon_data.host_aliases)
-           != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "LMON_daemon_gethostname failed: %d");
+  if (LMON_daemon_gethostname(is_bluegene_ion(), bedata.daemon_data.my_hostname,
+                              LMON_DAEMON_HN_MAX, bedata.daemon_data.my_ip,
+                              LMON_DAEMON_HN_MAX,
+                              bedata.daemon_data.host_aliases) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON_daemon_gethostname failed: %d");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  if ( LMON_daemon_internal_init ( argc, argv, bedata.daemon_data.my_hostname, is_be )
-         != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "LMON_daemon_internal_init failed");
+  if (LMON_daemon_internal_init(argc, argv, bedata.daemon_data.my_hostname,
+                                is_be) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON_daemon_internal_init failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  if ( LMON_daemon_internal_getMyRank ( &(bedata.daemon_data.myrank) ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE getMyRank failed" );
+  if (LMON_daemon_internal_getMyRank(&(bedata.daemon_data.myrank)) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON BE getMyRank failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  if ( LMON_daemon_internal_getSize ( &(bedata.daemon_data.width ) ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "LMON BE getSize failed" );
+  if (LMON_daemon_internal_getSize(&(bedata.daemon_data.width)) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON BE getSize failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  bedata.proctab_msg        = NULL;
-  bedata.proctab_msg_size   = 0;
-  bedata.daemon_data.pack   = NULL;
+  bedata.proctab_msg = NULL;
+  bedata.proctab_msg_size = 0;
+  bedata.daemon_data.pack = NULL;
   bedata.daemon_data.unpack = NULL;
-  bool ismstr = (bedata.daemon_data.myrank == LMON_DAEMON_MASTER)? true : false;
+  bool ismstr =
+      (bedata.daemon_data.myrank == LMON_DAEMON_MASTER) ? true : false;
   int connfd = 0;
 
   BEGIN_MASTER_ONLY(bedata)
-    if ( LMON_daemon_internal_getConnFd(&connfd) != LMON_OK )
-      {
-        LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-          "LMON_daemon_internal_getConnFd failed" );
+  if (LMON_daemon_internal_getConnFd(&connfd) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON_daemon_internal_getConnFd failed");
 
-        return LMON_ESUBCOM;
-      }
+    return LMON_ESUBCOM;
+  }
   END_MASTER_ONLY
 
-  bedata.daemon_data.daemon_spawner 
-    = new spawner_coloc_t( ismstr,
-                           connfd,
-                          (int (*)(void*,int))LMON_be_broadcast);
+  bedata.daemon_data.daemon_spawner = new spawner_coloc_t(
+      ismstr, connfd, (int (*)(void *, int))LMON_be_broadcast);
 
   BEGIN_MASTER_ONLY(bedata)
+  /*
+   *
+   * The backend master initiates a handshake with FE
+   *
+   */
+  int i;
+  lmonp_t initmsg;
+  char shared_key[LMON_KEY_LENGTH];
+  unsigned char sessID[LMON_KEY_LENGTH];
+  unsigned char *sid_traverse;
+  int32_t intsessID;
+  gcry_cipher_hd_t cipher_hndl;
+  gcry_error_t gcrc;
+
+  if (LMON_daemon_internal_getConnFd(&servsockfd) != LMON_OK) {
     /*
-     *
-     * The backend master initiates a handshake with FE
-     *
+     * Establishing a connection with the FE
+     * if the master has not established a connection
      */
-    int i;
-    lmonp_t initmsg;
-    char shared_key[LMON_KEY_LENGTH];
-    unsigned char sessID[LMON_KEY_LENGTH];
-    unsigned char *sid_traverse;
-    int32_t intsessID;
-    gcry_cipher_hd_t cipher_hndl;
-    gcry_error_t gcrc;
-
-    if ( LMON_daemon_internal_getConnFd (&servsockfd) != LMON_OK )
-      {
-	/*
-	 * Establishing a connection with the FE
-	 * if the master has not established a connection
-	 */
-	if ( ( servsockfd = socket ( AF_INET, SOCK_STREAM, 0 )) < 0 )
-	  {
-	    LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	      "socket failed ");
-	    return LMON_ESYS;
-	  }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "BE master: socket created" );
-#endif
-	/*
-	 * Where does the master be connect to?
-	 *
-	 */ 
-	if ( (lrc = LMON_daemon_getWhereToConnect ( &servaddr ) ) != LMON_OK )
-	  {
-	    LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	      "LMON_daemon_getWhereToConnect failed ");
-
-	    return LMON_ESYS;
-	  }
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: got where to connect" );
-#endif
-
-	if ( (rc = connect ( servsockfd, 
-		    ( struct sockaddr* )&servaddr, 
-		    sizeof(servaddr))) < 0 )
-	  {
-	    LMON_say_msg ( LMON_BE_MSG_PREFIX, true, 
-              "connect failed " );
-
-	    return LMON_ESYS;
-	  }
-      }
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: got an actual connection" );
-#endif
-
-    bzero ( shared_key, LMON_KEY_LENGTH );
-    /*
-     * getting shared key and session ID that will be used 
-     * to securely connect to the front-end.
-     */
-    if ( (lrc = LMON_daemon_getSharedKeyAndID ( shared_key,
-		  &intsessID) ) != LMON_OK)
-      {
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-    	  "LMON_daemon_getSharedKeyAndID failed ");
-
-	return LMON_ESYS;
-      }
-  
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: got a shared key: %s %d", shared_key, intsessID);
-#endif
-
-    if ( ( gcrc = gcry_cipher_open ( &cipher_hndl,
-	            GCRY_CIPHER_BLOWFISH,
-		    GCRY_CIPHER_MODE_ECB,
-		    0 )) != GPG_ERR_NO_ERROR )
-      {
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	  "gcry_cipher_open failed: %s", gcry_strerror (gcrc));
-	
-	return LMON_ESYS;
-      }
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: GCRYPT open");
-#endif
-
-    /*
-     * setting a 128 bit key 
-     */
-    if ( ( gcrc = gcry_cipher_setkey ( cipher_hndl, 
-		    shared_key,
-		    LMON_KEY_LENGTH )) != GPG_ERR_NO_ERROR )
-      {
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	  "gcry_cipher_setkey failed: %s", gcry_strerror (gcrc));
-
-	return LMON_ESYS;
-      }
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: GCRYPT setkey, %x:%x:%x:%x", 
-      *(int *) shared_key, 
-      *(int *)(shared_key+4),
-      *(int *)(shared_key+8),
-      *(int *)(shared_key+12));
-#endif
-
-    bzero ((void *)sessID, LMON_KEY_LENGTH );
-    memcpy ((void *)sessID, 
-            (void *)&intsessID, sizeof(intsessID));
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: GCRYPT before encrypt, %x:%x:%x:%x",
-      *(int *) sessID,
-      *(int *)(sessID+4),
-      *(int *)(sessID+8),
-      *(int *)(sessID+12));
-#endif
-
-    if ( ( gcrc = gcry_cipher_encrypt ( cipher_hndl, 
-		    (unsigned char*) &sessID,
-		    LMON_KEY_LENGTH,
-		    NULL, 
-		    0)) != GPG_ERR_NO_ERROR )
-      {
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	  "gcry_cipher_encrypt failed: %s",gcry_strerror (gcrc));
-
-	return LMON_ESYS;
-      }
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: GCRYPT encrypt, %x:%x:%x:%x",
-      *(int *)sessID,
-      *(int *)(sessID+4),
-      *(int *)(sessID+8),
-      *(int *)(sessID+12));
-#endif
-
-    sid_traverse = sessID;
-
-    for (i=0; i < LMON_KEY_LENGTH/sizeof(int32_t); i++)
-      {
-	uint32_t tmpSK;
-	memcpy ( (void *) &tmpSK, 
-		 sid_traverse,
-		 sizeof(uint32_t) );
-	set_msg_header ( &initmsg,
-			 lmonp_fetobe,
-			 lmonp_febe_security_chk,
-			 0,      /* security_key1 */
-			 tmpSK,  /* security_key2 */
-			 0,0,0,0,0 );   
-	if ( ( write_lmonp_long_msg ( servsockfd, 
-				      &initmsg, 
-				      sizeof (initmsg) )) < 0 )
-	  {
-	    LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-	      "write_lmonp_long_msg failed");
-
-	    return LMON_ESYS;
-	  }
-
-	sid_traverse += sizeof(uint32_t);
-      }
-
-    gcry_cipher_close ( cipher_hndl );
-
-#if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: wrote back the security key");
-#endif
-
-    /*
-     * ** End of the MASTER ONLY SECTION **
-     *
-     *
-     */
-  END_MASTER_ONLY
-
-  //
-  // Synch-point: the master just finished sending 
-  // "ack-back" to FE. Thus at this point every BE's 
-  // init should have completed.
-  //
-  if ( LMON_be_barrier() != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-    	"LMON_be_barrier failed" );
-	
-      return LMON_ESUBCOM;
+    if ((servsockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "socket failed ");
+      return LMON_ESYS;
     }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BEs: exiting LMON_be_init");
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: socket created");
+#endif
+    /*
+     * Where does the master be connect to?
+     *
+     */
+    if ((lrc = LMON_daemon_getWhereToConnect(&servaddr)) != LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "LMON_daemon_getWhereToConnect failed ");
+
+      return LMON_ESYS;
+    }
+
+#if VERBOSE
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: got where to connect");
+#endif
+
+    if ((rc = connect(servsockfd, (struct sockaddr *)&servaddr,
+                      sizeof(servaddr))) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "connect failed ");
+
+      return LMON_ESYS;
+    }
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: got an actual connection");
+#endif
+
+  bzero(shared_key, LMON_KEY_LENGTH);
+  /*
+   * getting shared key and session ID that will be used
+   * to securely connect to the front-end.
+   */
+  if ((lrc = LMON_daemon_getSharedKeyAndID(shared_key, &intsessID)) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON_daemon_getSharedKeyAndID failed ");
+
+    return LMON_ESYS;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: got a shared key: %s %d",
+               shared_key, intsessID);
+#endif
+
+  if ((gcrc = gcry_cipher_open(&cipher_hndl, GCRY_CIPHER_BLOWFISH,
+                               GCRY_CIPHER_MODE_ECB, 0)) != GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "gcry_cipher_open failed: %s",
+                 gcry_strerror(gcrc));
+
+    return LMON_ESYS;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: GCRYPT open");
+#endif
+
+  /*
+   * setting a 128 bit key
+   */
+  if ((gcrc = gcry_cipher_setkey(cipher_hndl, shared_key, LMON_KEY_LENGTH)) !=
+      GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "gcry_cipher_setkey failed: %s",
+                 gcry_strerror(gcrc));
+
+    return LMON_ESYS;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: GCRYPT setkey, %x:%x:%x:%x", *(int *)shared_key,
+               *(int *)(shared_key + 4), *(int *)(shared_key + 8),
+               *(int *)(shared_key + 12));
+#endif
+
+  bzero((void *)sessID, LMON_KEY_LENGTH);
+  memcpy((void *)sessID, (void *)&intsessID, sizeof(intsessID));
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: GCRYPT before encrypt, %x:%x:%x:%x", *(int *)sessID,
+               *(int *)(sessID + 4), *(int *)(sessID + 8),
+               *(int *)(sessID + 12));
+#endif
+
+  if ((gcrc = gcry_cipher_encrypt(cipher_hndl, (unsigned char *)&sessID,
+                                  LMON_KEY_LENGTH, NULL, 0)) !=
+      GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "gcry_cipher_encrypt failed: %s",
+                 gcry_strerror(gcrc));
+
+    return LMON_ESYS;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: GCRYPT encrypt, %x:%x:%x:%x", *(int *)sessID,
+               *(int *)(sessID + 4), *(int *)(sessID + 8),
+               *(int *)(sessID + 12));
+#endif
+
+  sid_traverse = sessID;
+
+  for (i = 0; i < LMON_KEY_LENGTH / sizeof(int32_t); i++) {
+    uint32_t tmpSK;
+    memcpy((void *)&tmpSK, sid_traverse, sizeof(uint32_t));
+    set_msg_header(&initmsg, lmonp_fetobe, lmonp_febe_security_chk,
+                   0,     /* security_key1 */
+                   tmpSK, /* security_key2 */
+                   0, 0, 0, 0, 0);
+    if ((write_lmonp_long_msg(servsockfd, &initmsg, sizeof(initmsg))) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "write_lmonp_long_msg failed");
+
+      return LMON_ESYS;
+    }
+
+    sid_traverse += sizeof(uint32_t);
+  }
+
+  gcry_cipher_close(cipher_hndl);
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: wrote back the security key");
+#endif
+
+  /*
+   * ** End of the MASTER ONLY SECTION **
+   *
+   *
+   */
+  END_MASTER_ONLY
+
+  //
+  // Synch-point: the master just finished sending
+  // "ack-back" to FE. Thus at this point every BE's
+  // init should have completed.
+  //
+  if (LMON_be_barrier() != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "LMON_be_barrier failed");
+
+    return LMON_ESUBCOM;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BEs: exiting LMON_be_init");
 #endif
 
   return LMON_OK;
 }
 
-
-//! lmon_rc_e LMON_be_amIMaster 
+//! lmon_rc_e LMON_be_amIMaster
 /*!
     Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e 
-LMON_be_amIMaster ()
-{
-  if ( bedata.daemon_data.myrank < 0 )
-    return LMON_EINVAL;
-  
-  return (( bedata.daemon_data.myrank == 0) ? LMON_YES : LMON_NO);
-}
+extern "C" lmon_rc_e LMON_be_amIMaster() {
+  if (bedata.daemon_data.myrank < 0) return LMON_EINVAL;
 
+  return ((bedata.daemon_data.myrank == 0) ? LMON_YES : LMON_NO);
+}
 
 //! lmon_rc_e LMON_be_getMyRank
 /*!
     Please refer to the header file: lmon_be.h
 */
-extern "C" 
-lmon_rc_e 
-LMON_be_getMyRank ( int *rank )
-{
-  if ( LMON_daemon_internal_getMyRank (rank) != LMON_OK ) 
-    return LMON_EINVAL;
+extern "C" lmon_rc_e LMON_be_getMyRank(int *rank) {
+  if (LMON_daemon_internal_getMyRank(rank) != LMON_OK) return LMON_EINVAL;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_be_getSize
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-extern "C" 
-lmon_rc_e 
-LMON_be_getSize ( int* size )
-{
-  if ( LMON_daemon_internal_getSize (size) != LMON_OK ) 
-    return LMON_EINVAL;
+extern "C" lmon_rc_e LMON_be_getSize(int *size) {
+  if (LMON_daemon_internal_getSize(size) != LMON_OK) return LMON_EINVAL;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_be_barrier()
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_barrier ()
-{
-  if ( LMON_daemon_internal_barrier () != LMON_OK )
-    return LMON_ESUBCOM;
-  
+extern "C" lmon_rc_e LMON_be_barrier() {
+  if (LMON_daemon_internal_barrier() != LMON_OK) return LMON_ESUBCOM;
+
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_be_broadcast
+//! lmon_rc_e LMON_be_broadcast
 /*!
-   Please refer to the header file: lmon_be.h 
+   Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_broadcast ( void *buf, int numbyte ) 
-{
-  if ( LMON_daemon_internal_broadcast ( buf, numbyte ) != LMON_OK )
+extern "C" lmon_rc_e LMON_be_broadcast(void *buf, int numbyte) {
+  if (LMON_daemon_internal_broadcast(buf, numbyte) != LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_be_gather 
-/* 
-   Please refer to the header file: lmon_be.h 
+//! lmon_rc_e LMON_be_gather
+/*
+   Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_gather ( void *sendbuf, int numbyte_per_elem,
-                 void *recvbuf )
-{
-  if ( LMON_daemon_internal_gather ( sendbuf, 
-         numbyte_per_elem, recvbuf ) != LMON_OK )
+extern "C" lmon_rc_e LMON_be_gather(void *sendbuf, int numbyte_per_elem,
+                                    void *recvbuf) {
+  if (LMON_daemon_internal_gather(sendbuf, numbyte_per_elem, recvbuf) !=
+      LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_be_scatter
+//! lmon_rc_e LMON_be_scatter
 /*!
-   Please refer to the header file: lmon_be.h 
+   Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_scatter (
-		void *sendbuf,
-		int numbyte_per_element,
-		void *recvbuf )
-{
-  if ( LMON_daemon_internal_scatter ( sendbuf, 
-         numbyte_per_element, recvbuf ) != LMON_OK )
+extern "C" lmon_rc_e LMON_be_scatter(void *sendbuf, int numbyte_per_element,
+                                     void *recvbuf) {
+  if (LMON_daemon_internal_scatter(sendbuf, numbyte_per_element, recvbuf) !=
+      LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
-
 
 //! LMON_be_finalize();
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_finalize ()
-{
-  MPIR_PROCDESC_EXT * proctab;
+extern "C" lmon_rc_e LMON_be_finalize() {
+  MPIR_PROCDESC_EXT *proctab;
   int proctab_size;
   int i;
 
-  if ( LMON_be_getMyProctabSize ( &proctab_size ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "My proctable size is unavailable");
+  if (LMON_be_getMyProctabSize(&proctab_size) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "My proctable size is unavailable");
 
-      return LMON_EDUNAV;
-    }
-  proctab = (MPIR_PROCDESC_EXT *)
-        malloc (proctab_size*sizeof ( MPIR_PROCDESC_EXT ) );
+    return LMON_EDUNAV;
+  }
+  proctab =
+      (MPIR_PROCDESC_EXT *)malloc(proctab_size * sizeof(MPIR_PROCDESC_EXT));
 
-  if ( proctab == NULL )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Out of memory");
+  if (proctab == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Out of memory");
 
-      return LMON_ENOMEM;
-    }
+    return LMON_ENOMEM;
+  }
 
-  if ( LMON_be_getMyProctab ( proctab, 
-         &proctab_size, proctab_size) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "My proctable is unavailable");
+  if (LMON_be_getMyProctab(proctab, &proctab_size, proctab_size) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "My proctable is unavailable");
 
-      return LMON_EDUNAV;
-    }
+    return LMON_EDUNAV;
+  }
 
-  if ( LMON_be_procctl_done ( bedata.rmtype_instance,
-			      proctab,
-                              proctab_size) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "proc control fini failed");
+  if (LMON_be_procctl_done(bedata.rmtype_instance, proctab, proctab_size) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "proc control fini failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
   //
   // Clean up proctab
   //
-  for(i=0; i < proctab_size; i++)
-    {
-     if (proctab[i].pd.executable_name)
-        {
-          free(proctab[i].pd.executable_name);
-          proctab[i].pd.executable_name = NULL;
-        }
-      if (proctab[i].pd.host_name)
-        {
-          free(proctab[i].pd.host_name);
-          proctab[i].pd.host_name = NULL;
-        }
+  for (i = 0; i < proctab_size; i++) {
+    if (proctab[i].pd.executable_name) {
+      free(proctab[i].pd.executable_name);
+      proctab[i].pd.executable_name = NULL;
     }
-  free (proctab);
+    if (proctab[i].pd.host_name) {
+      free(proctab[i].pd.host_name);
+      proctab[i].pd.host_name = NULL;
+    }
+  }
+  free(proctab);
 
   int is_be = 1;
-  if ( LMON_daemon_internal_finalize (is_be) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "comm. fabric fini failed");    
-      return LMON_ESUBCOM;
-    }
+  if (LMON_daemon_internal_finalize(is_be) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "comm. fabric fini failed");
+    return LMON_ESUBCOM;
+  }
 
-  if ( bedata.proctab_msg != NULL )
-    {
-      free(bedata.proctab_msg);
-      bedata.proctab_msg = NULL;
-    }
+  if (bedata.proctab_msg != NULL) {
+    free(bedata.proctab_msg);
+    bedata.proctab_msg = NULL;
+  }
 
-  if (proctab_cache.size() != 0) 
-    {
-      std::map<std::string,std::vector<MPIR_PROCDESC_EXT *> >::iterator iter;
-      std::vector<MPIR_PROCDESC_EXT *>::iterator vectiter;
-      for (iter=proctab_cache.begin(); iter != proctab_cache.end(); ++iter)
-        {
-          for (vectiter = iter->second.begin(); vectiter != iter->second.end(); ++vectiter)
-            {
-              free((*vectiter)->pd.executable_name);
-              free((*vectiter)->pd.host_name);
-              free((*vectiter));
-            }
-        }
-      proctab_cache.clear();
+  if (proctab_cache.size() != 0) {
+    std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::iterator iter;
+    std::vector<MPIR_PROCDESC_EXT *>::iterator vectiter;
+    for (iter = proctab_cache.begin(); iter != proctab_cache.end(); ++iter) {
+      for (vectiter = iter->second.begin(); vectiter != iter->second.end();
+           ++vectiter) {
+        free((*vectiter)->pd.executable_name);
+        free((*vectiter)->pd.host_name);
+        free((*vectiter));
+      }
     }
+    proctab_cache.clear();
+  }
 
-  if (bedata.daemon_data.daemon_spawner)
-    {
-      delete bedata.daemon_data.daemon_spawner;
-    }
+  if (bedata.daemon_data.daemon_spawner) {
+    delete bedata.daemon_data.daemon_spawner;
+  }
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_be_handshake
 /*!
   - BEs first gather the hostname list into the master BE
   - The master BE ships this to FE
   - The master BE receives RPDTAB message as an ack-back message
-  - The master BE receives launch or attach message 
+  - The master BE receives launch or attach message
     and then broadcasts it
   - The master BE receives an usrdata message
   - The master BE sends the usrdata for BEs by piggybacking it
     to be-ready message
- 
-  This routine only returns when all BEs sychronized 
+
+  This routine only returns when all BEs sychronized
   at the end.
 
-  Please refer to the header file for more details: lmon_be.h 
+  Please refer to the header file for more details: lmon_be.h
  */
-extern "C"
-lmon_rc_e
-LMON_be_handshake ( void *udata )
-{
+extern "C" lmon_rc_e LMON_be_handshake(void *udata) {
   using namespace std;
 
   //
-  // gathering hostnames and other tool specific data 
+  // gathering hostnames and other tool specific data
   // to piggyback to FE
   //
   int i;
@@ -744,394 +620,325 @@ LMON_be_handshake ( void *udata )
 
   BEGIN_MASTER_ONLY(bedata)
 
-    hngatherbuf = (char *) malloc ( LMON_DAEMON_HN_MAX * bedata.daemon_data.width );
-    if ( hngatherbuf == NULL )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-      	  "malloc returned zero");
+  hngatherbuf = (char *)malloc(LMON_DAEMON_HN_MAX * bedata.daemon_data.width);
+  if (hngatherbuf == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "malloc returned zero");
 
-	return LMON_ENOMEM;
-      }
+    return LMON_ENOMEM;
+  }
 #if VERBOSE
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-         "BE master: alloc buf of size %d x %d", 
-         LMON_DAEMON_HN_MAX, bedata.daemon_data.width);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: alloc buf of size %d x %d", LMON_DAEMON_HN_MAX,
+               bedata.daemon_data.width);
 #endif
   END_MASTER_ONLY
 
   //
-  // once be_gather is performed, hngatherbuf 
+  // once be_gather is performed, hngatherbuf
   // should hold all the hostnames
   //
-  if ( LMON_be_gather ( bedata.daemon_data.my_hostname, LMON_DAEMON_HN_MAX, hngatherbuf ) != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-        "gather failed");
+  if (LMON_be_gather(bedata.daemon_data.my_hostname, LMON_DAEMON_HN_MAX,
+                     hngatherbuf) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "gather failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 #if VERBOSE
-	LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-          "BES: host names are gathered");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BES: host names are gathered");
 #endif
   BEGIN_MASTER_ONLY(bedata)
 
-    map<string, vector<unsigned int> > hostName;
-    lmonp_t *sendbuf;
-    int sendbufsize;
-    unsigned int offset = 0;
-    char *hntrav = NULL;
-    hntrav = hngatherbuf; // hntrav will traverse the gathered hostnames   
+  map<string, vector<unsigned int> > hostName;
+  lmonp_t *sendbuf;
+  int sendbufsize;
+  unsigned int offset = 0;
+  char *hntrav = NULL;
+  hntrav = hngatherbuf;  // hntrav will traverse the gathered hostnames
 
-    string tmpstr;
-    for ( i=0; i < bedata.daemon_data.width ; ++i )
-      {
-    	//
-    	// the first pass to compute the size of the string table
-    	//
-    	tmpstr = hntrav;
-    	if ( hostName.find (tmpstr) == hostName.end ())
-	  {
-    	    hostName[tmpstr].push_back(offset);
-            hostName[tmpstr].push_back(0);
-    	    offset += (strlen (hntrav) + 1 );
-	  }
-    	 hntrav += LMON_DAEMON_HN_MAX;
-       }
-
+  string tmpstr;
+  for (i = 0; i < bedata.daemon_data.width; ++i) {
     //
-    // sendbuf alloc and message header work
+    // the first pass to compute the size of the string table
     //
-    sendbufsize = sizeof (lmonp_t)
-                + bedata.daemon_data.width * sizeof(int)
-                + offset;
-    sendbuf = (lmonp_t *) malloc ( sendbufsize );
-    if (bedata.daemon_data.width < LMON_NTASKS_THRE)
-      {
-        set_msg_header (
-                sendbuf,
-                lmonp_fetobe,
-                (int) lmonp_befe_hostname,
-                (unsigned short) bedata.daemon_data.width,
-                0,
-                0,
-                bedata.daemon_data.width,
-                0,
-                offset+bedata.daemon_data.width*sizeof(int),
-                0 );
-      }
-    else
-      {
-        set_msg_header (
-                sendbuf,
-                lmonp_fetobe,
-                (int) lmonp_befe_hostname,
-                LMON_NTASKS_THRE,
-                0,
-                0,
-                bedata.daemon_data.width,
-                bedata.daemon_data.width,
-                offset+bedata.daemon_data.width*sizeof(int),
-                0 );
-      }
+    tmpstr = hntrav;
+    if (hostName.find(tmpstr) == hostName.end()) {
+      hostName[tmpstr].push_back(offset);
+      hostName[tmpstr].push_back(0);
+      offset += (strlen(hntrav) + 1);
+    }
+    hntrav += LMON_DAEMON_HN_MAX;
+  }
 
+  //
+  // sendbuf alloc and message header work
+  //
+  sendbufsize =
+      sizeof(lmonp_t) + bedata.daemon_data.width * sizeof(int) + offset;
+  sendbuf = (lmonp_t *)malloc(sendbufsize);
+  if (bedata.daemon_data.width < LMON_NTASKS_THRE) {
+    set_msg_header(sendbuf, lmonp_fetobe, (int)lmonp_befe_hostname,
+                   (unsigned short)bedata.daemon_data.width, 0, 0,
+                   bedata.daemon_data.width, 0,
+                   offset + bedata.daemon_data.width * sizeof(int), 0);
+  } else {
+    set_msg_header(sendbuf, lmonp_fetobe, (int)lmonp_befe_hostname,
+                   LMON_NTASKS_THRE, 0, 0, bedata.daemon_data.width,
+                   bedata.daemon_data.width,
+                   offset + bedata.daemon_data.width * sizeof(int), 0);
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: set a msg header of lmonp_befe_hostname type");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: set a msg header of lmonp_befe_hostname type");
 #endif
 
-    //
-    // packing hostname indices and string table into the message
-    //
-    char *packptr   = get_lmonpayload_begin (sendbuf); 
-    char *strtabptr = get_strtab_begin (sendbuf);
-    if ( packptr == NULL || strtabptr == NULL )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "cannot pack hostname index and string into a message" );
-	return LMON_EBDMSG;
-      }
+  //
+  // packing hostname indices and string table into the message
+  //
+  char *packptr = get_lmonpayload_begin(sendbuf);
+  char *strtabptr = get_strtab_begin(sendbuf);
+  if (packptr == NULL || strtabptr == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "cannot pack hostname index and string into a message");
+    return LMON_EBDMSG;
+  }
 
-    hntrav = hngatherbuf;
-    for ( i=0; i < bedata.daemon_data.width; ++i )
-      {
-        tmpstr = hntrav;
-        memcpy ((void*) packptr,
-                (void*) &(hostName[tmpstr][0]),
-                sizeof (unsigned int));
-        packptr += sizeof (unsigned int);
+  hntrav = hngatherbuf;
+  for (i = 0; i < bedata.daemon_data.width; ++i) {
+    tmpstr = hntrav;
+    memcpy((void *)packptr, (void *)&(hostName[tmpstr][0]),
+           sizeof(unsigned int));
+    packptr += sizeof(unsigned int);
 
-        if (hostName[tmpstr][1] == 0)
-          {
-            memcpy ((void*) strtabptr,
-                    (void*) hntrav,
-                    (strlen(hntrav) + 1));
+    if (hostName[tmpstr][1] == 0) {
+      memcpy((void *)strtabptr, (void *)hntrav, (strlen(hntrav) + 1));
 
-            strtabptr += ( strlen (hntrav) + 1 );
-            hostName[tmpstr][1] = 1;
-          }
-        hntrav += LMON_DAEMON_HN_MAX;
-      }
+      strtabptr += (strlen(hntrav) + 1);
+      hostName[tmpstr][1] = 1;
+    }
+    hntrav += LMON_DAEMON_HN_MAX;
+  }
 
-    free ( hngatherbuf );
+  free(hngatherbuf);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: about to write the hosts list to the FE");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: about to write the hosts list to the FE");
 #endif
 
-    //
-    // shipping it out and free the message buffer
-    //
-    write_lmonp_long_msg (servsockfd, sendbuf, sendbufsize );
+  //
+  // shipping it out and free the message buffer
+  //
+  write_lmonp_long_msg(servsockfd, sendbuf, sendbufsize);
 
-    free (sendbuf);
+  free(sendbuf);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: the hosts list written to the FE");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: the hosts list written to the FE");
 #endif
 
-    //
-    // receiving the PROCTAB stream from the front-end 
-    // 
-    lmonp_t recvmsg;
-    char *proctab_payload;
-    unsigned int bytesread;
-    
-    read_lmonp_msgheader ( servsockfd, &recvmsg );
-    if ( recvmsg.type.fetobe_type != lmonp_febe_proctab)
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "Unexpected message type, protocol mismatch?");
+  //
+  // receiving the PROCTAB stream from the front-end
+  //
+  lmonp_t recvmsg;
+  char *proctab_payload;
+  unsigned int bytesread;
 
-	return LMON_EBDMSG;
-      }
+  read_lmonp_msgheader(servsockfd, &recvmsg);
+  if (recvmsg.type.fetobe_type != lmonp_febe_proctab) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "Unexpected message type, protocol mismatch?");
+
+    return LMON_EBDMSG;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: received remote descriptor process "
-      "table message header: lmon payload %d", 
-      recvmsg.lmon_payload_length); 
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: received remote descriptor process "
+               "table message header: lmon payload %d",
+               recvmsg.lmon_payload_length);
 #endif
-    bedata.proctab_msg_size = sizeof (lmonp_t)
-                            + recvmsg.lmon_payload_length
-                            + recvmsg.usr_payload_length;
-    bedata.proctab_msg = (lmonp_t *) malloc ( bedata.proctab_msg_size );
-    memcpy ( bedata.proctab_msg, &recvmsg, sizeof (lmonp_t));
-    proctab_payload = get_lmonpayload_begin ( bedata.proctab_msg );
-    if ( proctab_payload == NULL )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "No proctab payload" );
+  bedata.proctab_msg_size = sizeof(lmonp_t) + recvmsg.lmon_payload_length +
+                            recvmsg.usr_payload_length;
+  bedata.proctab_msg = (lmonp_t *)malloc(bedata.proctab_msg_size);
+  memcpy(bedata.proctab_msg, &recvmsg, sizeof(lmonp_t));
+  proctab_payload = get_lmonpayload_begin(bedata.proctab_msg);
+  if (proctab_payload == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "No proctab payload");
 
-	return LMON_EBDMSG;
-      }
-    bytesread = read_lmonp_payloads ( 
-    		               servsockfd, 
-    		               proctab_payload, 
-    		               recvmsg.lmon_payload_length 
-    		               + recvmsg.usr_payload_length );
-    if ( bytesread 
-         != recvmsg.lmon_payload_length+recvmsg.usr_payload_length )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "Bytes read don't equal the size specified in the received msg");
+    return LMON_EBDMSG;
+  }
+  bytesread = read_lmonp_payloads(
+      servsockfd, proctab_payload,
+      recvmsg.lmon_payload_length + recvmsg.usr_payload_length);
+  if (bytesread != recvmsg.lmon_payload_length + recvmsg.usr_payload_length) {
+    LMON_say_msg(
+        LMON_BE_MSG_PREFIX, true,
+        "Bytes read don't equal the size specified in the received msg");
 
-	return LMON_EBDMSG;
-      }
+    return LMON_EBDMSG;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: received RPDTAB payload"); 
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: received RPDTAB payload");
 #endif
 
-    //
-    // receiving a launch or attach message
-    //
-    read_lmonp_msgheader ( servsockfd, &recvmsg );
-    switch (recvmsg.type.fetobe_type )
-      {
-      case lmonp_febe_attach:
-        bedata.is_launch = trm_attach;
-        break;
+  //
+  // receiving a launch or attach message
+  //
+  read_lmonp_msgheader(servsockfd, &recvmsg);
+  switch (recvmsg.type.fetobe_type) {
+    case lmonp_febe_attach:
+      bedata.is_launch = trm_attach;
+      break;
 
-      case lmonp_febe_launch:
-        bedata.is_launch = trm_launch;
-        break;
+    case lmonp_febe_launch:
+      bedata.is_launch = trm_launch;
+      break;
 
-      case lmonp_febe_launch_dontstop:
-        bedata.is_launch = trm_launch_dontstop;
-        break;
+    case lmonp_febe_launch_dontstop:
+      bedata.is_launch = trm_launch_dontstop;
+      break;
 
-      case lmonp_febe_attach_stop:
-        bedata.is_launch = trm_attach_stop;
-        break;
+    case lmonp_febe_attach_stop:
+      bedata.is_launch = trm_attach_stop;
+      break;
 
-      default:
-        {
-          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-            "Wrong msg type: expected a febe launch or attach mode"); 
-	  return LMON_EBDMSG;
-        }
-      }
+    default: {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Wrong msg type: expected a febe launch or attach mode");
+      return LMON_EBDMSG;
+    }
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: received is_launch msg %d", bedata.is_launch); 
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE master: received is_launch msg %d", bedata.is_launch);
 #endif
 
-    read_lmonp_msgheader ( servsockfd, &recvmsg );
-    if ( recvmsg.type.fetobe_type != lmonp_febe_rm_type)
-      {
-        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-          "Unexpected message type, a protocol mismatch?");
+  read_lmonp_msgheader(servsockfd, &recvmsg);
+  if (recvmsg.type.fetobe_type != lmonp_febe_rm_type) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "Unexpected message type, a protocol mismatch?");
 
-        return LMON_EBDMSG;
-      }
-    bedata.rmtype_instance
-      = (rm_catalogue_e) recvmsg.sec_or_jobsizeinfo.rm_type;
+    return LMON_EBDMSG;
+  }
+  bedata.rmtype_instance = (rm_catalogue_e)recvmsg.sec_or_jobsizeinfo.rm_type;
 
+  //
+  // receiving the USRDATA stream from the front-end
+  //
+  read_lmonp_msgheader(servsockfd, &recvmsg);
+  if (recvmsg.type.fetobe_type != lmonp_febe_usrdata) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "Wrong msg type: expected a febe user data");
+    return LMON_EBDMSG;
+  }
+
+  int usrpayloadlen = recvmsg.usr_payload_length;
+  if (usrpayloadlen > 0) {
+    char *usrpl = (char *)malloc(recvmsg.usr_payload_length);
+    bytesread =
+        read_lmonp_payloads(servsockfd, usrpl, recvmsg.usr_payload_length);
     //
-    // receiving the USRDATA stream from the front-end
+    // with the following unpack func, udata comes to have
+    // deserialized usr data
     //
-    read_lmonp_msgheader ( servsockfd, &recvmsg );
-    if ( recvmsg.type.fetobe_type != lmonp_febe_usrdata )
-      {
-        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-          "Wrong msg type: expected a febe user data"); 
-        return LMON_EBDMSG; 
-      }
-
-    int usrpayloadlen = recvmsg.usr_payload_length;
-    if ( usrpayloadlen > 0 )
-      {
-    	char *usrpl = (char *) malloc ( recvmsg.usr_payload_length );
-    	bytesread = read_lmonp_payloads (
-    			servsockfd,
-    			usrpl,
-    			recvmsg.usr_payload_length );
-    	//
-    	// with the following unpack func, udata comes to have
-    	// deserialized usr data
-    	//
-    	bedata.daemon_data.unpack ( usrpl, recvmsg.usr_payload_length, udata );
+    bedata.daemon_data.unpack(usrpl, recvmsg.usr_payload_length, udata);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BE master: received USRDATA"); 
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BE master: received USRDATA");
 #endif
-      }
+  }
 
   END_MASTER_ONLY
 
   //
-  // we want to bcast if this is launch or attach, 
+  // we want to bcast if this is launch or attach,
   // and the aggregate size of proctab_msg
   //
-  if ( LMON_be_broadcast ( &(bedata.is_launch), 
-                  sizeof (bedata.is_launch)) != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	"Broadcast failed for is_launch"); 
+  if (LMON_be_broadcast(&(bedata.is_launch), sizeof(bedata.is_launch)) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Broadcast failed for is_launch");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  if ( LMON_be_broadcast ( &(bedata.rmtype_instance), 
-                  sizeof (bedata.rmtype_instance)) != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-       "Broadcast failed for rmtype_instance"); 
+  if (LMON_be_broadcast(&(bedata.rmtype_instance),
+                        sizeof(bedata.rmtype_instance)) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "Broadcast failed for rmtype_instance");
 
-      return LMON_ESUBCOM;
-    }
- 
-  if ( LMON_be_broadcast (
-		  &(bedata.proctab_msg_size), 
-		  sizeof (bedata.proctab_msg_size)) != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	"Broadcast failed"); 
+    return LMON_ESUBCOM;
+  }
 
-      return LMON_ESUBCOM;
-    }
+  if (LMON_be_broadcast(&(bedata.proctab_msg_size),
+                        sizeof(bedata.proctab_msg_size)) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Broadcast failed");
+
+    return LMON_ESUBCOM;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BES: Bcasted is_launch and proctab_msg_size: %d", 
-      bedata.proctab_msg_size); 
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BES: Bcasted is_launch and proctab_msg_size: %d",
+               bedata.proctab_msg_size);
 #endif
 
   BEGIN_SLAVE_ONLY(bedata)
-    //
-    // slave BEs preparing for proctab_msg broadcast 
-    //
-    bedata.proctab_msg = (lmonp_t *) 
-      malloc ( bedata.proctab_msg_size );
-    if ( bedata.proctab_msg == NULL )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "Malloc returned NULL"); 
-	return LMON_ENOMEM;
-      }
+  //
+  // slave BEs preparing for proctab_msg broadcast
+  //
+  bedata.proctab_msg = (lmonp_t *)malloc(bedata.proctab_msg_size);
+  if (bedata.proctab_msg == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Malloc returned NULL");
+    return LMON_ENOMEM;
+  }
   END_SLAVE_ONLY
 
   //
   // duplicating the proctab_msg using broadcast
   //
-  if ( LMON_be_broadcast ( bedata.proctab_msg, bedata.proctab_msg_size ) 
-       != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-	"Broadcast failed"); 
-      return LMON_ESUBCOM;
-    }
+  if (LMON_be_broadcast(bedata.proctab_msg, bedata.proctab_msg_size) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Broadcast failed");
+    return LMON_ESUBCOM;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BEs: proctab_msg finish Bcasting");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BEs: proctab_msg finish Bcasting");
 #endif
-
 
   //
   //
   // ** Begin Tool <--> MPI synchronization **
   //
   //
-  
-  MPIR_PROCDESC_EXT* proctab;
+
+  MPIR_PROCDESC_EXT *proctab;
   int proctab_size;
 
-  if ( LMON_be_getMyProctabSize ( &proctab_size ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "My proctable size is unavailable");
+  if (LMON_be_getMyProctabSize(&proctab_size) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "My proctable size is unavailable");
 
-      return LMON_EDUNAV;
-    }
+    return LMON_EDUNAV;
+  }
 
-  proctab = (MPIR_PROCDESC_EXT *)
-        malloc (proctab_size*sizeof ( MPIR_PROCDESC_EXT ) );
+  proctab =
+      (MPIR_PROCDESC_EXT *)malloc(proctab_size * sizeof(MPIR_PROCDESC_EXT));
 
-  if ( proctab == NULL )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Out of memory");
+  if (proctab == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Out of memory");
 
-      return LMON_ENOMEM;
-    }
+    return LMON_ENOMEM;
+  }
 
-  if ( LMON_be_getMyProctab ( proctab, 
-         &proctab_size, proctab_size) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "My proctable is unavailable");
+  if (LMON_be_getMyProctab(proctab, &proctab_size, proctab_size) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "My proctable is unavailable");
 
-      return LMON_EDUNAV;
-    }
-
+    return LMON_EDUNAV;
+  }
 
   //
   // Call procctl_init which then calls into OS-dependent
@@ -1140,217 +947,169 @@ LMON_be_handshake ( void *udata )
   // the job in a stopped state.
   //
   int dontstop_fastpath = 0;
-  if ( ( bedata.is_launch == trm_launch_dontstop ) 
-       || ( bedata.is_launch == trm_attach ) )
-    {
-      // hint: fastpath will allow BG not to use proccontrol at all
-      dontstop_fastpath = 1;
-    }
+  if ((bedata.is_launch == trm_launch_dontstop) ||
+      (bedata.is_launch == trm_attach)) {
+    // hint: fastpath will allow BG not to use proccontrol at all
+    dontstop_fastpath = 1;
+  }
 
-  int islaunch 
-    = ((bedata.is_launch == trm_launch) || (bedata.is_launch == trm_launch_dontstop))
-       ? 1 : 0;
+  int islaunch = ((bedata.is_launch == trm_launch) ||
+                  (bedata.is_launch == trm_launch_dontstop))
+                     ? 1
+                     : 0;
 
-  if ( LMON_be_procctl_init ( bedata.rmtype_instance,
-         proctab, islaunch, proctab_size,
-         dontstop_fastpath ) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "proc control initialization failed");
+  if (LMON_be_procctl_init(bedata.rmtype_instance, proctab, islaunch,
+                           proctab_size, dontstop_fastpath) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "proc control initialization failed");
 
-      return LMON_ESUBSYNC;
-    }
+    return LMON_ESUBSYNC;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BES: LMON_be_procctl_init done");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BES: LMON_be_procctl_init done");
 #endif
 
   //
   // All BEs need to have completed procctl init
   //
-  LMON_be_barrier ();
+  LMON_be_barrier();
 
   //
-  // We're almost ready: so we tell FEN to release RM from MPIR_Breakpoint 
+  // We're almost ready: so we tell FEN to release RM from MPIR_Breakpoint
   //
   //
   BEGIN_MASTER_ONLY(bedata)
-    lmonp_t cont_launch_msg;
-    set_msg_header ( &cont_launch_msg,
-                     lmonp_fetobe,
-                     lmonp_befe_cont_launch_bp,
-                     0,0,0,0,0,0,0 );
-    if ( ( write_lmonp_long_msg ( servsockfd,
-                                  &cont_launch_msg,
-                                  sizeof (cont_launch_msg) )) < 0 )
-      {
-        LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-              "write_lmonp_long_msg failed while sending lmonp_befe_cont_launch_bp msg");
+  lmonp_t cont_launch_msg;
+  set_msg_header(&cont_launch_msg, lmonp_fetobe, lmonp_befe_cont_launch_bp, 0,
+                 0, 0, 0, 0, 0, 0);
+  if ((write_lmonp_long_msg(servsockfd, &cont_launch_msg,
+                            sizeof(cont_launch_msg))) < 0) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "write_lmonp_long_msg failed while sending "
+                 "lmonp_befe_cont_launch_bp msg");
 
-        return LMON_ESYS;
-      }
-  END_MASTER_ONLY 
+    return LMON_ESYS;
+  }
+  END_MASTER_ONLY
 
-  if ( LMON_be_procctl_initdone ( bedata.rmtype_instance,
-                                  proctab, islaunch, proctab_size )
-       != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "proc control initdone failed");
+  if (LMON_be_procctl_initdone(bedata.rmtype_instance, proctab, islaunch,
+                               proctab_size) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "proc control initdone failed");
+
+    return LMON_ESUBSYNC;
+  }
+
+  if (dontstop_fastpath == 1) {
+    //
+    // Call procctl_run if the user requested to continue
+    // for the start-up case or the default attach case.
+    //
+    if (LMON_be_procctl_run(bedata.rmtype_instance, 0, proctab, proctab_size) !=
+        LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "proc control run failed");
 
       return LMON_ESUBSYNC;
     }
+  }
 
-
-  if ( dontstop_fastpath == 1 )
-    {
-      //
-      // Call procctl_run if the user requested to continue
-      // for the start-up case or the default attach case.
-      //
-      if ( LMON_be_procctl_run ( bedata.rmtype_instance, 0,
-                                 proctab, proctab_size )
-           != LMON_OK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "proc control run failed");
-
-          return LMON_ESUBSYNC;
-        }
-
-
-    }
-
-
-# if VERBOSE
-    LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-      "BES: LMON_be_procctl_initdone done; "
-      "the job has been sync'ed for next operations");
-# endif
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BES: LMON_be_procctl_initdone done; "
+               "the job has been sync'ed for next operations");
+#endif
 
   //
   // Clean up proctab
   //
-  for( i = 0; i < proctab_size; i++ )
-    {
-     if (proctab[i].pd.executable_name)
-        {
-          free(proctab[i].pd.executable_name);
-          proctab[i].pd.executable_name = NULL;
-        }
-      if (proctab[i].pd.host_name)
-        {
-          free(proctab[i].pd.host_name);
-          proctab[i].pd.host_name = NULL;
-        }
+  for (i = 0; i < proctab_size; i++) {
+    if (proctab[i].pd.executable_name) {
+      free(proctab[i].pd.executable_name);
+      proctab[i].pd.executable_name = NULL;
     }
-  free (proctab);
-
-  if ( LMON_be_barrier () != LMON_OK )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "Barrier failed");
-      return LMON_ESUBCOM;
+    if (proctab[i].pd.host_name) {
+      free(proctab[i].pd.host_name);
+      proctab[i].pd.host_name = NULL;
     }
+  }
+  free(proctab);
 
-  //
-  //
-  // ** Complete Tool <--> MPI synchronization **
-  //
-  //
+  if (LMON_be_barrier() != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Barrier failed");
+    return LMON_ESUBCOM;
+  }
+
+//
+//
+// ** Complete Tool <--> MPI synchronization **
+//
+//
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "BES: returning from LMON_be_handshake");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BES: returning from LMON_be_handshake");
 #endif
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_be_ready()
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e 
-LMON_be_ready ( void *udata )
-{
+extern "C" lmon_rc_e LMON_be_ready(void *udata) {
   BEGIN_MASTER_ONLY(bedata)
-    lmonp_t *readymsg = NULL;
-    if ( (udata != NULL) && (bedata.daemon_data.pack != NULL) )
-      {
-    	char *uoffset;
-        int upl_leng;
-    	readymsg = (lmonp_t *) malloc ( 
-    			      sizeof (lmonp_t) 
-    			      + LMON_MAX_USRPAYLOAD );
-        set_msg_header ( 
-                    readymsg,
-                    lmonp_fetobe,
-                    (int) lmonp_befe_usrdata,
-                    0,0,0,0,0,0,
-                    LMON_MAX_USRPAYLOAD);
+  lmonp_t *readymsg = NULL;
+  if ((udata != NULL) && (bedata.daemon_data.pack != NULL)) {
+    char *uoffset;
+    int upl_leng;
+    readymsg = (lmonp_t *)malloc(sizeof(lmonp_t) + LMON_MAX_USRPAYLOAD);
+    set_msg_header(readymsg, lmonp_fetobe, (int)lmonp_befe_usrdata, 0, 0, 0, 0,
+                   0, 0, LMON_MAX_USRPAYLOAD);
 
-    	uoffset = get_usrpayload_begin ( readymsg );
-    	bedata.daemon_data.pack ( udata,
-    		      uoffset,
-    		      LMON_MAX_USRPAYLOAD, 
-    		      &upl_leng );
-    	//assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
-        readymsg->usr_payload_length = upl_leng;
-      }
-    else
-      {
-    	readymsg = (lmonp_t *) malloc ( sizeof (lmonp_t));
-    	readymsg->usr_payload_length = 0;
-      }
+    uoffset = get_usrpayload_begin(readymsg);
+    bedata.daemon_data.pack(udata, uoffset, LMON_MAX_USRPAYLOAD, &upl_leng);
+    // assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
+    readymsg->usr_payload_length = upl_leng;
+  } else {
+    readymsg = (lmonp_t *)malloc(sizeof(lmonp_t));
+    readymsg->usr_payload_length = 0;
+  }
 
-    readymsg->msgclass = lmonp_fetobe;
-    readymsg->type.fetobe_type = lmonp_befe_ready;
-    readymsg->sec_or_jobsizeinfo.security_key1 = 0;
-    readymsg->sec_or_stringinfo.security_key2 = 0;
-    readymsg->lmon_payload_length = 0;
-    write_lmonp_long_msg (
-    		servsockfd,
-    		readymsg,
-    		sizeof (lmonp_t) + readymsg->usr_payload_length );
+  readymsg->msgclass = lmonp_fetobe;
+  readymsg->type.fetobe_type = lmonp_befe_ready;
+  readymsg->sec_or_jobsizeinfo.security_key1 = 0;
+  readymsg->sec_or_stringinfo.security_key2 = 0;
+  readymsg->lmon_payload_length = 0;
+  write_lmonp_long_msg(servsockfd, readymsg,
+                       sizeof(lmonp_t) + readymsg->usr_payload_length);
 
-    free(readymsg);
+  free(readymsg);
   END_MASTER_ONLY
 
-  if ( LMON_be_barrier() != LMON_OK )
-    return LMON_ESUBCOM;
+  if (LMON_be_barrier() != LMON_OK) return LMON_ESUBCOM;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_be_assist_mw_coloc()
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e
-LMON_be_assist_mw_coloc()
-{
+extern "C" lmon_rc_e LMON_be_assist_mw_coloc() {
   using std::string;
-  if (bedata.daemon_data.daemon_spawner)
-    {
-      if (!bedata.daemon_data.daemon_spawner->spawn())
-        {
-           LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-             "coloc spawner failed: %s", 
-             bedata.daemon_data.daemon_spawner->get_err_str().c_str());
+  if (bedata.daemon_data.daemon_spawner) {
+    if (!bedata.daemon_data.daemon_spawner->spawn()) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "coloc spawner failed: %s",
+                   bedata.daemon_data.daemon_spawner->get_err_str().c_str());
 
-           return LMON_ESUBCOM;
-        }
+      return LMON_ESUBCOM;
     }
+  }
 
 #if VERBOSE
-   LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-     "BE daemon assisted in MW daemon spawn");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "BE daemon assisted in MW daemon spawn");
 #endif
 
   return LMON_OK;
@@ -1358,388 +1117,241 @@ LMON_be_assist_mw_coloc()
 
 //! lmon_rc_e LMON_be_getMyProctab
 /*!
-    Please refer to the header file: lmon_be.h  
+    Please refer to the header file: lmon_be.h
 */
-extern "C"
-lmon_rc_e 
-LMON_be_getMyProctab (
-		 MPIR_PROCDESC_EXT *proctabbuf,
-		 int *size, 
-		 int proctab_num_elem )
-{
+extern "C" lmon_rc_e LMON_be_getMyProctab(MPIR_PROCDESC_EXT *proctabbuf,
+                                          int *size, int proctab_num_elem) {
   using namespace std;
 
   unsigned int i;
   char *key;
   lmon_rc_e lrc;
 
-  if ( bedata.proctab_msg == NULL )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "bedata.proctab_msg is null!  ");
+  if (bedata.proctab_msg == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "bedata.proctab_msg is null!  ");
+
+    return LMON_EINVAL;
+  }
+
+  if (proctab_cache.size() == 0) {
+    if (parse_raw_RPDTAB_msg(bedata.proctab_msg, &proctab_cache) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "parse_raw_RPDTAB_msg failed to parse RPDTAB");
 
       return LMON_EINVAL;
     }
-
-  if ( proctab_cache.size () == 0 )
-    {
-      if ( parse_raw_RPDTAB_msg ( bedata.proctab_msg, &proctab_cache) < 0 )
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "parse_raw_RPDTAB_msg failed to parse RPDTAB");
-
-          return LMON_EINVAL;
-        }
-
-    }
+  }
 
   std::vector<std::string>::const_iterator itr;
-  map<string, vector<MPIR_PROCDESC_EXT* > >::const_iterator viter;
+  map<string, vector<MPIR_PROCDESC_EXT *> >::const_iterator viter;
   *size = 0;
 
-  for (itr = bedata.daemon_data.host_aliases.begin(); 
-         itr != bedata.daemon_data.host_aliases.end(); itr++)
-    {
-      viter = proctab_cache.find(*itr);
-      if (viter != proctab_cache.end())
-        {
-          *size = viter->second.size();
+  for (itr = bedata.daemon_data.host_aliases.begin();
+       itr != bedata.daemon_data.host_aliases.end(); itr++) {
+    viter = proctab_cache.find(*itr);
+    if (viter != proctab_cache.end()) {
+      *size = viter->second.size();
 #if VERBOSE
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "found an entry with an alias %s.", (*itr).c_str());
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "found an entry with an alias %s.", (*itr).c_str());
 #endif
-          break;
-        }
-#if VERBOSE
-      else
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "couldn't find an entry with an alias %s... trying the next alias", (*itr).c_str());
-        }
-#endif
-    } 
-
-  for ( i=0; (i < (*size)) && (i < proctab_num_elem); ++i )
-    {
-      //
-      // The caller is responsible for freeing strdup's memory
-      //
-      proctabbuf[i].pd.executable_name = strdup ((*viter).second[i]->pd.executable_name);
-      proctabbuf[i].pd.host_name = strdup ((*viter).second[i]->pd.host_name);
-      proctabbuf[i].pd.pid = (*viter).second[i]->pd.pid;
-      proctabbuf[i].mpirank = (*viter).second[i]->mpirank;
-      proctabbuf[i].cnodeid = (*viter).second[i]->cnodeid;
+      break;
     }
+#if VERBOSE
+    else {
+      LMON_say_msg(
+          LMON_BE_MSG_PREFIX, false,
+          "couldn't find an entry with an alias %s... trying the next alias",
+          (*itr).c_str());
+    }
+#endif
+  }
 
-  if ( ( i == proctab_num_elem ) && ( proctab_num_elem < (*size) ) )
+  for (i = 0; (i < (*size)) && (i < proctab_num_elem); ++i) {
+    //
+    // The caller is responsible for freeing strdup's memory
+    //
+    proctabbuf[i].pd.executable_name =
+        strdup((*viter).second[i]->pd.executable_name);
+    proctabbuf[i].pd.host_name = strdup((*viter).second[i]->pd.host_name);
+    proctabbuf[i].pd.pid = (*viter).second[i]->pd.pid;
+    proctabbuf[i].mpirank = (*viter).second[i]->mpirank;
+    proctabbuf[i].cnodeid = (*viter).second[i]->cnodeid;
+  }
+
+  if ((i == proctab_num_elem) && (proctab_num_elem < (*size)))
     return LMON_ETRUNC;
 
   return LMON_OK;
-}  
-
+}
 
 //! lmon_rc_e LMON_be_getMyProctabSize
 /*
-    Please refer to the header file: lmon_be.h  
+    Please refer to the header file: lmon_be.h
 */
-lmon_rc_e 
-LMON_be_getMyProctabSize ( int *size )
-{ 
+lmon_rc_e LMON_be_getMyProctabSize(int *size) {
   using namespace std;
 
-  char *key=NULL;
+  char *key = NULL;
   lmon_rc_e lrc;
-  
-  if ( bedata.proctab_msg == NULL )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-        "bedata.proctab_msg is null!  ");
+
+  if (bedata.proctab_msg == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "bedata.proctab_msg is null!  ");
+
+    return LMON_EINVAL;
+  }
+
+  if (proctab_cache.size() == 0) {
+    if (parse_raw_RPDTAB_msg(bedata.proctab_msg, &proctab_cache) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "parse_raw_RPDTAB_msg failed to parse RPDTAB");
 
       return LMON_EINVAL;
     }
-
-  if ( proctab_cache.size () == 0 )
-    {
-      if ( parse_raw_RPDTAB_msg ( bedata.proctab_msg, &proctab_cache) < 0 )
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "parse_raw_RPDTAB_msg failed to parse RPDTAB");
-
-          return LMON_EINVAL;
-        }
-    }
+  }
 
   std::vector<std::string>::const_iterator itr;
-  map<string, vector<MPIR_PROCDESC_EXT* > >::const_iterator viter;
+  map<string, vector<MPIR_PROCDESC_EXT *> >::const_iterator viter;
   *size = 0;
 
-  for (itr = bedata.daemon_data.host_aliases.begin(); 
-         itr != bedata.daemon_data.host_aliases.end(); itr++)
-    {
-      viter = proctab_cache.find(*itr);
-      if (viter != proctab_cache.end())
-        {
-          *size = viter->second.size();
+  for (itr = bedata.daemon_data.host_aliases.begin();
+       itr != bedata.daemon_data.host_aliases.end(); itr++) {
+    viter = proctab_cache.find(*itr);
+    if (viter != proctab_cache.end()) {
+      *size = viter->second.size();
 #if VERBOSE
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "found an entry with an alias %s.", (*itr).c_str());
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "found an entry with an alias %s.", (*itr).c_str());
 #endif
-          break;
-        }
-#if VERBOSE
-      else
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, false,
-            "couldn't find an entry with an alias %s... trying the next alias", (*itr).c_str());
-        }
-#endif
-
+      break;
     }
-
-  return LMON_OK;  
-}
-
-
-//! lmon_rc_e LMON_be_regPackForBeToFe
-/* 
-    Please refer to the header file: lmon_be.h     
-*/
-extern "C" 
-lmon_rc_e 
-LMON_be_regPackForBeToFe ( int (*packBefe) ( 
-                   void *udata,void *msgbuf,
-                   int msgbufmax,int *msgbuflen ) )
-{
-  if ( bedata.daemon_data.pack != NULL )
-  {
-    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-      "pack has already been registered or has not been initialized");  
-    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-      "replacing the pack function...");  
+#if VERBOSE
+    else {
+      LMON_say_msg(
+          LMON_BE_MSG_PREFIX, false,
+          "couldn't find an entry with an alias %s... trying the next alias",
+          (*itr).c_str());
+    }
+#endif
   }
-  
-  bedata.daemon_data.pack = packBefe;
 
-  return LMON_OK; 
-}
-
-
-//! lmon_rc_e LMON_be_regUnpackForFeToBe
-/*
-    Please refer to the header file: lmon_be.h     
-*/
-extern "C"
-lmon_rc_e 
-LMON_be_regUnpackForFeToBe (
-		 int (*unpackFebe) ( 
-		 void *udatabuf,int udatabuflen, void *udata ))
-{
-  if ( bedata.daemon_data.unpack != NULL )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-        "pack has already been registered or has not been initialized");  
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-        "replacing the pack function...");  	  
-    }
-	  
-  bedata.daemon_data.unpack = unpackFebe;
-  
   return LMON_OK;
 }
 
+//! lmon_rc_e LMON_be_regPackForBeToFe
+/*
+    Please refer to the header file: lmon_be.h
+*/
+extern "C" lmon_rc_e LMON_be_regPackForBeToFe(
+    int (*packBefe)(void *udata, void *msgbuf, int msgbufmax, int *msgbuflen)) {
+  if (bedata.daemon_data.pack != NULL) {
+    LMON_say_msg(
+        LMON_BE_MSG_PREFIX, true,
+        "pack has already been registered or has not been initialized");
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "replacing the pack function...");
+  }
+
+  bedata.daemon_data.pack = packBefe;
+
+  return LMON_OK;
+}
+
+//! lmon_rc_e LMON_be_regUnpackForFeToBe
+/*
+    Please refer to the header file: lmon_be.h
+*/
+extern "C" lmon_rc_e LMON_be_regUnpackForFeToBe(
+    int (*unpackFebe)(void *udatabuf, int udatabuflen, void *udata)) {
+  if (bedata.daemon_data.unpack != NULL) {
+    LMON_say_msg(
+        LMON_BE_MSG_PREFIX, true,
+        "pack has already been registered or has not been initialized");
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "replacing the pack function...");
+  }
+
+  bedata.daemon_data.unpack = unpackFebe;
+
+  return LMON_OK;
+}
 
 //! lmon_rc_e LMON_fe_recvUsrData
 /*!
-    Please refer to the header file: lmon_be.h 
+    Please refer to the header file: lmon_be.h
 */
-lmon_rc_e 
-LMON_be_recvUsrData ( void* udata )
-{
+lmon_rc_e LMON_be_recvUsrData(void *udata) {
   lmonp_t recvmsg;
   unsigned int bytesread;
   lmon_rc_e lrc = LMON_OK;
 
   BEGIN_MASTER_ONLY(bedata)
+  //
+  // receiving the USRDATA stream from the frontend
+  //
+  if (read_lmonp_msgheader(servsockfd, &recvmsg) < 0) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "read_lmonp return a neg value");
+
+    lrc = LMON_ESYS;
+    goto something_bad;
+  }
+
+  if (recvmsg.type.fetobe_type != lmonp_febe_usrdata) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "the received message doesn't match with the expected type");
+
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "  The expected type is {Class(lmonp_fetobe),"
+                 "Type(lmonp_febe_usrdata),"
+                 "LMON_payload_size(0),"
+                 "USR_payload_size(>=0)}.");
+
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "  A recv'ed msg of {Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s),"
+                 "USR_payload_size(%s)} has been received.",
+                 lmon_msg_to_str(field_class, &recvmsg),
+                 lmon_msg_to_str(field_type, &recvmsg),
+                 lmon_msg_to_str(field_lmon_payload_length, &recvmsg),
+                 lmon_msg_to_str(field_usr_payload_length, &recvmsg));
+
+    lrc = LMON_EBDMSG;
+    goto something_bad;
+  }
+
+  int usrpayloadlen = recvmsg.usr_payload_length;
+  if (usrpayloadlen > 0) {
+    char *usrpl = (char *)malloc(recvmsg.usr_payload_length);
+    if (usrpl == NULL) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Out of memory");
+
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
+
+    bytesread =
+        read_lmonp_payloads(servsockfd, usrpl, recvmsg.usr_payload_length);
     //
-    // receiving the USRDATA stream from the frontend
-    //     
-    if ( read_lmonp_msgheader ( servsockfd, &recvmsg ) < 0 )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	  "read_lmonp return a neg value");
+    // with the following unpack func, udata comes to have
+    // deserialized usr data
+    //
+    if (bedata.daemon_data.unpack) {
+      if (bedata.daemon_data.unpack(usrpl, recvmsg.usr_payload_length, udata) <
+          0) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "a negative return code from bedata.daemon_data.unpack.");
 
-	lrc = LMON_ESYS;
-        goto something_bad;
+        lrc = LMON_ENEGCB;
       }
-
-    if ( recvmsg.type.fetobe_type != lmonp_febe_usrdata )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-          "the received message doesn't match with the expected type");
-
-        LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-          "  The expected type is {Class(lmonp_fetobe),"
-                       "Type(lmonp_febe_usrdata),"
-                       "LMON_payload_size(0),"
-                       "USR_payload_size(>=0)}.");
-
-        LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-          "  A recv'ed msg of {Class(%s),"
-                       "Type(%s),"
-                       "LMON_payload_size(%s),"
-                       "USR_payload_size(%s)} has been received.",
-                       lmon_msg_to_str(field_class, &recvmsg),
-                       lmon_msg_to_str(field_type, &recvmsg),
-                       lmon_msg_to_str(field_lmon_payload_length, &recvmsg),
-                       lmon_msg_to_str(field_usr_payload_length, &recvmsg));
-
-	lrc = LMON_EBDMSG;
-        goto something_bad; 
-      }
-
-    int usrpayloadlen = recvmsg.usr_payload_length;
-    if ( usrpayloadlen > 0 )
-      {
-    	char *usrpl = (char *) malloc ( recvmsg.usr_payload_length );
-	if ( usrpl == NULL)
-	  {
-	    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	      "Out of memory");
-
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-
-    	bytesread = read_lmonp_payloads (
-    			servsockfd,
-    			usrpl,
-    			recvmsg.usr_payload_length );
-    	//
-    	// with the following unpack func, udata comes to have
-    	// deserialized usr data
-    	//
-	if ( bedata.daemon_data.unpack )	  
-	  {
-	    if (bedata.daemon_data.unpack ( usrpl, recvmsg.usr_payload_length, udata ) < 0)	  
-              {
-	        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-                "a negative return code from bedata.daemon_data.unpack.");
-	   
-                lrc = LMON_ENEGCB;
-              }
-          }
-	else
-	  {
-	    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	      "bedata.daemon_data.unpack has not been registered!  ");
-
-	    lrc = LMON_ENCLLB;
-	  }
-	free (usrpl);
-      }
-    else
-      {
-	lrc = LMON_ENOPLD;
-      }
-
-  END_MASTER_ONLY
-
-
-something_bad:
-  //
-  // duplicating the return code
-  //
-  if ( LMON_be_broadcast ( &lrc, sizeof(lrc) != LMON_OK ))
-    {
+    } else {
       LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "Broadcast failed");
+                   "bedata.daemon_data.unpack has not been registered!  ");
 
-      lrc = LMON_ESUBCOM;
+      lrc = LMON_ENCLLB;
     }
-
-    return lrc;
-}
-
-
-//! lmon_rc_e LMON_fe_sendUsrData
-/*!
-    Please refer to the header file: lmon_be.h 
-*/
-lmon_rc_e 
-LMON_be_sendUsrData ( void* udata )
-{
-  lmon_rc_e lrc = LMON_OK;
-
-  BEGIN_MASTER_ONLY(bedata)
-    
-    lmonp_t *usrmsg;
-  
-    if ( (udata != NULL) && (bedata.daemon_data.pack != NULL) )
-      {
-    	char *uoffset;
-        int upl_leng;
-    	usrmsg = (lmonp_t *) malloc ( 
-    			      sizeof (lmonp_t) 
-    			      + LMON_MAX_USRPAYLOAD );
-	if ( usrmsg == NULL )
-	  {
-	    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
- 	      "Out of memory");
-
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-	
-        set_msg_header ( 
-                    usrmsg,
-                    lmonp_fetobe,
-                    (int) lmonp_befe_usrdata,
-                    0,0,0,0,0,0,
-                    LMON_MAX_USRPAYLOAD);
-
-    	uoffset = get_usrpayload_begin ( usrmsg );
-        if ( bedata.daemon_data.pack ( udata, uoffset, LMON_MAX_USRPAYLOAD, &upl_leng ) < 0 )
-          {
-	    lrc = LMON_ENEGCB;
-	    goto something_bad;
-          }
-
-    	//assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
-        usrmsg->usr_payload_length = upl_leng;
-      }
-    else
-      {
-    	usrmsg = (lmonp_t *) malloc ( sizeof (lmonp_t));
-	if ( usrmsg == NULL )
-	  {
-	    LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-	      "Out of memory");
-
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-    	usrmsg->usr_payload_length = 0;
-	lrc = LMON_ENCLLB;
-      }
-
-    usrmsg->msgclass = lmonp_fetobe;
-    usrmsg->type.fetobe_type = lmonp_befe_usrdata;
-    usrmsg->sec_or_jobsizeinfo.security_key1 = 0;
-    usrmsg->sec_or_stringinfo.security_key2 = 0;
-    usrmsg->lmon_payload_length = 0;
-    if ( (write_lmonp_long_msg ( 
-    		       servsockfd, 
-		       usrmsg, 
-		       sizeof (lmonp_t) + usrmsg->usr_payload_length ))
-	 < 0 )
-      {
-	LMON_say_msg(LMON_BE_MSG_PREFIX, true, 
-          "write_lmonp returned a neg value");
-
-	lrc = LMON_ESYS;
-        goto something_bad;
-      }
-    free (usrmsg);
+    free(usrpl);
+  } else {
+    lrc = LMON_ENOPLD;
+  }
 
   END_MASTER_ONLY
 
@@ -1747,13 +1359,91 @@ something_bad:
   //
   // duplicating the return code
   //
-  if ( LMON_be_broadcast ( &lrc, sizeof(lrc) != LMON_OK ))
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "Broadcast failed");
+  if (LMON_be_broadcast(&lrc, sizeof(lrc) != LMON_OK)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Broadcast failed");
 
-      lrc = LMON_ESUBCOM;
-    }
+    lrc = LMON_ESUBCOM;
+  }
 
   return lrc;
 }
+
+//! lmon_rc_e LMON_fe_sendUsrData
+/*!
+    Please refer to the header file: lmon_be.h
+*/
+lmon_rc_e LMON_be_sendUsrData(void *udata) {
+  lmon_rc_e lrc = LMON_OK;
+
+  BEGIN_MASTER_ONLY(bedata)
+
+  lmonp_t *usrmsg;
+
+  if ((udata != NULL) && (bedata.daemon_data.pack != NULL)) {
+    char *uoffset;
+    int upl_leng;
+    usrmsg = (lmonp_t *)malloc(sizeof(lmonp_t) + LMON_MAX_USRPAYLOAD);
+    if (usrmsg == NULL) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Out of memory");
+
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
+
+    set_msg_header(usrmsg, lmonp_fetobe, (int)lmonp_befe_usrdata, 0, 0, 0, 0, 0,
+                   0, LMON_MAX_USRPAYLOAD);
+
+    uoffset = get_usrpayload_begin(usrmsg);
+    if (bedata.daemon_data.pack(udata, uoffset, LMON_MAX_USRPAYLOAD,
+                                &upl_leng) < 0) {
+      lrc = LMON_ENEGCB;
+      goto something_bad;
+    }
+
+    // assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
+    usrmsg->usr_payload_length = upl_leng;
+  } else {
+    usrmsg = (lmonp_t *)malloc(sizeof(lmonp_t));
+    if (usrmsg == NULL) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Out of memory");
+
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
+    usrmsg->usr_payload_length = 0;
+    lrc = LMON_ENCLLB;
+  }
+
+  usrmsg->msgclass = lmonp_fetobe;
+  usrmsg->type.fetobe_type = lmonp_befe_usrdata;
+  usrmsg->sec_or_jobsizeinfo.security_key1 = 0;
+  usrmsg->sec_or_stringinfo.security_key2 = 0;
+  usrmsg->lmon_payload_length = 0;
+  if ((write_lmonp_long_msg(servsockfd, usrmsg,
+                            sizeof(lmonp_t) + usrmsg->usr_payload_length)) <
+      0) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "write_lmonp returned a neg value");
+
+    lrc = LMON_ESYS;
+    goto something_bad;
+  }
+  free(usrmsg);
+
+  END_MASTER_ONLY
+
+something_bad:
+  //
+  // duplicating the return code
+  //
+  if (LMON_be_broadcast(&lrc, sizeof(lrc) != LMON_OK)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Broadcast failed");
+
+    lrc = LMON_ESUBCOM;
+  }
+
+  return lrc;
+}
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi.cxx
@@ -1,27 +1,28 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -43,14 +44,14 @@
 #error This source file requires a LINUX-like OS
 #endif
 
-#include "lmon_daemon_internal.hxx"
 #include "../../sdbg_rm_map.hxx"
 #include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
 #include "lmon_be_sync_mpi.hxx"
-#include "lmon_be_sync_mpi_generic.hxx"
 #include "lmon_be_sync_mpi_bg.hxx"
 #include "lmon_be_sync_mpi_bgq.hxx"
+#include "lmon_be_sync_mpi_generic.hxx"
+#include "lmon_daemon_internal.hxx"
 
 static int dontstop_fastpath = 0;
 
@@ -59,70 +60,55 @@ static int dontstop_fastpath = 0;
 // LAUNCHMON MPI-Tool SYNC LAYER PUBLIC INTERFACE
 //
 
-lmon_rc_e
-LMON_be_procctl_tester_init ( rm_catalogue_e rmtype,
-                              MPIR_PROCDESC_EXT *ptab,
-                              int islaunch,
-                              int psize,
-                              int dontstop)
-{
+lmon_rc_e LMON_be_procctl_tester_init(rm_catalogue_e rmtype,
+                                      MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                      int psize, int dontstop) {
   lmon_rc_e rc = LMON_OK;
 
   //
   // tester procctller init should be a noop for BGP as OS doesn't
   // allow launchmon layer to cleanly undo the process control effects
   // Thus, the tester cannot go through its own ATTACH sequence cleanly
-  // This has been fixed in BGQ though. 
+  // This has been fixed in BGQ though.
   //
 
-  if ( (rmtype != RC_bgprm) && (rmtype != RC_bglrm) )
-    {
-      rc = LMON_be_procctl_init (rmtype, ptab, islaunch, psize, dontstop);
-    }
+  if ((rmtype != RC_bgprm) && (rmtype != RC_bglrm)) {
+    rc = LMON_be_procctl_init(rmtype, ptab, islaunch, psize, dontstop);
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_init ( rm_catalogue_e rmtype,
-                       MPIR_PROCDESC_EXT *ptab,
-                       int islaunch,
-                       int psize,
-                       int dontstop )
-{
+lmon_rc_e LMON_be_procctl_init(rm_catalogue_e rmtype, MPIR_PROCDESC_EXT *ptab,
+                               int islaunch, int psize, int dontstop) {
   lmon_rc_e rc = LMON_EINVAL;
 
   // 0: don't use fastpath
   // 1: use fastpath
   // anything else: inherit the state
 
-  if ( dontstop == 0 || dontstop == 1 )
-    {
-      dontstop_fastpath = dontstop;
-    }
+  if (dontstop == 0 || dontstop == 1) {
+    dontstop_fastpath = dontstop;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control init"
-    " visited with rmtype(%d) psize(%d), islaunch(%d), dontstop_fastpath(%d)", 
-    rmtype, psize, islaunch, dontstop_fastpath );
+  LMON_say_msg(
+      LMON_BE_MSG_PREFIX, false,
+      "Platform-independent proc control init"
+      " visited with rmtype(%d) psize(%d), islaunch(%d), dontstop_fastpath(%d)",
+      rmtype, psize, islaunch, dontstop_fastpath);
 #endif
 
-  switch(rmtype)
-    {
+  switch (rmtype) {
     case RC_slurm:
       //
       // Call generic Linux init
       //
-      if (islaunch)
-        { 
-          rc = LMON_be_procctl_init_ptrace ( ptab, islaunch, psize );
-        }
-      else
-        {
-          rc = LMON_be_procctl_init_generic ( ptab, islaunch, psize );
-        } 
+      if (islaunch) {
+        rc = LMON_be_procctl_init_ptrace(ptab, islaunch, psize);
+      } else {
+        rc = LMON_be_procctl_init_generic(ptab, islaunch, psize);
+      }
       break;
 
     case RC_orte:
@@ -133,7 +119,7 @@ LMON_be_procctl_init ( rm_catalogue_e rmtype,
       //
       // Call generic Linux init
       //
-      rc = LMON_be_procctl_init_generic ( ptab, islaunch, psize );
+      rc = LMON_be_procctl_init_generic(ptab, islaunch, psize);
       break;
 
     case RC_bglrm:
@@ -141,7 +127,7 @@ LMON_be_procctl_init ( rm_catalogue_e rmtype,
       //
       // Call RM-specific init with BG CIOD debug interface
       //
-      rc = LMON_be_procctl_init_bg ( ptab, islaunch, psize );
+      rc = LMON_be_procctl_init_bg(ptab, islaunch, psize);
       break;
 
     case RC_bgqrm:
@@ -149,40 +135,35 @@ LMON_be_procctl_init ( rm_catalogue_e rmtype,
       //
       // Call RM-specific init with BGQ CDTI interface
       //
-      rc = (dontstop_fastpath) 
-           ? LMON_OK 
-           : LMON_be_procctl_init_bgq ( ptab, islaunch, psize );
+      rc = (dontstop_fastpath) ? LMON_OK : LMON_be_procctl_init_bgq(
+                                               ptab, islaunch, psize);
       break;
 
     case RC_mchecker_rm:
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_init", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_init", rmtype);
 #endif
       break;
-    }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_stop ( rm_catalogue_e rmtype,
-                       MPIR_PROCDESC_EXT *ptab,
-                       int psize )
-{
+lmon_rc_e LMON_be_procctl_stop(rm_catalogue_e rmtype, MPIR_PROCDESC_EXT *ptab,
+                               int psize) {
   lmon_rc_e rc = LMON_EINVAL;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control stop"
-    " visited with rmtype(%d)", rmtype );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "Platform-independent proc control stop"
+               " visited with rmtype(%d)",
+               rmtype);
 #endif
 
-  switch ( rmtype )
-    {
+  switch (rmtype) {
     case RC_slurm:
     case RC_orte:
     case RC_alps:
@@ -192,7 +173,7 @@ LMON_be_procctl_stop ( rm_catalogue_e rmtype,
       //
       // Call generic Linux stop
       //
-      rc = LMON_be_procctl_stop_generic ( ptab, psize );
+      rc = LMON_be_procctl_stop_generic(ptab, psize);
       break;
 
     case RC_bglrm:
@@ -200,7 +181,7 @@ LMON_be_procctl_stop ( rm_catalogue_e rmtype,
       //
       // Call RM-specific stop with BG CIOD debug interface
       //
-      rc = LMON_be_procctl_stop_bg ( ptab, psize );
+      rc = LMON_be_procctl_stop_bg(ptab, psize);
       break;
 
     case RC_bgqrm:
@@ -208,52 +189,41 @@ LMON_be_procctl_stop ( rm_catalogue_e rmtype,
       //
       // Call RM-specific stop with BGQ CDTI interface
       //
-      rc = (dontstop_fastpath) ?
-               LMON_OK :
-               LMON_be_procctl_stop_bgq ( ptab, psize );
+      rc =
+          (dontstop_fastpath) ? LMON_OK : LMON_be_procctl_stop_bgq(ptab, psize);
       break;
 
     case RC_mchecker_rm:
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_stop", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_stop", rmtype);
 #endif
       break;
-    }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_tester_run ( rm_catalogue_e rmtype,
-                      int signum,
-                      MPIR_PROCDESC_EXT *ptab,
-                      int psize )
-{
-  return LMON_be_procctl_run ( rmtype, signum, ptab, psize);
+lmon_rc_e LMON_be_procctl_tester_run(rm_catalogue_e rmtype, int signum,
+                                     MPIR_PROCDESC_EXT *ptab, int psize) {
+  return LMON_be_procctl_run(rmtype, signum, ptab, psize);
 }
 
-
-lmon_rc_e
-LMON_be_procctl_run ( rm_catalogue_e rmtype,
-                      int signum,
-                      MPIR_PROCDESC_EXT *ptab,
-                      int psize )
-{
+lmon_rc_e LMON_be_procctl_run(rm_catalogue_e rmtype, int signum,
+                              MPIR_PROCDESC_EXT *ptab, int psize) {
   lmon_rc_e rc = LMON_EINVAL;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control run"
-    " visited with rmtype(%d) dontstop_fastpath(%d) signum(%d) psize(%d)", 
-    rmtype, dontstop_fastpath, signum, psize );
+  LMON_say_msg(
+      LMON_BE_MSG_PREFIX, false,
+      "Platform-independent proc control run"
+      " visited with rmtype(%d) dontstop_fastpath(%d) signum(%d) psize(%d)",
+      rmtype, dontstop_fastpath, signum, psize);
 #endif
 
-  switch(rmtype)
-    {
+  switch (rmtype) {
     case RC_slurm:
     case RC_orte:
     case RC_alps:
@@ -263,7 +233,7 @@ LMON_be_procctl_run ( rm_catalogue_e rmtype,
       //
       // Call generic Linux run
       //
-      rc = LMON_be_procctl_run_generic ( signum, ptab, psize );
+      rc = LMON_be_procctl_run_generic(signum, ptab, psize);
       break;
 
     case RC_bglrm:
@@ -271,7 +241,7 @@ LMON_be_procctl_run ( rm_catalogue_e rmtype,
       //
       // Call RM-specific run with BG CIOD debug interface
       //
-      rc = LMON_be_procctl_run_bg ( signum, ptab, psize );
+      rc = LMON_be_procctl_run_bg(signum, ptab, psize);
       break;
 
     case RC_bgqrm:
@@ -279,48 +249,42 @@ LMON_be_procctl_run ( rm_catalogue_e rmtype,
       //
       // Call RM-specific run with BGQ CDTI interface
       //
-      rc = (dontstop_fastpath) 
-           ? LMON_OK 
-           : LMON_be_procctl_run_bgq ( signum, ptab, psize );
+      rc = (dontstop_fastpath) ? LMON_OK
+                               : LMON_be_procctl_run_bgq(signum, ptab, psize);
       break;
 
     case RC_mchecker_rm:
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_run", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_run", rmtype);
 #endif
       break;
-    }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_initdone( rm_catalogue_e rmtype,
-                          MPIR_PROCDESC_EXT *ptab,
-                          int islaunch,
-                          int psize)
-{
+lmon_rc_e LMON_be_procctl_initdone(rm_catalogue_e rmtype,
+                                   MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                   int psize) {
   lmon_rc_e rc = LMON_EINVAL;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control initdone"
-    " visited with rmtype(%d)", rmtype );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "Platform-independent proc control initdone"
+               " visited with rmtype(%d)",
+               rmtype);
 #endif
 
-  switch(rmtype)
-    {
+  switch (rmtype) {
     case RC_slurm:
       //
       // Call ptrace Linux initdone for launch case
       //
-      rc = (islaunch == 1) 
-           ? LMON_be_procctl_initdone_ptrace (ptab, psize) 
-           : LMON_be_procctl_initdone_generic (ptab, psize);
+      rc = (islaunch == 1) ? LMON_be_procctl_initdone_ptrace(ptab, psize)
+                           : LMON_be_procctl_initdone_generic(ptab, psize);
       break;
 
     case RC_orte:
@@ -331,7 +295,7 @@ LMON_be_procctl_initdone( rm_catalogue_e rmtype,
       //
       // Call generic Linux initdone
       //
-      rc = LMON_be_procctl_initdone_generic (ptab, psize);
+      rc = LMON_be_procctl_initdone_generic(ptab, psize);
       break;
 
     case RC_bglrm:
@@ -339,7 +303,7 @@ LMON_be_procctl_initdone( rm_catalogue_e rmtype,
       //
       // Call RM-specific initdone with BG CIOD debug interface
       //
-      rc = LMON_be_procctl_initdone_bg (ptab, islaunch, psize);
+      rc = LMON_be_procctl_initdone_bg(ptab, islaunch, psize);
       break;
 
     case RC_bgqrm:
@@ -347,40 +311,35 @@ LMON_be_procctl_initdone( rm_catalogue_e rmtype,
       //
       // Call RM-specific initdone with BGQ CDTI interface
       //
-      rc = (dontstop_fastpath) 
-           ? LMON_OK
-           : LMON_be_procctl_initdone_bgq (ptab, islaunch, psize) ;
+      rc = (dontstop_fastpath) ? LMON_OK : LMON_be_procctl_initdone_bgq(
+                                               ptab, islaunch, psize);
       break;
 
     case RC_mchecker_rm:
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_initdone", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_initdone", rmtype);
 #endif
-     break;
-    }
+      break;
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_done(rm_catalogue_e rmtype,
-                    MPIR_PROCDESC_EXT *ptab,
-                    int psize)
-{
+lmon_rc_e LMON_be_procctl_done(rm_catalogue_e rmtype, MPIR_PROCDESC_EXT *ptab,
+                               int psize) {
   lmon_rc_e rc = LMON_EINVAL;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control done"
-    " visited with rmtype(%d) dontstop_faststop", rmtype, dontstop_fastpath );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "Platform-independent proc control done"
+               " visited with rmtype(%d) dontstop_faststop",
+               rmtype, dontstop_fastpath);
 #endif
 
-  switch(rmtype)
-    {
+  switch (rmtype) {
     case RC_slurm:
     case RC_orte:
     case RC_alps:
@@ -406,44 +365,37 @@ LMON_be_procctl_done(rm_catalogue_e rmtype,
       //
       // Call RM-specific init with BGQ CDTI interface
       //
-      rc = (dontstop_fastpath) ? 
-	      LMON_OK :
-              LMON_be_procctl_done_bgq(ptab, psize);
+      rc =
+          (dontstop_fastpath) ? LMON_OK : LMON_be_procctl_done_bgq(ptab, psize);
       break;
 
     case RC_mchecker_rm:
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_done", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_done", rmtype);
 #endif
       break;
-    }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e 
-LMON_be_procctl_perf ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize, 
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
+lmon_rc_e LMON_be_procctl_perf(rm_catalogue_e rmtype, MPIR_PROCDESC_EXT *ptab,
+                               int psize, long unsigned int membase,
+                               unsigned int numbytes, unsigned int *fetchunit,
+                               unsigned int *usecperunit) {
   lmon_rc_e rc = LMON_EINVAL;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "Platform-independent proc control perf"
-    " visited with rmtype(%d)", rmtype );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "Platform-independent proc control perf"
+               " visited with rmtype(%d)",
+               rmtype);
 #endif
 
-  switch(rmtype)
-    {
+  switch (rmtype) {
     case RC_slurm:
     case RC_orte:
     case RC_alps:
@@ -453,8 +405,7 @@ LMON_be_procctl_perf ( rm_catalogue_e rmtype,
       //
       // You need to do nothing for these resource managers
       //
-      rc = LMON_be_procctl_perf_generic(ptab, psize,
-                                        membase, numbytes,
+      rc = LMON_be_procctl_perf_generic(ptab, psize, membase, numbytes,
                                         fetchunit, usecperunit);
       break;
 
@@ -463,9 +414,8 @@ LMON_be_procctl_perf ( rm_catalogue_e rmtype,
       //
       // Call RM-specific init with BG CIOD debug interface
       //
-      rc = LMON_be_procctl_perf_bg(ptab, psize,
-                                   membase, numbytes,
-                                   fetchunit, usecperunit);
+      rc = LMON_be_procctl_perf_bg(ptab, psize, membase, numbytes, fetchunit,
+                                   usecperunit);
       break;
 
     case RC_bgqrm:
@@ -473,9 +423,8 @@ LMON_be_procctl_perf ( rm_catalogue_e rmtype,
       //
       // Call RM-specific init with BGQ CDTI interface
       //
-      rc = LMON_be_procctl_perf_bgq(ptab, psize,
-                                    membase, numbytes,
-                                    fetchunit, usecperunit);
+      rc = LMON_be_procctl_perf_bgq(ptab, psize, membase, numbytes, fetchunit,
+                                    usecperunit);
 
       break;
 
@@ -483,11 +432,15 @@ LMON_be_procctl_perf ( rm_catalogue_e rmtype,
     case RC_none:
     default:
 #if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "Unsupported RM Type (%d) for procctl_perf", rmtype );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Unsupported RM Type (%d) for procctl_perf", rmtype);
 #endif
       break;
-    }
+  }
 
   return rc;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi.hxx
@@ -1,29 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_be.cxx,v 1.12.2.5 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *              Oct 31 2011 DHA: File created
@@ -37,48 +38,42 @@
 #include "lmon_api/lmon_api_std.h"
 #include "lmon_api/lmon_proctab.h"
 
-extern lmon_rc_e LMON_be_procctl_init ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize,
-		   int dontstop );
+extern lmon_rc_e LMON_be_procctl_init(rm_catalogue_e rmtype,
+                                      MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                      int psize, int dontstop);
 
-extern lmon_rc_e LMON_be_procctl_tester_init ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize,
-		   int dontstop );
+extern lmon_rc_e LMON_be_procctl_tester_init(rm_catalogue_e rmtype,
+                                             MPIR_PROCDESC_EXT *ptab,
+                                             int islaunch, int psize,
+                                             int dontstop);
 
-extern lmon_rc_e LMON_be_procctl_stop ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_stop(rm_catalogue_e rmtype,
+                                      MPIR_PROCDESC_EXT *ptab, int psize);
 
-extern lmon_rc_e LMON_be_procctl_tester_run ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize,
-		   int dontstop );
+extern lmon_rc_e LMON_be_procctl_tester_run(rm_catalogue_e rmtype,
+                                            MPIR_PROCDESC_EXT *ptab,
+                                            int islaunch, int psize,
+                                            int dontstop);
 
-extern lmon_rc_e LMON_be_procctl_run ( rm_catalogue_e rmtype,
-                   int signum,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_run(rm_catalogue_e rmtype, int signum,
+                                     MPIR_PROCDESC_EXT *ptab, int psize);
 
-extern lmon_rc_e LMON_be_procctl_perf ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit);
+extern lmon_rc_e LMON_be_procctl_perf(rm_catalogue_e rmtype,
+                                      MPIR_PROCDESC_EXT *ptab, int psize,
+                                      long unsigned int membase,
+                                      unsigned int numbytes,
+                                      unsigned int *fetchunit,
+                                      unsigned int *usecperunit);
 
-extern lmon_rc_e LMON_be_procctl_initdone ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_initdone(rm_catalogue_e rmtype,
+                                          MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                          int psize);
 
-extern lmon_rc_e LMON_be_procctl_done ( rm_catalogue_e rmtype,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_done(rm_catalogue_e rmtype,
+                                      MPIR_PROCDESC_EXT *ptab, int psize);
 
-#endif // LMON_BE_SYNC_MPI_HXX
+#endif  // LMON_BE_SYNC_MPI_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bg.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bg.cxx
@@ -1,27 +1,28 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2011 - 2012, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -44,10 +45,10 @@
 
 #include <signal.h>
 #include <sys/types.h>
-#include "lmon_daemon_internal.hxx"
 #include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
 #include "lmon_be_sync_mpi_bg.hxx"
+#include "lmon_daemon_internal.hxx"
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -56,453 +57,341 @@
 //
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
-# include "debugger_interface.h"
+#include "debugger_interface.h"
 
 using namespace DebuggerInterface;
 
 static int all_stopped = 0;
 
-static lmon_rc_e
-reap_stop_noti ( MPIR_PROCDESC_EXT *ptab,
-                 int psize )
-{
+static lmon_rc_e reap_stop_noti(MPIR_PROCDESC_EXT *ptab, int psize) {
   lmon_rc_e lrc = LMON_OK;
   int i;
 
-  for ( i = 0; i < psize; i++ )
-    {
-      BG_Debugger_Msg ackmsg;
+  for (i = 0; i < psize; i++) {
+    BG_Debugger_Msg ackmsg;
 
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd for SIGNAL_ENCOUNTERED." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.messageType != SIGNAL_ENCOUNTERED)
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "msg type isn't SIGNAL_ENCOUNTERED." );
-          lrc = LMON_EINVAL;
-          break;
-        }
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "readFromFd for SIGNAL_ENCOUNTERED.");
+      lrc = LMON_EINVAL;
+      break;
     }
 
-  if (lrc == LMON_OK)
-    all_stopped = 1;
+    if (ackmsg.header.messageType != SIGNAL_ENCOUNTERED) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "msg type isn't SIGNAL_ENCOUNTERED.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
+
+  if (lrc == LMON_OK) all_stopped = 1;
 
   return lrc;
 }
 
-
-static lmon_rc_e
-stop_all_wo_noti_reap ( MPIR_PROCDESC_EXT *ptab,
-                          int psize )
-{
+static lmon_rc_e stop_all_wo_noti_reap(MPIR_PROCDESC_EXT *ptab, int psize) {
   lmon_rc_e lrc = LMON_OK;
   int i;
 
-  for ( i = 0; i < psize; i++ )
-    {
-      BG_Debugger_Msg dbgmsg ( KILL,ptab[i].pd.pid,0,0,0 );
-      dbgmsg.dataArea.KILL.signal = SIGSTOP;
-      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
-      BG_Debugger_Msg ackmsg;
-      BG_Debugger_Msg ackmsg2;
+  for (i = 0; i < psize; i++) {
+    BG_Debugger_Msg dbgmsg(KILL, ptab[i].pd.pid, 0, 0, 0);
+    dbgmsg.dataArea.KILL.signal = SIGSTOP;
+    dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
+    BG_Debugger_Msg ackmsg;
+    BG_Debugger_Msg ackmsg2;
 
-      if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE, dbgmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "writeOnFd for KILL.");
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd for KILL ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.messageType != KILL_ACK)
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "msg type isn't KILL ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
+    if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "writeOnFd for KILL.");
+      lrc = LMON_EINVAL;
+      break;
     }
+
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "readFromFd for KILL ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (ackmsg.header.messageType != KILL_ACK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "msg type isn't KILL ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
 
   return lrc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_init_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int islaunch,
-                          int psize)
-{
+lmon_rc_e LMON_be_procctl_init_bg(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                  int psize) {
   lmon_rc_e lrc = LMON_OK;
 
   int i;
-  for (i=0; i < psize; i++)
-    {
-      BG_Debugger_Msg dbgmsg ( ATTACH,ptab[i].pd.pid,0,0,0 );
-      BG_Debugger_Msg ackmsg;
-      BG_Debugger_Msg ackmsg2;
-      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.ATTACH);
+  for (i = 0; i < psize; i++) {
+    BG_Debugger_Msg dbgmsg(ATTACH, ptab[i].pd.pid, 0, 0, 0);
+    BG_Debugger_Msg ackmsg;
+    BG_Debugger_Msg ackmsg2;
+    dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.ATTACH);
 
-      if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE, dbgmsg) )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "ATTACH command failed.");
+    if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "ATTACH command failed.");
 
-          lrc = LMON_EINVAL;
-          break;
-        }
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg) )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "ATTACH_ACK failed.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "ATTACH_ACK failed.");
 
-          lrc = LMON_EINVAL;
-          break;
-        }
-      if ( ackmsg.header.messageType != ATTACH_ACK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd received a wrong msg type: %d.",
-              ackmsg.header.messageType);
+      lrc = LMON_EINVAL;
+      break;
+    }
+    if (ackmsg.header.messageType != ATTACH_ACK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "readFromFd received a wrong msg type: %d.",
+                   ackmsg.header.messageType);
 
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.nodeNumber
-           != (unsigned int) ptab[i].pd.pid )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "ATTACH_ACK contains a wrong nodeNumber");
-
-          lrc = LMON_EINVAL;
-          break;
-        }
+      lrc = LMON_EINVAL;
+      break;
     }
 
-  if (lrc != LMON_EINVAL)
-    {
-      lrc = (islaunch == 1) 
-            ?  stop_all_wo_noti_reap (ptab, psize)
-            : LMON_be_procctl_stop_bg (ptab, psize);
+    if (ackmsg.header.nodeNumber != (unsigned int)ptab[i].pd.pid) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "ATTACH_ACK contains a wrong nodeNumber");
+
+      lrc = LMON_EINVAL;
+      break;
     }
- 
-  return lrc;
-}
+  }
 
-
-lmon_rc_e
-LMON_be_procctl_stop_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int psize )
-{
-  lmon_rc_e lrc = LMON_OK;
-  int i;
-
-  for ( i=0; i < psize; i++ )
-    {
-      BG_Debugger_Msg dbgmsg ( KILL,ptab[i].pd.pid,0,0,0 );
-      dbgmsg.dataArea.KILL.signal = SIGSTOP;
-      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
-      BG_Debugger_Msg ackmsg;
-      BG_Debugger_Msg ackmsg2;
-
-      if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE, dbgmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "writeOnFd for KILL.");
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd for KILL ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.messageType != KILL_ACK)
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "msg type isn't KILL ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg2 ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd for SINGANL ENCOUNTERED ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg2.header.messageType != SIGNAL_ENCOUNTERED)
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "msg type isn't SIGNAL_ENCOUNTERED ACK." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-    }
-
-  if (lrc == LMON_OK)
-    all_stopped = 1;
+  if (lrc != LMON_EINVAL) {
+    lrc = (islaunch == 1) ? stop_all_wo_noti_reap(ptab, psize)
+                          : LMON_be_procctl_stop_bg(ptab, psize);
+  }
 
   return lrc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_run_bg ( int signum,
-                         MPIR_PROCDESC_EXT* ptab,
-                         int psize)
-{
+lmon_rc_e LMON_be_procctl_stop_bg(MPIR_PROCDESC_EXT *ptab, int psize) {
   lmon_rc_e lrc = LMON_OK;
   int i;
 
-  if (all_stopped == 0)
-    {
-      lrc = LMON_be_procctl_stop_bg (ptab, psize);
-      if (lrc != LMON_OK)
-        return lrc;
+  for (i = 0; i < psize; i++) {
+    BG_Debugger_Msg dbgmsg(KILL, ptab[i].pd.pid, 0, 0, 0);
+    dbgmsg.dataArea.KILL.signal = SIGSTOP;
+    dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
+    BG_Debugger_Msg ackmsg;
+    BG_Debugger_Msg ackmsg2;
+
+    if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "writeOnFd for KILL.");
+      lrc = LMON_EINVAL;
+      break;
     }
+
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "readFromFd for KILL ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (ackmsg.header.messageType != KILL_ACK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "msg type isn't KILL ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg2)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "readFromFd for SINGANL ENCOUNTERED ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (ackmsg2.header.messageType != SIGNAL_ENCOUNTERED) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "msg type isn't SIGNAL_ENCOUNTERED ACK.");
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
+
+  if (lrc == LMON_OK) all_stopped = 1;
+
+  return lrc;
+}
+
+lmon_rc_e LMON_be_procctl_run_bg(int signum, MPIR_PROCDESC_EXT *ptab,
+                                 int psize) {
+  lmon_rc_e lrc = LMON_OK;
+  int i;
+
+  if (all_stopped == 0) {
+    lrc = LMON_be_procctl_stop_bg(ptab, psize);
+    if (lrc != LMON_OK) return lrc;
+  }
 
   //
   // continue
   //
-  for (i=0; i < psize; i++)
-    {
-      BG_Debugger_Msg dbgmsg ( CONTINUE,ptab[i].pd.pid,0,0,0 );
-      BG_Debugger_Msg ackmsg;
-      dbgmsg.dataArea.CONTINUE.signal = (signum==SIGCONT)? 0 : signum;
-      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.CONTINUE);
+  for (i = 0; i < psize; i++) {
+    BG_Debugger_Msg dbgmsg(CONTINUE, ptab[i].pd.pid, 0, 0, 0);
+    BG_Debugger_Msg ackmsg;
+    dbgmsg.dataArea.CONTINUE.signal = (signum == SIGCONT) ? 0 : signum;
+    dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.CONTINUE);
 
-      if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE, dbgmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "writeOnFd for CONTINUE." );
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "readFromFd for CONTINUE ACK." );
-
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.messageType != CONTINUE_ACK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "msg type isn't CONTINUE ACK." );
-
-          lrc = LMON_EINVAL;
-          break;
-        }
-
-      if ( ackmsg.header.nodeNumber
-           != (unsigned int) ptab[i].pd.pid )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Incorrect pid in the returned debug msg.");
-
-          lrc = LMON_EINVAL;
-          break;
-        }
+    if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "writeOnFd for CONTINUE.");
+      lrc = LMON_EINVAL;
+      break;
     }
 
-  if (lrc == LMON_OK)
-    all_stopped = 0;
+    if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "readFromFd for CONTINUE ACK.");
+
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (ackmsg.header.messageType != CONTINUE_ACK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "msg type isn't CONTINUE ACK.");
+
+      lrc = LMON_EINVAL;
+      break;
+    }
+
+    if (ackmsg.header.nodeNumber != (unsigned int)ptab[i].pd.pid) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Incorrect pid in the returned debug msg.");
+
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
+
+  if (lrc == LMON_OK) all_stopped = 0;
 
   return lrc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_perf_bg ( 
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
+lmon_rc_e LMON_be_procctl_perf_bg(MPIR_PROCDESC_EXT *ptab, int psize,
+                                  long unsigned int membase,
+                                  unsigned int numbytes,
+                                  unsigned int *fetchunit,
+                                  unsigned int *usecperunit) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_initdone_bg ( MPIR_PROCDESC_EXT *ptab,
-                              int islaunch,
-                              int psize)
-{
+lmon_rc_e LMON_be_procctl_initdone_bg(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                      int psize) {
   lmon_rc_e rc = LMON_OK;
 
-  if (islaunch)
-    {
-      rc = reap_stop_noti (ptab, psize);
-    }
+  if (islaunch) {
+    rc = reap_stop_noti(ptab, psize);
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_done_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int psize )
-{
+lmon_rc_e LMON_be_procctl_done_bg(MPIR_PROCDESC_EXT *ptab, int psize) {
   lmon_rc_e lrc = LMON_OK;
 
-  BG_Debugger_Msg dbgmsg ( VERSION_MSG,0,0,0,0 );
-  BG_Debugger_Msg dbgmsg2 ( END_DEBUG,0,0,0,0 );
+  BG_Debugger_Msg dbgmsg(VERSION_MSG, 0, 0, 0, 0);
+  BG_Debugger_Msg dbgmsg2(END_DEBUG, 0, 0, 0, 0);
   BG_Debugger_Msg ackmsg;
   BG_Debugger_Msg ackmsg2;
   dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.VERSION_MSG);
   dbgmsg2.header.dataLength = sizeof(dbgmsg2.dataArea.END_DEBUG);
 
-  if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE, dbgmsg) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "VERSION_MSG command failed.");
+  if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "VERSION_MSG command failed.");
 
-      lrc = LMON_EINVAL;
-      goto return_loc;
+    lrc = LMON_EINVAL;
+    goto return_loc;
+  }
+
+  if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "VERSION_MSG_ACK failed.");
+
+    lrc = LMON_EINVAL;
+    goto return_loc;
+  }
+
+  if (ackmsg.header.messageType != VERSION_MSG_ACK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "readFromFd received a wrong msg type: %d.",
+                 ackmsg.header.messageType);
+
+    lrc = LMON_EINVAL;
+    goto return_loc;
+  } else {
+    if (ackmsg.dataArea.VERSION_MSG_ACK.protocolVersion >= 3) {
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "BES: debugger protocol higher than or equal to 3.");
+#endif
+
+      if (!BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, dbgmsg2)) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true, "END_DEBUG command failed.");
+
+        lrc = LMON_EINVAL;
+        goto return_loc;
+      }
+
+      if (!BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, ackmsg2)) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true, "VERSION_MSG_ACK failed.");
+
+        lrc = LMON_EINVAL;
+        goto return_loc;
+      }
+
+    } else {
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "BES: debugger protocol lower than or equal to 3.");
+#endif
     }
-
-  if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE, ackmsg) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "VERSION_MSG_ACK failed.");
-
-      lrc = LMON_EINVAL;
-      goto return_loc;
-    }
-
-  if ( ackmsg.header.messageType != VERSION_MSG_ACK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "readFromFd received a wrong msg type: %d.",
-        ackmsg.header.messageType);
-
-      lrc = LMON_EINVAL;
-      goto return_loc;
-    }
-  else
-    {
-      if ( ackmsg.dataArea.VERSION_MSG_ACK.protocolVersion >= 3 )
-        {
-
-# if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "BES: debugger protocol higher than or equal to 3." );
-# endif
-
-          if ( !BG_Debugger_Msg::writeOnFd (BG_DEBUGGER_WRITE_PIPE,
-                                            dbgmsg2) )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "END_DEBUG command failed.");
-
-              lrc = LMON_EINVAL;
-              goto return_loc;
-            }
-
-          if ( !BG_Debugger_Msg::readFromFd (BG_DEBUGGER_READ_PIPE,
-                                             ackmsg2) )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "VERSION_MSG_ACK failed.");
-
-              lrc = LMON_EINVAL;
-              goto return_loc;
-            }
-
-          }
-        else
-          {
-# if VERBOSE
-            LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-              "BES: debugger protocol lower than or equal to 3." );
-# endif
-          }
-    }
+  }
 
 return_loc:
   return lrc;
 }
 
-#else // if SUB_ARCH_BGL || SUB_ARCH_BGP
+#else  // if SUB_ARCH_BGL || SUB_ARCH_BGP
 
-lmon_rc_e
-LMON_be_procctl_init_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int islaunch,
-                          int psize)
-{
-   return LMON_EINVAL;
-}
-
-
-lmon_rc_e
-LMON_be_procctl_stop_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int psize)
-{
+lmon_rc_e LMON_be_procctl_init_bg(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                  int psize) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_run_bg ( int signum,
-                         MPIR_PROCDESC_EXT *ptab,
-                         int psize)
-{
+lmon_rc_e LMON_be_procctl_stop_bg(MPIR_PROCDESC_EXT *ptab, int psize) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_perf_bg ( 
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
+lmon_rc_e LMON_be_procctl_run_bg(int signum, MPIR_PROCDESC_EXT *ptab,
+                                 int psize) {
   return LMON_EINVAL;
 }
 
-lmon_rc_e
-LMON_be_procctl_initdone_bg ( MPIR_PROCDESC_EXT *ptab,
-                              int islaunch,
-                              int psize)
-{
+lmon_rc_e LMON_be_procctl_perf_bg(MPIR_PROCDESC_EXT *ptab, int psize,
+                                  long unsigned int membase,
+                                  unsigned int numbytes,
+                                  unsigned int *fetchunit,
+                                  unsigned int *usecperunit) {
   return LMON_EINVAL;
 }
 
+lmon_rc_e LMON_be_procctl_initdone_bg(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                      int psize) {
+  return LMON_EINVAL;
+}
 
-lmon_rc_e
-LMON_be_procctl_done_bg ( MPIR_PROCDESC_EXT *ptab,
-                          int psize)
-{
+lmon_rc_e LMON_be_procctl_done_bg(MPIR_PROCDESC_EXT *ptab, int psize) {
   return LMON_EINVAL;
 }
 
 #endif
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bg.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bg.hxx
@@ -1,29 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_be.cxx,v 1.12.2.5 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2011, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *              Oct 31 2011 DHA: File created
@@ -36,35 +37,27 @@
 #include "lmon_api/lmon_api_std.h"
 #include "lmon_api/lmon_proctab.h"
 
-extern lmon_rc_e LMON_be_procctl_init_bg (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_init_bg(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                         int psize);
 
-extern lmon_rc_e LMON_be_procctl_stop_bg (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_stop_bg(MPIR_PROCDESC_EXT *ptab, int psize);
 
-extern lmon_rc_e LMON_be_procctl_run_bg (
-                   int signum,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_run_bg(int signum, MPIR_PROCDESC_EXT *ptab,
+                                        int psize);
 
-extern lmon_rc_e LMON_be_procctl_perf_bg (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit);
+extern lmon_rc_e LMON_be_procctl_perf_bg(MPIR_PROCDESC_EXT *ptab, int psize,
+                                         long unsigned int membase,
+                                         unsigned int numbytes,
+                                         unsigned int *fetchunit,
+                                         unsigned int *usecperunit);
 
-extern lmon_rc_e LMON_be_procctl_initdone_bg (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_initdone_bg(MPIR_PROCDESC_EXT *ptab,
+                                             int islaunch, int psize);
 
-extern lmon_rc_e LMON_be_procctl_done_bg (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_done_bg(MPIR_PROCDESC_EXT *ptab, int psize);
 
-#endif // LMON_BE_SYNC_MPI_BG_HXX
+#endif  // LMON_BE_SYNC_MPI_BG_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bgq.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bgq.cxx
@@ -1,29 +1,30 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *              Nov 28 2011 DHA: Added Thread Hold/Release
@@ -49,29 +50,28 @@
 #error This source file requires a LINUX-like OS
 #endif
 
-#include <signal.h>
-#include <sys/un.h> 
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <errno.h>
-#include <string.h>
 #include <limits.h>
-#include <map>
-#include <vector>
-#include <string>
-#include <iostream>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
 #include <fstream>
+#include <iostream>
+#include <map>
 #include <sstream>
+#include <string>
+#include <vector>
 
-#include "lmon_daemon_internal.hxx"
-#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_be_sync_mpi_bgq.hxx"
+#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
+#include "lmon_daemon_internal.hxx"
 
 #if SUB_ARCH_BGQ
 
-# include "ramdisk/include/services/ToolctlMessages.h"
-
+#include "ramdisk/include/services/ToolctlMessages.h"
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -80,112 +80,82 @@
 //
 //
 
-struct CNMap
-{
+struct CNMap {
   std::map<int, int> CN2Sock;
   std::map<int, std::vector<int> > CN2Ranks;
 };
 
-
-struct SendSignalMessage
-{
+struct SendSignalMessage {
   bgcios::toolctl::UpdateMessage uMsg;
   bgcios::toolctl::SendSignalCmd sSigCmd;
 };
 
-
-struct SendSignalAckMessage
-{
+struct SendSignalAckMessage {
   bgcios::toolctl::UpdateMessage uMsg;
   bgcios::toolctl::SendSignalAckCmd sigAckCmd;
 };
 
-
-struct HoldThrMessage
-{
+struct HoldThrMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::HoldThreadCmd holdThrCmd;
 };
 
-
-struct HoldThrAckMessage
-{
+struct HoldThrAckMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::HoldThreadAckCmd holdThrAckCmd;
 };
 
-
-struct ReleaseThrMessage
-{
+struct ReleaseThrMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::ReleaseThreadCmd releaseThrCmd;
 };
 
-
-struct ReleaseThrAckMessage
-{
+struct ReleaseThrAckMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::ReleaseThreadAckCmd releaseThrAckCmd;
 };
 
-
-struct ContProcMessage
-{
+struct ContProcMessage {
   bgcios::toolctl::UpdateMessage uMsg;
   bgcios::toolctl::SetContinuationSignalCmd sigContCmd;
   bgcios::toolctl::ContinueProcessCmd contProcCmd;
 };
 
-
-struct ContProcAckMessage
-{
+struct ContProcAckMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::SetContinuationSignalAckCmd sigContAckCmd;
   bgcios::toolctl::ContinueProcessAckCmd contProcCmd;
 };
 
-
-struct ReleaseMessage
-{
+struct ReleaseMessage {
   bgcios::toolctl::UpdateMessage uMsg;
   bgcios::toolctl::ReleaseControlCmd releaseCmd;
 };
 
-
-struct ReleaseAckMessage
-{
+struct ReleaseAckMessage {
   bgcios::toolctl::UpdateAckMessage uMsg;
   bgcios::toolctl::ReleaseControlAckCmd releaseAckCmd;
 };
 
-
-struct FetchMemoryMessage
-{
+struct FetchMemoryMessage {
   bgcios::toolctl::QueryMessage uMsg;
   bgcios::toolctl::GetMemoryCmd getMemCmd;
 };
 
-
-struct FetchMemoryAckMessage
-{
+struct FetchMemoryAckMessage {
   bgcios::toolctl::QueryAckMessage uMsg;
   bgcios::toolctl::GetMemoryAckCmd getMemAckCmd;
 };
 
-
-struct ThrListMessage
-{
+struct ThrListMessage {
   bgcios::toolctl::QueryMessage uMsg;
   bgcios::toolctl::GetThreadListCmd tListCmd;
 };
 
-
-struct ThrListAckMessage
-{
+struct ThrListAckMessage {
   bgcios::toolctl::QueryAckMessage uMsg;
   bgcios::toolctl::GetThreadListAckCmd tLAckCmd;
 };
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -200,26 +170,18 @@ static uint32_t _toolid;
 static uint64_t _cdtiVer;
 static uint32_t _seqNum = 0;
 
-
 //////////////////////////////////////////////////////////////////////////////////
 //
 // LAUNCHMON MPI-Tool SYNC LAYER (Blue Gene /Q)
 //           INTERNAL INTERFACE
 //
 
-static void
-fill_CIOS_Header ( bgcios::MessageHeader &hdr,
-                 uint8_t service,
-                 uint8_t version,
-                 uint16_t type,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint32_t returnCode,
-                 uint32_t errorCode,
-                 uint32_t length,
-                 uint64_t jobId )
-{
-  bgcios::initHeader ( &hdr );
+static void fill_CIOS_Header(bgcios::MessageHeader &hdr, uint8_t service,
+                             uint8_t version, uint16_t type, uint32_t rank,
+                             uint32_t sequenceId, uint32_t returnCode,
+                             uint32_t errorCode, uint32_t length,
+                             uint64_t jobId) {
+  bgcios::initHeader(&hdr);
 
   hdr.service = service;
   hdr.version = version;
@@ -232,297 +194,214 @@ fill_CIOS_Header ( bgcios::MessageHeader &hdr,
   hdr.jobId = jobId;
 }
 
-
-static void
-print_cios_header ( const bgcios::MessageHeader &hdr )
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                   "[[[[MessageHeader]]]]service(%d)"
-                   " version(%d)"
-                   " type(%d)"
-                   " rank(%d)"
-                   " sequenceId(%d)"
-                   " returnCode(%d)"
-                   " errorCode(%d)"
-                   " length(%d)"
-                   " jobid(%ld)",
-                   hdr.service, 
-                   hdr.version, 
-                   hdr.type, 
-                   hdr.rank,
-                   hdr.sequenceId, 
-                   hdr.returnCode, 
-                   hdr.errorCode, 
-                   hdr.length, 
-                   hdr.jobId ); 
+static void print_cios_header(const bgcios::MessageHeader &hdr) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "[[[[MessageHeader]]]]service(%d)"
+               " version(%d)"
+               " type(%d)"
+               " rank(%d)"
+               " sequenceId(%d)"
+               " returnCode(%d)"
+               " errorCode(%d)"
+               " length(%d)"
+               " jobid(%ld)",
+               hdr.service, hdr.version, hdr.type, hdr.rank, hdr.sequenceId,
+               hdr.returnCode, hdr.errorCode, hdr.length, hdr.jobId);
 }
 
-
-static void
-print_cios_toolmsg ( const bgcios::toolctl::ToolMessage *msg)
-{
-  LMON_say_msg (LMON_BE_MSG_PREFIX, false, "<<ToolMessage>>");
-  print_cios_header ( msg->header );
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                 "  ToolMessage: tooldId(%d)",
-                 msg->toolId );
-
+static void print_cios_toolmsg(const bgcios::toolctl::ToolMessage *msg) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "<<ToolMessage>>");
+  print_cios_header(msg->header);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "  ToolMessage: tooldId(%d)",
+               msg->toolId);
 }
 
-
-static void
-print_cios_toolcmd (const bgcios::toolctl::ToolCommand *cmd)
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                 "    <<ToolCommand>>: threadID(%d)",
-                 cmd->threadID );
+static void print_cios_toolcmd(const bgcios::toolctl::ToolCommand *cmd) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "    <<ToolCommand>>: threadID(%d)",
+               cmd->threadID);
 }
 
-
-static void
-print_cios_toolcmd_getthreadlist(const bgcios::toolctl::GetThreadListCmd *cmd)
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "    <GetThreadListCmd> ");
-  print_cios_toolcmd ((const bgcios::toolctl::ToolCommand *)cmd);
+static void print_cios_toolcmd_getthreadlist(
+    const bgcios::toolctl::GetThreadListCmd *cmd) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "    <GetThreadListCmd> ");
+  print_cios_toolcmd((const bgcios::toolctl::ToolCommand *)cmd);
 }
 
-
-static void
-print_cios_toolcmd_getmemory (const bgcios::toolctl::GetMemoryCmd *cmd)
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "    <GetMemoryCmd> ");
-  print_cios_toolcmd ((const bgcios::toolctl::ToolCommand *)cmd);
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "    addr(%d) length(%d) specaccess(%d)", cmd->addr, cmd->length, cmd->specAccess);
+static void print_cios_toolcmd_getmemory(
+    const bgcios::toolctl::GetMemoryCmd *cmd) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "    <GetMemoryCmd> ");
+  print_cios_toolcmd((const bgcios::toolctl::ToolCommand *)cmd);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "    addr(%d) length(%d) specaccess(%d)", cmd->addr, cmd->length,
+               cmd->specAccess);
 }
 
-
-static void
-print_cios_toolcmd_getthreadlistack(const bgcios::toolctl::GetThreadListAckCmd *cmd)
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "    <GetThreadListAckCmd>");
-  print_cios_toolcmd ((const bgcios::toolctl::ToolCommand *)cmd);
+static void print_cios_toolcmd_getthreadlistack(
+    const bgcios::toolctl::GetThreadListAckCmd *cmd) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "    <GetThreadListAckCmd>");
+  print_cios_toolcmd((const bgcios::toolctl::ToolCommand *)cmd);
   int i;
-  for (i=0; i < cmd->numthreads; ++i)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                     "    GetThreadListAckCmd: threadlist[%d]: tid (%d), info.commthread(%d)",
-                     i, cmd->threadlist[i].tid, cmd->threadlist[i].info.commthread);
-    }
+  for (i = 0; i < cmd->numthreads; ++i) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                 "    GetThreadListAckCmd: threadlist[%d]: tid (%d), "
+                 "info.commthread(%d)",
+                 i, cmd->threadlist[i].tid, cmd->threadlist[i].info.commthread);
+  }
 }
 
-
-static void
-print_cios_toolcmd_getmemoryack(const bgcios::toolctl::GetMemoryAckCmd *cmd)
-{
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "    <GetMemoryAckCmd>");
-  print_cios_toolcmd ((const bgcios::toolctl::ToolCommand *)cmd);
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                   "    GetMemoryAckCmd: address(%x), length(%d)",
-                   cmd->addr, cmd->length);
+static void print_cios_toolcmd_getmemoryack(
+    const bgcios::toolctl::GetMemoryAckCmd *cmd) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "    <GetMemoryAckCmd>");
+  print_cios_toolcmd((const bgcios::toolctl::ToolCommand *)cmd);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "    GetMemoryAckCmd: address(%x), length(%d)", cmd->addr,
+               cmd->length);
 }
 
+static void print_cios_querymsg(const bgcios::toolctl::QueryMessage *msg) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "<QueryMessage>");
+  print_cios_toolmsg((const bgcios::toolctl::ToolMessage *)msg);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, " QueryMessage: numCommands(%d)",
+               msg->numCommands);
+  int i = 0;
+  for (i = 0; i < msg->numCommands; ++i) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                 " CommandDestriptor[%d] type(%d)"
+                 " reserved(%d)"
+                 " offset(%d)"
+                 " length(%d)"
+                 " returnCode(%d)",
+                 i, msg->cmdList[i].type, msg->cmdList[i].reserved,
+                 msg->cmdList[i].offset, msg->cmdList[i].length,
+                 msg->cmdList[i].returnCode);
+    char *t;
+    switch (msg->cmdList[i].type) {
+      case bgcios::toolctl::GetThreadList:
+        t = (char *)msg + msg->cmdList[i].offset;
+        print_cios_toolcmd_getthreadlist(
+            (const bgcios::toolctl::GetThreadListCmd *)t);
+        break;
 
-static void
-print_cios_querymsg ( const bgcios::toolctl::QueryMessage *msg)
-{
-  LMON_say_msg (LMON_BE_MSG_PREFIX, false, "<QueryMessage>");
-  print_cios_toolmsg ( (const bgcios::toolctl::ToolMessage *) msg);
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                 " QueryMessage: numCommands(%d)",
-                 msg->numCommands);
-  int i=0;
-  for (i=0; i < msg->numCommands; ++i)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                     " CommandDestriptor[%d] type(%d)"
-                     " reserved(%d)"
-                     " offset(%d)"
-                     " length(%d)"
-                     " returnCode(%d)",
-                     i,
-                     msg->cmdList[i].type,
-                     msg->cmdList[i].reserved,
-                     msg->cmdList[i].offset,
-                     msg->cmdList[i].length,
-                     msg->cmdList[i].returnCode);
-      char *t;
-      switch(msg->cmdList[i].type)
-        {
-        case bgcios::toolctl::GetThreadList:
-          t = (char *)msg + msg->cmdList[i].offset;
-          print_cios_toolcmd_getthreadlist ((const bgcios::toolctl::GetThreadListCmd *)t);
-          break;
+      case bgcios::toolctl::GetMemory:
+        t = (char *)msg + msg->cmdList[i].offset;
+        print_cios_toolcmd_getmemory((const bgcios::toolctl::GetMemoryCmd *)t);
+        break;
 
-        case bgcios::toolctl::GetMemory:
-          t = (char *)msg + msg->cmdList[i].offset;
-          print_cios_toolcmd_getmemory ((const bgcios::toolctl::GetMemoryCmd *)t);
-          break;
-
-        default:
-          break;
-       }
+      default:
+        break;
     }
+  }
 }
 
+static void print_cios_queryackmsg(
+    const bgcios::toolctl::QueryAckMessage *msg) {
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "<QueryAckMessage>");
+  print_cios_toolmsg((const bgcios::toolctl::ToolMessage *)msg);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, " QueryAckMessage: numCommands(%d)",
+               msg->numCommands);
+  int i = 0;
+  for (i = 0; i < msg->numCommands; ++i) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                 "     CommandDestriptor[%d] type(%d)"
+                 " reserved(%d)"
+                 " offset(%d)"
+                 " length(%d)"
+                 " returnCode(%d)",
+                 i, msg->cmdList[i].type, msg->cmdList[i].reserved,
+                 msg->cmdList[i].offset, msg->cmdList[i].length,
+                 msg->cmdList[i].returnCode);
+    char *t = NULL;
+    switch (msg->cmdList[i].type) {
+      case bgcios::toolctl::GetThreadListAck:
+        t = (char *)msg + msg->cmdList[i].offset;
+        print_cios_toolcmd_getthreadlistack(
+            (const bgcios::toolctl::GetThreadListAckCmd *)t);
+        break;
 
-static void
-print_cios_queryackmsg ( const bgcios::toolctl::QueryAckMessage *msg)
-{
-  LMON_say_msg (LMON_BE_MSG_PREFIX, false, "<QueryAckMessage>");
-  print_cios_toolmsg ( (const bgcios::toolctl::ToolMessage *) msg);
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                 " QueryAckMessage: numCommands(%d)",
-                 msg->numCommands);
-  int i=0;
-  for (i=0; i < msg->numCommands; ++i)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                     "     CommandDestriptor[%d] type(%d)"
-                     " reserved(%d)"
-                     " offset(%d)"
-                     " length(%d)"
-                     " returnCode(%d)",
-                     i,
-                     msg->cmdList[i].type,
-                     msg->cmdList[i].reserved,
-                     msg->cmdList[i].offset,
-                     msg->cmdList[i].length,
-                     msg->cmdList[i].returnCode);
-        char *t = NULL;
-      switch(msg->cmdList[i].type)
-        {
-        case bgcios::toolctl::GetThreadListAck:
-          t = (char *)msg + msg->cmdList[i].offset;
-          print_cios_toolcmd_getthreadlistack ((const bgcios::toolctl::GetThreadListAckCmd *)t);
-          break;
+      case bgcios::toolctl::GetMemoryAck:
+        t = (char *)msg + msg->cmdList[i].offset;
+        print_cios_toolcmd_getmemoryack(
+            (const bgcios::toolctl::GetMemoryAckCmd *)t);
+        break;
 
-        case bgcios::toolctl::GetMemoryAck:
-          t = (char *)msg + msg->cmdList[i].offset;
-          print_cios_toolcmd_getmemoryack ((const bgcios::toolctl::GetMemoryAckCmd *)t);
-          break;
-
-        default:
-          break;
-        }
+      default:
+        break;
     }
+  }
 }
 
-
-static lmon_rc_e
-verify_MessageHeader ( bgcios::MessageHeader &hdr,
-                 uint8_t  version,
-                 uint16_t type,
-                 uint32_t rank,
-                 uint32_t sequenceId )
+static lmon_rc_e verify_MessageHeader(bgcios::MessageHeader &hdr,
+                                      uint8_t version, uint16_t type,
+                                      uint32_t rank, uint32_t sequenceId)
 
 {
-  if ( hdr.returnCode != bgcios::Success )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned via MessageHeader "
-        "returnCode(%d) %s",
-        hdr.returnCode, strerror(hdr.errorCode) );
+  if (hdr.returnCode != bgcios::Success) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned via MessageHeader "
+                 "returnCode(%d) %s",
+                 hdr.returnCode, strerror(hdr.errorCode));
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( hdr.type != type )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "A different Ack type (%d)", hdr.type );
+  if (hdr.type != type) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "A different Ack type (%d)",
+                 hdr.type);
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( hdr.rank != rank )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "A different rank (%d vs. %d)", hdr.rank, rank );
+  if (hdr.rank != rank) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "A different rank (%d vs. %d)",
+                 hdr.rank, rank);
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( hdr.sequenceId != sequenceId )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "A different sequenceId (%d vs. %d)",
-        hdr.sequenceId, sequenceId );
+  if (hdr.sequenceId != sequenceId) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "A different sequenceId (%d vs. %d)",
+                 hdr.sequenceId, sequenceId);
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
+static bgcios::toolctl::AttachMessage *create_AttachAllMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, const char *tTag, uint8_t prio) {
+  bgcios::toolctl::AttachMessage *msg = new bgcios::toolctl::AttachMessage();
 
-static bgcios::toolctl::AttachMessage *
-create_AttachAllMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 const char *tTag,
-                 uint8_t prio )
-{
-  bgcios::toolctl::AttachMessage *msg
-    = new bgcios::toolctl::AttachMessage ();
-
-  fill_CIOS_Header ( msg->header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Attach,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, //errorCode
-                     sizeof(*msg),
-                     jobId);
+  fill_CIOS_Header(msg->header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Attach, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->toolId = toolId;
-  snprintf ( msg->toolTag, bgcios::toolctl::ToolTagSize,
-             "%s", (tTag==NULL)? "LMON" : tTag);
+  snprintf(msg->toolTag, bgcios::toolctl::ToolTagSize, "%s",
+           (tTag == NULL) ? "LMON" : tTag);
   msg->procSelect = bgcios::toolctl::RanksInNode;
 
   return msg;
 }
 
-
-static lmon_rc_e
-verify_AttachAllAckMessage ( bgcios::toolctl::AttachAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId )
-{
-  return (verify_MessageHeader ( msg.header,
-                                 version,
-                                 bgcios::toolctl::AttachAck,
-                                 rank,
-                                 sequenceId ));
+static lmon_rc_e verify_AttachAllAckMessage(
+    bgcios::toolctl::AttachAckMessage &msg, uint8_t version, uint32_t rank,
+    uint32_t sequenceId, uint64_t jobId, uint32_t toolId) {
+  return (verify_MessageHeader(msg.header, version, bgcios::toolctl::AttachAck,
+                               rank, sequenceId));
 }
 
+static bgcios::toolctl::DetachMessage *create_DetachAllMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId) {
+  bgcios::toolctl::DetachMessage *msg = new bgcios::toolctl::DetachMessage();
 
-static bgcios::toolctl::DetachMessage *
-create_DetachAllMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId)
-{
-  bgcios::toolctl::DetachMessage *msg
-    = new bgcios::toolctl::DetachMessage ();
-
-  fill_CIOS_Header ( msg->header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Detach,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof(*msg),
-                     jobId );
+  fill_CIOS_Header(msg->header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Detach, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->toolId = toolId;
   msg->procSelect = bgcios::toolctl::RanksInNode;
@@ -530,50 +409,27 @@ create_DetachAllMessage ( uint8_t version,
   return msg;
 }
 
-
-static lmon_rc_e
-verify_DetachAllAckMessage ( bgcios::toolctl::DetachAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId)
-{
-  return ( verify_MessageHeader ( msg.header,
-                                 version,
-                                 bgcios::toolctl::DetachAck,
-                                 rank,
-                                 sequenceId ));
+static lmon_rc_e verify_DetachAllAckMessage(
+    bgcios::toolctl::DetachAckMessage &msg, uint8_t version, uint32_t rank,
+    uint32_t sequenceId, uint64_t jobId, uint32_t toolId) {
+  return (verify_MessageHeader(msg.header, version, bgcios::toolctl::DetachAck,
+                               rank, sequenceId));
 }
 
+static bgcios::toolctl::ControlMessage *create_ControlMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, sigset_t *sigset, uint32_t sndSig,
+    bgcios::toolctl::DynamicNotifyMode dNMode,
+    bgcios::toolctl::DACTrapMode dacTMode) {
+  bgcios::toolctl::ControlMessage *msg = new bgcios::toolctl::ControlMessage();
 
-static bgcios::toolctl::ControlMessage *
-create_ControlMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 sigset_t *sigset,
-                 uint32_t sndSig,
-                 bgcios::toolctl::DynamicNotifyMode dNMode,
-                 bgcios::toolctl::DACTrapMode dacTMode )
-{
-  bgcios::toolctl::ControlMessage *msg
-    = new bgcios::toolctl::ControlMessage ();
-
-  fill_CIOS_Header ( msg->header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Control,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof(*msg),
-                     jobId);
+  fill_CIOS_Header(msg->header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Control, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->toolId = toolId;
-  msg->notifySignalSet ( sigset );
+  msg->notifySignalSet(sigset);
   msg->sndSignal = sndSig;
   msg->dynamicNotifyMode = dNMode;
   msg->dacTrapMode = dacTMode;
@@ -581,578 +437,393 @@ create_ControlMessage ( uint8_t version,
   return msg;
 }
 
-
-static ThrListMessage *
-create_ThrListMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId)
-{
-  ThrListMessage *msg = new ThrListMessage ();
+static ThrListMessage *create_ThrListMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, bgcios::toolctl::BG_ThreadID_t threadId) {
+  ThrListMessage *msg = new ThrListMessage();
   msg->tListCmd.threadID = threadId;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Query,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof ( *msg ),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Query, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::GetThreadList;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->tListCmd );
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->tListCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_ThrListAckMessage(
+    ThrListAckMessage &msg, uint8_t version, uint32_t rank, uint32_t sequenceId,
+    uint64_t jobId, uint32_t toolId, bgcios::toolctl::BG_ThreadID_t threadId) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::QueryAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in QueryAckMessage for ThrListAck");
 
-static lmon_rc_e
-verify_ThrListAckMessage ( ThrListAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId )
-{
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::QueryAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in QueryAckMessage for ThrListAck");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if ((msg.uMsg.numCommands != 1) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::GetThreadListAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "numCommands (%d), "
+                 "type (%d), "
+                 "An error was returned in QueryAckMessage(%d)",
+                 msg.uMsg.numCommands, msg.uMsg.cmdList[0].type,
+                 msg.uMsg.cmdList[0].returnCode);
 
-  if ( (msg.uMsg.numCommands != 1)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::GetThreadListAck)
-       || (msg.uMsg.cmdList[0].returnCode
-          != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "numCommands (%d), "
-        "type (%d), " 
-        "An error was returned in QueryAckMessage(%d)",
-        msg.uMsg.numCommands,
-        msg.uMsg.cmdList[0].type,
-        msg.uMsg.cmdList[0].returnCode );
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static HoldThrMessage *
-create_HoldThrMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId )
-{
-  HoldThrMessage *msg = new HoldThrMessage ();
+static HoldThrMessage *create_HoldThrMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, bgcios::toolctl::BG_ThreadID_t threadId) {
+  HoldThrMessage *msg = new HoldThrMessage();
   msg->holdThrCmd.threadID = threadId;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Update,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof ( *msg ),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Update, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::HoldThread;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->holdThrCmd );
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->holdThrCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_HoldThrAckMessage(
+    HoldThrAckMessage &msg, uint8_t version, uint32_t rank, uint32_t sequenceId,
+    uint64_t jobId, uint32_t toolId, bgcios::toolctl::BG_ThreadID_t threadId) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::UpdateAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage for Signal");
 
-static lmon_rc_e
-verify_HoldThrAckMessage ( HoldThrAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId )
-{
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::UpdateAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage for Signal");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if ((msg.uMsg.numCommands != 1) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::HoldThreadAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage(%d)",
+                 msg.uMsg.cmdList[0].returnCode);
 
-  if ( (msg.uMsg.numCommands != 1)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::HoldThreadAck)
-       || (msg.uMsg.cmdList[0].returnCode
-          != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage(%d)",
-        msg.uMsg.cmdList[0].returnCode );
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static ReleaseThrMessage *
-create_ReleaseThrMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId )
-{
-  ReleaseThrMessage *msg = new ReleaseThrMessage ();
+static ReleaseThrMessage *create_ReleaseThrMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, bgcios::toolctl::BG_ThreadID_t threadId) {
+  ReleaseThrMessage *msg = new ReleaseThrMessage();
   msg->releaseThrCmd.threadID = threadId;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Update,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof ( *msg ),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Update, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::ReleaseThread;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->releaseThrCmd );
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->releaseThrCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_ReleaseThrAckMessage(
+    ReleaseThrAckMessage &msg, uint8_t version, uint32_t rank,
+    uint32_t sequenceId, uint64_t jobId, uint32_t toolId,
+    bgcios::toolctl::BG_ThreadID_t threadId) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::UpdateAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage for Signal");
 
-static lmon_rc_e
-verify_ReleaseThrAckMessage ( ReleaseThrAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_ThreadID_t threadId )
-{
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::UpdateAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage for Signal");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if ((msg.uMsg.numCommands != 1) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::ReleaseThreadAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage(%d)",
+                 msg.uMsg.cmdList[0].returnCode);
 
-  if ( (msg.uMsg.numCommands != 1)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::ReleaseThreadAck)
-       || (msg.uMsg.cmdList[0].returnCode
-          != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage(%d)",
-        msg.uMsg.cmdList[0].returnCode );
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static SendSignalMessage *
-create_SendSignalMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 int sndSig )
-{
-  SendSignalMessage *msg = new SendSignalMessage ();
+static SendSignalMessage *create_SendSignalMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, int sndSig) {
+  SendSignalMessage *msg = new SendSignalMessage();
   msg->sSigCmd.signum = sndSig;
   msg->sSigCmd.threadID = 0;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Update,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof ( *msg ),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Update, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::SendSignal;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->sSigCmd );
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->sSigCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_SendSignalAckMessage(SendSignalAckMessage &msg,
+                                             uint8_t version, uint32_t rank,
+                                             uint32_t sequenceId,
+                                             uint64_t jobId, uint32_t toolId,
+                                             int sndSig) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::UpdateAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage for Signal");
 
-static lmon_rc_e
-verify_SendSignalAckMessage ( SendSignalAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 int sndSig )
-{
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::UpdateAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage for Signal");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if ((msg.uMsg.numCommands != 1) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::SendSignalAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in SendSignalAckMessage(%d)",
+                 msg.uMsg.cmdList[0].returnCode);
 
-  if ( (msg.uMsg.numCommands != 1)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::SendSignalAck)
-       || (msg.uMsg.cmdList[0].returnCode
-          != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in SendSignalAckMessage(%d)",
-        msg.uMsg.cmdList[0].returnCode );
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static ContProcMessage *
-create_ContinueMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 int signum,
-                 uint64_t jobId,
-                 uint32_t toolId )
-{
-  ContProcMessage *msg
-    = new ContProcMessage ();
+static ContProcMessage *create_ContinueMessage(uint8_t version, uint32_t rank,
+                                               uint32_t sequenceId, int signum,
+                                               uint64_t jobId,
+                                               uint32_t toolId) {
+  ContProcMessage *msg = new ContProcMessage();
   msg->sigContCmd.threadID = 0;
   msg->sigContCmd.signum = signum;
   msg->contProcCmd.threadID = 0;
 
-
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Update,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof(*msg),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Update, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 2;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::SetContinuationSignal;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->sigContCmd ); 
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->sigContCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   msg->uMsg.cmdList[1].type = bgcios::toolctl::ContinueProcess;
   msg->uMsg.cmdList[1].reserved = 0;
-  msg->uMsg.cmdList[1].offset = msg->uMsg.cmdList[0].offset
-                                + msg->uMsg.cmdList[0].length;
-  msg->uMsg.cmdList[1].length = sizeof ( msg->contProcCmd ); 
+  msg->uMsg.cmdList[1].offset =
+      msg->uMsg.cmdList[0].offset + msg->uMsg.cmdList[0].length;
+  msg->uMsg.cmdList[1].length = sizeof(msg->contProcCmd);
   msg->uMsg.cmdList[1].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_ContinueAckMessage(ContProcAckMessage &msg,
+                                           uint8_t version, uint32_t rank,
+                                           uint32_t sequenceId, uint64_t jobId,
+                                           uint32_t toolId) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::UpdateAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage for Continue");
 
-static lmon_rc_e
-verify_ContinueAckMessage ( ContProcAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId)
-{
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::UpdateAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage for Continue" );
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if ((msg.uMsg.numCommands != 2) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::SetContinuationSignalAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess) ||
+      (msg.uMsg.cmdList[1].type != bgcios::toolctl::ContinueProcessAck) ||
+      (msg.uMsg.cmdList[1].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage: "
+                 "numCommands (%d), type (%d), returnCode (%d)"
+                 "type (%d), returnCode (%d)",
+                 msg.uMsg.numCommands, msg.uMsg.cmdList[0].type,
+                 msg.uMsg.cmdList[0].returnCode, msg.uMsg.cmdList[1].type,
+                 msg.uMsg.cmdList[1].returnCode);
 
-
-  if ( (msg.uMsg.numCommands != 2)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::SetContinuationSignalAck)
-       || (msg.uMsg.cmdList[0].returnCode
-          != bgcios::toolctl::CmdSuccess) 
-       || (msg.uMsg.cmdList[1].type
-          != bgcios::toolctl::ContinueProcessAck)
-       || (msg.uMsg.cmdList[1].returnCode
-          != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage: "
-        "numCommands (%d), type (%d), returnCode (%d)"
-        "type (%d), returnCode (%d)",
-        msg.uMsg.numCommands,
-        msg.uMsg.cmdList[0].type,
-        msg.uMsg.cmdList[0].returnCode,
-        msg.uMsg.cmdList[1].type,
-        msg.uMsg.cmdList[1].returnCode);
-
-     return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static ReleaseMessage *
-create_ReleaseMessage ( uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId )
-{
-  ReleaseMessage *msg
-    = new ReleaseMessage ();
+static ReleaseMessage *create_ReleaseMessage(uint8_t version, uint32_t rank,
+                                             uint32_t sequenceId,
+                                             uint64_t jobId, uint32_t toolId) {
+  ReleaseMessage *msg = new ReleaseMessage();
 
   msg->releaseCmd.threadID = 0;
-  msg->releaseCmd.notify 
-    = bgcios::toolctl::ReleaseControlNotify_Inactive;
+  msg->releaseCmd.notify = bgcios::toolctl::ReleaseControlNotify_Inactive;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Update,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof(*msg),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Update, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::ReleaseControl;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->releaseCmd );
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->releaseCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
+static lmon_rc_e verify_ReleaseAckMessage(ReleaseAckMessage &msg,
+                                          uint8_t version, uint32_t rank,
+                                          uint32_t sequenceId, uint64_t jobId,
+                                          uint32_t toolId) {
+  lmon_rc_e rc = verify_MessageHeader(
+      msg.uMsg.header, version, bgcios::toolctl::UpdateAck, rank, sequenceId);
+  if (rc != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage for Release");
 
-static lmon_rc_e
-verify_ReleaseAckMessage ( ReleaseAckMessage &msg,
-                 uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId)
-{
+    return LMON_EINVAL;
+  }
 
-  lmon_rc_e rc = verify_MessageHeader ( msg.uMsg.header,
-                                        version,
-                                        bgcios::toolctl::UpdateAck,
-                                        rank,
-                                        sequenceId );
-  if ( rc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "An error was returned in UpdateAckMessage for Release" );
+  if ((msg.uMsg.numCommands != 1) ||
+      (msg.uMsg.cmdList[0].type != bgcios::toolctl::ReleaseControlAck) ||
+      (msg.uMsg.cmdList[0].returnCode != bgcios::toolctl::CmdSuccess)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "An error was returned in UpdateAckMessage(%d)",
+                 msg.uMsg.cmdList[0].returnCode);
 
-      return LMON_EINVAL;
-    }
-
-  if ( (msg.uMsg.numCommands != 1)
-       || (msg.uMsg.cmdList[0].type
-          != bgcios::toolctl::ReleaseControlAck)
-       || (msg.uMsg.cmdList[0].returnCode
-	   != bgcios::toolctl::CmdSuccess) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-      "An error was returned in UpdateAckMessage(%d)",
-        msg.uMsg.cmdList[0].returnCode);
-
-      return LMON_EINVAL;
-
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static FetchMemoryMessage *
-create_FetchMemoryMessage (uint8_t version,
-                 uint32_t rank,
-                 uint32_t sequenceId,
-                 uint64_t jobId,
-                 uint32_t toolId,
-                 bgcios::toolctl::BG_Addr_t addr,
-                 int length)
-{
-  FetchMemoryMessage *msg = new FetchMemoryMessage ();
+static FetchMemoryMessage *create_FetchMemoryMessage(
+    uint8_t version, uint32_t rank, uint32_t sequenceId, uint64_t jobId,
+    uint32_t toolId, bgcios::toolctl::BG_Addr_t addr, int length) {
+  FetchMemoryMessage *msg = new FetchMemoryMessage();
   msg->getMemCmd.threadID = 0;
   msg->getMemCmd.addr = addr;
   msg->getMemCmd.length = length;
   msg->getMemCmd.specAccess = bgcios::toolctl::SpecAccess_ForceNonSpeculative;
 
-  fill_CIOS_Header ( msg->uMsg.header,
-                     bgcios::ToolctlService,
-                     version,
-                     bgcios::toolctl::Query,
-                     rank,
-                     sequenceId,
-                     bgcios::Success,
-                     0, // errorCode
-                     sizeof(*msg),
-                     jobId );
+  fill_CIOS_Header(msg->uMsg.header, bgcios::ToolctlService, version,
+                   bgcios::toolctl::Query, rank, sequenceId, bgcios::Success,
+                   0,  // errorCode
+                   sizeof(*msg), jobId);
 
   msg->uMsg.toolId = toolId;
   msg->uMsg.numCommands = 1;
   msg->uMsg.cmdList[0].type = bgcios::toolctl::GetMemory;
   msg->uMsg.cmdList[0].reserved = 0;
-  msg->uMsg.cmdList[0].offset = sizeof ( msg->uMsg );
-  msg->uMsg.cmdList[0].length = sizeof ( msg->getMemCmd);
+  msg->uMsg.cmdList[0].offset = sizeof(msg->uMsg);
+  msg->uMsg.cmdList[0].length = sizeof(msg->getMemCmd);
   msg->uMsg.cmdList[0].returnCode = bgcios::toolctl::CmdSuccess;
 
   return msg;
 }
 
-
-
-static lmon_rc_e
-open_domain_socket ()
-{
+static lmon_rc_e open_domain_socket() {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator i;
 
-  for (i = IOToolMap.CN2Ranks.begin ();
-           i != IOToolMap.CN2Ranks.end (); ++i)
-    {
-      sockaddr_un saddr;
-      int result;
-      socklen_t socklen = sizeof ( sockaddr_un );
-      int fd  = socket ( PF_UNIX, SOCK_STREAM, 0 );
-      if ( fd == -1 )
-       {
-          int error = errno;
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Error creating socket: %s.",
-            strerror(error) );
+  for (i = IOToolMap.CN2Ranks.begin(); i != IOToolMap.CN2Ranks.end(); ++i) {
+    sockaddr_un saddr;
+    int result;
+    socklen_t socklen = sizeof(sockaddr_un);
+    int fd = socket(PF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1) {
+      int error = errno;
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "Error creating socket: %s.",
+                   strerror(error));
 
-          goto return_loc;
-       }
-
-      bzero ( &saddr, socklen );
-      saddr.sun_family = AF_UNIX;
-
-      result = snprintf ( saddr.sun_path, sizeof ( saddr.sun_path ),
-        "/jobs/%lu/toolctl_node/%d",
-        _jobid, i->first);
-
-      if (result >= sizeof ( saddr.sun_path ))
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "addr.sun_path truncated");
-
-          goto return_loc;
-        }
-
-#if VERBOSE
-      char cmd[1024];
-      //sprintf(cmd, "ls -l /jobs/%lu/toolctl_node/", _jobid);
-      //system(cmd);
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "socket has been created for %s ", (char *) saddr.sun_path );
-#endif
-
-      if ( connect ( fd, (struct sockaddr *) &saddr, socklen ) == -1 )
-        {
-          int error = errno;
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Error connecting to a Unix domain socket: %s.",
-            strerror(error) );
-
-          goto return_loc;
-        }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "connect to %s", saddr.sun_path );
-#endif
-
-      IOToolMap.CN2Sock[i->first] = fd;
+      goto return_loc;
     }
+
+    bzero(&saddr, socklen);
+    saddr.sun_family = AF_UNIX;
+
+    result = snprintf(saddr.sun_path, sizeof(saddr.sun_path),
+                      "/jobs/%lu/toolctl_node/%d", _jobid, i->first);
+
+    if (result >= sizeof(saddr.sun_path)) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "addr.sun_path truncated");
+
+      goto return_loc;
+    }
+
+#if VERBOSE
+    char cmd[1024];
+    // sprintf(cmd, "ls -l /jobs/%lu/toolctl_node/", _jobid);
+    // system(cmd);
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "socket has been created for %s ",
+                 (char *)saddr.sun_path);
+#endif
+
+    if (connect(fd, (struct sockaddr *)&saddr, socklen) == -1) {
+      int error = errno;
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Error connecting to a Unix domain socket: %s.",
+                   strerror(error));
+
+      goto return_loc;
+    }
+
+#if VERBOSE
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "connect to %s", saddr.sun_path);
+#endif
+
+    IOToolMap.CN2Sock[i->first] = fd;
+  }
 
   rc = LMON_OK;
 
@@ -1160,20 +831,14 @@ return_loc:
   return rc;
 }
 
-
-static lmon_rc_e
-cleanup_resources ()
-{
+static lmon_rc_e cleanup_resources() {
   std::map<int, int>::iterator i;
-  
-  for (i = IOToolMap.CN2Sock.begin ();
-           i != IOToolMap.CN2Sock.end (); ++i)
-    {
-      if (close(i->second) == -1)
-        {
-          return LMON_EINVAL;
-        }
+
+  for (i = IOToolMap.CN2Sock.begin(); i != IOToolMap.CN2Sock.end(); ++i) {
+    if (close(i->second) == -1) {
+      return LMON_EINVAL;
     }
+  }
 
   IOToolMap.CN2Sock.clear();
   IOToolMap.CN2Ranks.clear();
@@ -1181,329 +846,141 @@ cleanup_resources ()
   return LMON_OK;
 }
 
-
-static int
-read_cios_longmsg ( int fd, void *msg, int buflen, int hdrlen,
-                    bgcios::toolctl::CommandDescriptor *cmdDesc )
-{
+static int read_cios_longmsg(int fd, void *msg, int buflen, int hdrlen,
+                             bgcios::toolctl::CommandDescriptor *cmdDesc) {
   int length;
-  char *msgPtr = (char *) msg;
+  char *msgPtr = (char *)msg;
 
-  if ( lmon_read_raw ( fd, (void *)msgPtr, hdrlen ) != hdrlen )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "lmon_read_raw did not read "
-        "the matching byte count for header" );
+  if (lmon_read_raw(fd, (void *)msgPtr, hdrlen) != hdrlen) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "lmon_read_raw did not read "
+                 "the matching byte count for header");
 
-      return -1;
-    }
+    return -1;
+  }
 
   length = cmdDesc->length;
-  if ( length > (buflen - hdrlen) )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "length of the payload greater than the buffer" );
+  if (length > (buflen - hdrlen)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "length of the payload greater than the buffer");
 
-      return -1;
-    }
+    return -1;
+  }
 
   msgPtr += hdrlen;
-  if ( lmon_read_raw (fd, (void *)msgPtr, length) != length )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "lmon_read_raw did not read "
-        "the matching byte count for the payload" );
+  if (lmon_read_raw(fd, (void *)msgPtr, length) != length) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "lmon_read_raw did not read "
+                 "the matching byte count for the payload");
 
-       return -1; 
-    }
+    return -1;
+  }
 
   return length + hdrlen;
 }
 
-
-static lmon_rc_e
-attach_all ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
+static lmon_rc_e attach_all(uint8_t cdtiVer, uint32_t &sequenceId,
+                            uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, int>::iterator i;
-  for (i = IOToolMap.CN2Sock.begin();
-           i != IOToolMap.CN2Sock.end(); ++i)
-    {
-      bgcios::toolctl::AttachMessage *attMsg = NULL;
-      bgcios::toolctl::AttachAckMessage ackMsg;
+  for (i = IOToolMap.CN2Sock.begin(); i != IOToolMap.CN2Sock.end(); ++i) {
+    bgcios::toolctl::AttachMessage *attMsg = NULL;
+    bgcios::toolctl::AttachAckMessage ackMsg;
 
+    attMsg = create_AttachAllMessage(cdtiVer, i->first, sequenceId, jobId,
+                                     toolId, "LMON", 1 /* priority */);
 
-      attMsg 
-	= create_AttachAllMessage ( cdtiVer, i->first,
-				    sequenceId, jobId, toolId,
-				    "LMON", 1 /* priority */ );
+    if (lmon_write_raw(i->second, (void *)attMsg, sizeof(*attMsg)) == -1) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Error writing to a Unix domain socket");
 
-      if (lmon_write_raw ( i->second, (void *) attMsg,
-                           sizeof(*attMsg)) == -1)
-        {
-          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-            "Error writing to a Unix domain socket");
-
-          goto return_loc;
-        }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "Sent AttachMessage to CN(%d)", i->first );
-#endif
-
-      if (lmon_read_raw ( i->second,
-                          (void *) &ackMsg,
-                          sizeof(ackMsg)) == -1)
-        {
-          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-            "Error reading from a Unix domain socket");
-
-          goto return_loc;
-        }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "Recv AttachAckMessage to CN(%d)", i->first );
-#endif
-
-      if ( verify_AttachAllAckMessage ( ackMsg,
-                                     cdtiVer,
-                                     i->first,
-                                     sequenceId,
-                                     jobId,
-                                     toolId ) != LMON_OK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "verify_AttachAllMessage reports a failure" );
-
-          goto return_loc;
-        }
-
-      delete attMsg;
-      attMsg = NULL;
-      sequenceId++;
+      goto return_loc;
     }
-  
+
+#if VERBOSE
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "Sent AttachMessage to CN(%d)",
+                 i->first);
+#endif
+
+    if (lmon_read_raw(i->second, (void *)&ackMsg, sizeof(ackMsg)) == -1) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Error reading from a Unix domain socket");
+
+      goto return_loc;
+    }
+
+#if VERBOSE
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "Recv AttachAckMessage to CN(%d)",
+                 i->first);
+#endif
+
+    if (verify_AttachAllAckMessage(ackMsg, cdtiVer, i->first, sequenceId, jobId,
+                                   toolId) != LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "verify_AttachAllMessage reports a failure");
+
+      goto return_loc;
+    }
+
+    delete attMsg;
+    attMsg = NULL;
+    sequenceId++;
+  }
+
   rc = LMON_OK;
 return_loc:
   return rc;
 }
 
-
-static lmon_rc_e
-detach_all ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
+static lmon_rc_e detach_all(uint8_t cdtiVer, uint32_t &sequenceId,
+                            uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, int>::iterator i;
 
-  for (i = IOToolMap.CN2Sock.begin ();
-                   i != IOToolMap.CN2Sock.end (); ++i)
-    {
-      bgcios::toolctl::DetachMessage *detMsg = NULL;
-      bgcios::toolctl::DetachAckMessage ackMsg;
-      detMsg = create_DetachAllMessage ( cdtiVer, i->first,
-                                         sequenceId, jobId, toolId );
+  for (i = IOToolMap.CN2Sock.begin(); i != IOToolMap.CN2Sock.end(); ++i) {
+    bgcios::toolctl::DetachMessage *detMsg = NULL;
+    bgcios::toolctl::DetachAckMessage ackMsg;
+    detMsg =
+        create_DetachAllMessage(cdtiVer, i->first, sequenceId, jobId, toolId);
 
-      if ( lmon_write_raw ( i->second, (void *) detMsg,
-                            sizeof(*detMsg)) == -1 )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Error writing to a Unix domain socket" );
+    if (lmon_write_raw(i->second, (void *)detMsg, sizeof(*detMsg)) == -1) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Error writing to a Unix domain socket");
 
-          goto return_loc;
-        }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "Sent DetachMessage to CN(%d)", i->first );
-#endif
-
-      if ( lmon_read_raw ( i->second, (void *) &ackMsg,
-                           sizeof(ackMsg)) == -1 )
-        {
-          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-            "Error reading from a Unix domain socket");
-
-          goto return_loc;
-        }
-
-#if VERBOSE
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-        "Recv DetachAckMessage to CN(%d)", i->first );
-#endif
-
-      if ( verify_DetachAllAckMessage ( ackMsg,
-                                        cdtiVer,
-                                        i->first,
-                                        sequenceId,
-                                        jobId,
-                                        toolId ) != LMON_OK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "verify_DetachAllAckMessage reports a failure" );
-
-          goto return_loc;
-        }
-
-      delete detMsg;
-      detMsg = NULL;
-      sequenceId++;
+      goto return_loc;
     }
 
-  rc = LMON_OK;
-
-return_loc:
-  return rc;
-}
-
-
-static lmon_rc_e
-hold_all_threads ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
-  lmon_rc_e rc = LMON_EINVAL;
-
-  std::map<int, std::vector<int> >::iterator cn;
-
-  for (cn = IOToolMap.CN2Ranks.begin();
-          cn != IOToolMap.CN2Ranks.end(); ++cn)
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin(); i != cn->second.end(); ++i)
-        {
-          ThrListMessage *tListMsg = NULL;
-          ThrListAckMessage ackMsg;
-
-          tListMsg = create_ThrListMessage( cdtiVer,
-                                            (uint32_t)(*i),
-                                            sequenceId,
-                                            jobId,
-                                            toolId,
-                                            0 /* directed to the dlft thread */ );
-
-          if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                 (void *) tListMsg,
-                                 sizeof(*tListMsg)) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
-
-              goto return_loc;
-            }
-
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent QueryMessage to CN(%d) rank(%d)"
-            " for ThrListMessage",
-            cn->first, *i );
-          print_cios_querymsg (&(tListMsg->uMsg));
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "Sent DetachMessage to CN(%d)",
+                 i->first);
 #endif
 
-          if ( read_cios_longmsg ( IOToolMap.CN2Sock[cn->first],
-                                   &ackMsg, sizeof (ackMsg),
-                                   sizeof (ackMsg.uMsg), 
-                                   ackMsg.uMsg.cmdList) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error reading from a Unix domain socket" );
+    if (lmon_read_raw(i->second, (void *)&ackMsg, sizeof(ackMsg)) == -1) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Error reading from a Unix domain socket");
 
-              goto return_loc;
-            }
+      goto return_loc;
+    }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv QueryAckMessage from CN(%d) rank(%d)"
-            " for ThrListAckMessage",
-            cn->first, *i);
-          print_cios_queryackmsg (&(ackMsg.uMsg));
+    LMON_say_msg(LMON_BE_MSG_PREFIX, false, "Recv DetachAckMessage to CN(%d)",
+                 i->first);
 #endif
 
-          if ( verify_ThrListAckMessage ( ackMsg,
-                                          cdtiVer,
-                                          (uint32_t)(*i),
-                                          sequenceId,
-                                          jobId,
-                                          toolId, 0) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_ThrListAckMessage reports a failure");
+    if (verify_DetachAllAckMessage(ackMsg, cdtiVer, i->first, sequenceId, jobId,
+                                   toolId) != LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "verify_DetachAllAckMessage reports a failure");
 
-              goto return_loc;
-            }
+      goto return_loc;
+    }
 
-          delete tListMsg;
-          tListMsg = NULL;
-          sequenceId++;
-
-          int tx;
-          for (tx=0; tx < ackMsg.tLAckCmd.numthreads; tx++)
-            {
-              HoldThrMessage *tHoldMsg = new HoldThrMessage ();
-              HoldThrAckMessage tHoldAckMsg;
-              bgcios::toolctl::BG_ThreadID_t threadId
-                = (bgcios::toolctl::BG_ThreadID_t)
-                  ackMsg.tLAckCmd.threadlist[tx].tid;
-
-              tHoldMsg = create_HoldThrMessage ( cdtiVer,
-                                                 (uint32_t)(*i),
-                                                 sequenceId,
-                                                 jobId,
-                                                 toolId,
-                                                 threadId );
-
-              if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                    (void *) tHoldMsg,
-                                    sizeof (*tHoldMsg)) == -1 )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error writing to a Unix domain socket" );
-
-                  goto return_loc;
-                }
-
-              if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) &tHoldAckMsg,
-                                   sizeof(tHoldAckMsg)) == -1 )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error reading from a Unix domain socket" );
-
-                  goto return_loc;
-                }
-
-              if ( verify_HoldThrAckMessage ( tHoldAckMsg,
-                                              cdtiVer,
-                                              (uint32_t)(*i),
-                                              sequenceId,
-                                              jobId,
-                                              toolId,
-                                              threadId ) != LMON_OK )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "verify_HoldThrAckMessage reports a failure");
-
-                  goto return_loc;
-                }
-
-              delete tHoldMsg;
-              tHoldMsg = NULL;
-              sequenceId++;
-            } // for each thread
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Held all threads in CN(%d) rank(%d)",
-            cn->first, *i );
-#endif
-
-        } // for each rank
-
-    } // for each compute node
+    delete detMsg;
+    detMsg = NULL;
+    sequenceId++;
+  }
 
   rc = LMON_OK;
 
@@ -1511,146 +988,115 @@ return_loc:
   return rc;
 }
 
-
-static lmon_rc_e
-release_all_threads ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
+static lmon_rc_e hold_all_threads(uint8_t cdtiVer, uint32_t &sequenceId,
+                                  uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator cn;
 
-  for (cn = IOToolMap.CN2Ranks.begin();
-          cn != IOToolMap.CN2Ranks.end(); ++cn)
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin(); i != cn->second.end(); ++i)
-        {
-          ThrListMessage *tListMsg = NULL;
-          ThrListAckMessage ackMsg;
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      ThrListMessage *tListMsg = NULL;
+      ThrListAckMessage ackMsg;
 
-          tListMsg = create_ThrListMessage( cdtiVer,
-                                            (uint32_t)(*i),
-                                            sequenceId,
-                                            jobId,
-                                            toolId,
-                                            0 /* directed to the dlft thread */ );
+      tListMsg =
+          create_ThrListMessage(cdtiVer, (uint32_t)(*i), sequenceId, jobId,
+                                toolId, 0 /* directed to the dlft thread */);
 
-          if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                (void *) tListMsg,
-                                sizeof(*tListMsg)) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)tListMsg,
+                         sizeof(*tListMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent QueryMessage to CN(%d) rank(%d)"
-            " for ThrListMessage",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent QueryMessage to CN(%d) rank(%d)"
+                   " for ThrListMessage",
+                   cn->first, *i);
+      print_cios_querymsg(&(tListMsg->uMsg));
 #endif
 
-          if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-                               sizeof(ackMsg)) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error reading from a Unix domain socket" );
+      if (read_cios_longmsg(IOToolMap.CN2Sock[cn->first], &ackMsg,
+                            sizeof(ackMsg), sizeof(ackMsg.uMsg),
+                            ackMsg.uMsg.cmdList) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv QueryAckMessage from CN(%d) rank(%d)"
-            " for ThrListAckMessage",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv QueryAckMessage from CN(%d) rank(%d)"
+                   " for ThrListAckMessage",
+                   cn->first, *i);
+      print_cios_queryackmsg(&(ackMsg.uMsg));
 #endif
 
-          if ( verify_ThrListAckMessage ( ackMsg,
-                                          cdtiVer,
-                                          (uint32_t)(*i),
-                                          sequenceId,
-                                          jobId,
-                                          toolId, 0) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_ThrListAckMessage reports a failure");
+      if (verify_ThrListAckMessage(ackMsg, cdtiVer, (uint32_t)(*i), sequenceId,
+                                   jobId, toolId, 0) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_ThrListAckMessage reports a failure");
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
-          delete tListMsg;
-          tListMsg = NULL;
-          sequenceId++;
+      delete tListMsg;
+      tListMsg = NULL;
+      sequenceId++;
 
-          int tx;
-          for (tx=0; tx < ackMsg.tLAckCmd.numthreads; tx++)
-            {
-              ReleaseThrMessage *tReleaseMsg = new ReleaseThrMessage ();
-              ReleaseThrAckMessage tReleaseAckMsg;
-              bgcios::toolctl::BG_ThreadID_t threadId
-                = (bgcios::toolctl::BG_ThreadID_t)
-                  ackMsg.tLAckCmd.threadlist[tx].tid;
+      int tx;
+      for (tx = 0; tx < ackMsg.tLAckCmd.numthreads; tx++) {
+        HoldThrMessage *tHoldMsg = new HoldThrMessage();
+        HoldThrAckMessage tHoldAckMsg;
+        bgcios::toolctl::BG_ThreadID_t threadId =
+            (bgcios::toolctl::BG_ThreadID_t)ackMsg.tLAckCmd.threadlist[tx].tid;
 
-              tReleaseMsg = create_ReleaseThrMessage ( cdtiVer,
-                                                       (uint32_t)(*i),
-                                                       sequenceId,
-                                                       jobId,
-                                                       toolId,
-                                                       threadId );
+        tHoldMsg = create_HoldThrMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                         jobId, toolId, threadId);
 
-              if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                    (void *) tReleaseMsg,
-                                    sizeof (*tReleaseMsg)) == -1 )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error writing to a Unix domain socket" );
+        if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)tHoldMsg,
+                           sizeof(*tHoldMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error writing to a Unix domain socket");
 
-                  goto return_loc;
-                }
+          goto return_loc;
+        }
 
-              if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) &tReleaseAckMsg,
-                                   sizeof(tReleaseAckMsg)) == -1 )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error reading from a Unix domain socket" );
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&tHoldAckMsg,
+                          sizeof(tHoldAckMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
 
-                  goto return_loc;
-                }
+          goto return_loc;
+        }
 
-              if ( verify_ReleaseThrAckMessage ( tReleaseAckMsg,
-                                                 cdtiVer,
-                                                 (uint32_t)(*i),
-                                                 sequenceId,
-                                                 jobId,
-                                                 toolId,
-                                                 threadId ) != LMON_OK )
-                {
-                  LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "verify_ReleaseThrAckMessage reports a failure");
+        if (verify_HoldThrAckMessage(tHoldAckMsg, cdtiVer, (uint32_t)(*i),
+                                     sequenceId, jobId, toolId,
+                                     threadId) != LMON_OK) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "verify_HoldThrAckMessage reports a failure");
 
-                  goto return_loc;
-                }
+          goto return_loc;
+        }
 
-              delete tReleaseMsg;
-              tReleaseMsg = NULL;
-              sequenceId++;
-            } // for each thread
+        delete tHoldMsg;
+        tHoldMsg = NULL;
+        sequenceId++;
+      }  // for each thread
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Released all threads in CN(%d) rank(%d)",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Held all threads in CN(%d) rank(%d)", cn->first, *i);
 #endif
 
-        } // for each rank
+    }  // for each rank
 
-    } // for each compute node
+  }  // for each compute node
 
   rc = LMON_OK;
 
@@ -1658,273 +1104,207 @@ return_loc:
   return rc;
 }
 
-
-static lmon_rc_e
-acquire_control_authority ( uint8_t cdtiVer,
-                 uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
+static lmon_rc_e release_all_threads(uint8_t cdtiVer, uint32_t &sequenceId,
+                                     uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator cn;
 
-  for ( cn = IOToolMap.CN2Ranks.begin();
-             cn != IOToolMap.CN2Ranks.end(); ++cn )
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin(); i != cn->second.end(); ++i)
-        {
-          bgcios::toolctl::ControlMessage *cntlMsg = NULL;
-          bgcios::toolctl::ControlAckMessage ackMsg;
-          bgcios::toolctl::NotifyMessage notifyMsg;
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      ThrListMessage *tListMsg = NULL;
+      ThrListAckMessage ackMsg;
 
-          sigset_t interestSig;
-          sigemptyset (&interestSig);
-          sigaddset (&interestSig, SIGSTOP);
+      tListMsg =
+          create_ThrListMessage(cdtiVer, (uint32_t)(*i), sequenceId, jobId,
+                                toolId, 0 /* directed to the dlft thread */);
 
-          cntlMsg = create_ControlMessage ( cdtiVer,
-                      (uint32_t)(*i),
-                      sequenceId,
-                      jobId,
-                      toolId,
-                      &interestSig,
-                      0,
-                      bgcios::toolctl::DynamicNotifyDLoader,
-                      bgcios::toolctl::DACTrap_NoChange );
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)tListMsg,
+                         sizeof(*tListMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
 
-          if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                (void *) cntlMsg,
-                                sizeof (*cntlMsg) ) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
-
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent ControlMessage to CN(%d) rank(%d)",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent QueryMessage to CN(%d) rank(%d)"
+                   " for ThrListMessage",
+                   cn->first, *i);
 #endif
 
-          if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-                               sizeof (ackMsg) ) == -1)
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error reading from a Unix domain socket" );
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv ControlAckMessage for CN(%d) rank(%d)",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv QueryAckMessage from CN(%d) rank(%d)"
+                   " for ThrListAckMessage",
+                   cn->first, *i);
 #endif
 
-	  //
-	  // TODO:
-	  // Control Authority Arbitration is Needed here
-	  //
-	  //
+      if (verify_ThrListAckMessage(ackMsg, cdtiVer, (uint32_t)(*i), sequenceId,
+                                   jobId, toolId, 0) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_ThrListAckMessage reports a failure");
 
-          if ( verify_MessageHeader ( ackMsg.header,
-                                      cdtiVer,
-                                      bgcios::toolctl::ControlAck,
-                                      *i,
-                                      sequenceId ) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "An error was returned in ControlAckMessage" );
+        goto return_loc;
+      }
 
-              goto return_loc;
-            }
+      delete tListMsg;
+      tListMsg = NULL;
+      sequenceId++;
+
+      int tx;
+      for (tx = 0; tx < ackMsg.tLAckCmd.numthreads; tx++) {
+        ReleaseThrMessage *tReleaseMsg = new ReleaseThrMessage();
+        ReleaseThrAckMessage tReleaseAckMsg;
+        bgcios::toolctl::BG_ThreadID_t threadId =
+            (bgcios::toolctl::BG_ThreadID_t)ackMsg.tLAckCmd.threadlist[tx].tid;
+
+        tReleaseMsg = create_ReleaseThrMessage(
+            cdtiVer, (uint32_t)(*i), sequenceId, jobId, toolId, threadId);
+
+        if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)tReleaseMsg,
+                           sizeof(*tReleaseMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error writing to a Unix domain socket");
+
+          goto return_loc;
+        }
+
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&tReleaseAckMsg,
+                          sizeof(tReleaseAckMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
+
+          goto return_loc;
+        }
+
+        if (verify_ReleaseThrAckMessage(tReleaseAckMsg, cdtiVer, (uint32_t)(*i),
+                                        sequenceId, jobId, toolId,
+                                        threadId) != LMON_OK) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "verify_ReleaseThrAckMessage reports a failure");
+
+          goto return_loc;
+        }
+
+        delete tReleaseMsg;
+        tReleaseMsg = NULL;
+        sequenceId++;
+      }  // for each thread
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "ControlAckMessage::controllingToolId(%d), "
-            "ControlAckMessage::toolTag(%c %c %c), "
-            "ControlAckMessage::priority(%d),",
-            ackMsg.controllingToolId,
-            ackMsg.toolTag[0],
-            ackMsg.toolTag[1],
-            ackMsg.toolTag[2],
-            ackMsg.priority );
-#endif 
-          delete cntlMsg;
-          cntlMsg = NULL;
-          sequenceId++;
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Released all threads in CN(%d) rank(%d)", cn->first, *i);
+#endif
+
+    }  // for each rank
+
+  }  // for each compute node
+
+  rc = LMON_OK;
+
+return_loc:
+  return rc;
+}
+
+static lmon_rc_e acquire_control_authority(uint8_t cdtiVer,
+                                           uint32_t &sequenceId, uint64_t jobId,
+                                           uint32_t toolId) {
+  lmon_rc_e rc = LMON_EINVAL;
+
+  std::map<int, std::vector<int> >::iterator cn;
+
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      bgcios::toolctl::ControlMessage *cntlMsg = NULL;
+      bgcios::toolctl::ControlAckMessage ackMsg;
+      bgcios::toolctl::NotifyMessage notifyMsg;
+
+      sigset_t interestSig;
+      sigemptyset(&interestSig);
+      sigaddset(&interestSig, SIGSTOP);
+
+      cntlMsg = create_ControlMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                      jobId, toolId, &interestSig, 0,
+                                      bgcios::toolctl::DynamicNotifyDLoader,
+                                      bgcios::toolctl::DACTrap_NoChange);
+
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)cntlMsg,
+                         sizeof(*cntlMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent ControlMessage to CN(%d) rank(%d)", cn->first, *i);
+#endif
+
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv ControlAckMessage for CN(%d) rank(%d)", cn->first, *i);
+#endif
+
+      //
+      // TODO:
+      // Control Authority Arbitration is Needed here
+      //
+      //
+
+      if (verify_MessageHeader(ackMsg.header, cdtiVer,
+                               bgcios::toolctl::ControlAck, *i,
+                               sequenceId) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "An error was returned in ControlAckMessage");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "ControlAckMessage::controllingToolId(%d), "
+                   "ControlAckMessage::toolTag(%c %c %c), "
+                   "ControlAckMessage::priority(%d),",
+                   ackMsg.controllingToolId, ackMsg.toolTag[0],
+                   ackMsg.toolTag[1], ackMsg.toolTag[2], ackMsg.priority);
+#endif
+      delete cntlMsg;
+      cntlMsg = NULL;
+      sequenceId++;
     }
   }
 
   //
   // This can be racy! But this should only affect testers
   //   And other realworld tool client will have a logic
-  //   to handle overlapping message between Ack and Notify   
-  // 
-  if ( release_all_threads ( _cdtiVer, _seqNum, _jobid, _toolid ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "release_all_threads returned an error code.");
+  //   to handle overlapping message between Ack and Notify
+  //
+  if (release_all_threads(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "release_all_threads returned an error code.");
 
-      return LMON_EINVAL;
-    }
-
-  rc = LMON_OK;
-
-return_loc:
-  return rc;
-}
-
-
-static lmon_rc_e
-reap_stop_noti ( uint8_t cdtiVer, uint32_t &sequenceId,
-                        uint64_t jobId, uint32_t toolId )
-{
-  lmon_rc_e rc = LMON_EINVAL;
-
-  std::map<int, std::vector<int> >::iterator cn;
-
-  for ( cn = IOToolMap.CN2Ranks.begin ();
-                    cn != IOToolMap.CN2Ranks.end (); ++cn )
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin ();
-                      i != cn->second.end (); ++i)
-        {
-          bgcios::toolctl::NotifyMessage notifyMsg;
-
-	  if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first], (void *) &notifyMsg,
-	  	           sizeof(notifyMsg)) == -1 )
-	      {
-	        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-	          "Error reading from a Unix domain socket");
-
-	        goto return_loc;
-	      }
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                "Recv NotifyMessage from CN(%d) rank(%d) for stop signal",
-                cn->first, *i );
-#endif
-
-	  if ( notifyMsg.header.returnCode != bgcios::Success )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		 "An error was returned in AttachMessageAck (%d)",
-		 notifyMsg.header.returnCode);
-
-	      goto return_loc;
-	    }
-
-	  if ( notifyMsg.notifyMessageType 
-               != bgcios::toolctl::NotifyMessageType_Signal )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		 "NotifyMessageType_Signal wasn't delivered (%d)",
-		 notifyMsg.notifyMessageType);
-
-	      goto return_loc;
-	    }
-
-	  if ( notifyMsg.type.signal.signum != SIGSTOP )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		 "Notified signal isn't SIGSTOP!");
-
-	      goto return_loc;
-	    }
-
-	  sequenceId++;
-        }
-    }
-
-  rc = LMON_OK;
-
-return_loc:
-  return rc;
-
-}
-
-
-static lmon_rc_e
-stop_all_wo_noti_reap ( uint8_t cdtiVer, uint32_t &sequenceId,
-                        uint64_t jobId, uint32_t toolId )
-{
-  lmon_rc_e rc = LMON_EINVAL;
-
-  std::map<int, std::vector<int> >::iterator cn;
-
-  for ( cn = IOToolMap.CN2Ranks.begin ();
-                    cn != IOToolMap.CN2Ranks.end (); ++cn )
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin ();
-                      i != cn->second.end (); ++i)
-        {
-          SendSignalMessage *stopMsg = NULL;
-          SendSignalAckMessage ackMsg;
-
-          stopMsg = create_SendSignalMessage ( cdtiVer,
-                      (uint32_t)(*i),
-                      sequenceId,
-                      jobId,
-                      toolId,
-                      SIGSTOP );
-
-          if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) stopMsg,
-                               sizeof (*stopMsg) ) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
-
-              goto return_loc;
-            }
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent UpdateMessage to CN(%d) rank(%d) for stop signal",
-            cn->first, *i );
-#endif
-
-          if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-                               sizeof (ackMsg) ) == -1 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error reading from a Unix domain socket" );
-
-              goto return_loc;
-            }
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv UpdateAckMessage from CN(%d) rank(%d) for stop signal",
-            cn->first, *i );
-#endif
-
-          if ( verify_SendSignalAckMessage ( ackMsg,
-                                             cdtiVer,
-                                             (uint32_t)(*i),
-                                             sequenceId,
-                                             jobId,
-                                             toolId,
-                                             SIGSTOP) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_SendSignalAckMessage reports a failure");
-
-              goto return_loc;
-            }
-
-	  delete stopMsg;
-	  stopMsg = NULL;
-	  sequenceId++;
-      }
+    return LMON_EINVAL;
   }
 
   rc = LMON_OK;
@@ -1933,126 +1313,58 @@ return_loc:
   return rc;
 }
 
-
-static lmon_rc_e
-stop_all ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId )
-{
+static lmon_rc_e reap_stop_noti(uint8_t cdtiVer, uint32_t &sequenceId,
+                                uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator cn;
 
-  for ( cn = IOToolMap.CN2Ranks.begin ();
-                    cn != IOToolMap.CN2Ranks.end (); ++cn )
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin ();
-                      i != cn->second.end (); ++i)
-	{
-	  SendSignalMessage *stopMsg = NULL;
-	  SendSignalAckMessage ackMsg;
-	  bgcios::toolctl::NotifyMessage notifyMsg;
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      bgcios::toolctl::NotifyMessage notifyMsg;
 
-	  stopMsg = create_SendSignalMessage ( cdtiVer,
-		      (uint32_t)(*i),
-		      sequenceId,
-		      jobId,
-		      toolId,
-                      SIGSTOP );
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&notifyMsg,
+                        sizeof(notifyMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
 
-	  if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) stopMsg,
-			       sizeof (*stopMsg) ) == -1 )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
-
-	      goto return_loc;
-	    }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent UpdateMessage to CN(%d) rank(%d) for stop signal",
-            cn->first, *i );
-#endif
-	 
-	  if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-			       sizeof (ackMsg) ) == -1 )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		"Error reading from a Unix domain socket" );
-
-	      goto return_loc;
-	    }
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv UpdateAckMessage from CN(%d) rank(%d) for stop signal",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv NotifyMessage from CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
 #endif
 
-          if ( verify_SendSignalAckMessage ( ackMsg,
-					     cdtiVer,
-		                             (uint32_t)(*i),
-		                             sequenceId,
-		                             jobId,
-		                             toolId,
-                                             SIGSTOP) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_SendSignalAckMessage reports a failure");
+      if (notifyMsg.header.returnCode != bgcios::Success) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "An error was returned in AttachMessageAck (%d)",
+                     notifyMsg.header.returnCode);
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
-	  if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first], (void *) &notifyMsg,
-	  	           sizeof(notifyMsg)) == -1 )
-	      {
-	        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-	          "Error reading from a Unix domain socket");
+      if (notifyMsg.notifyMessageType !=
+          bgcios::toolctl::NotifyMessageType_Signal) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "NotifyMessageType_Signal wasn't delivered (%d)",
+                     notifyMsg.notifyMessageType);
 
-	        goto return_loc;
-	      }
+        goto return_loc;
+      }
 
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                "Recv NotifyMessage from CN(%d) rank(%d) for stop signal",
-                cn->first, *i );
-#endif
+      if (notifyMsg.type.signal.signum != SIGSTOP) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Notified signal isn't SIGSTOP!");
 
-	  if ( notifyMsg.header.returnCode != bgcios::Success )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		 "An error was returned in AttachMessageAck (%d)",
-		 notifyMsg.header.returnCode);
+        goto return_loc;
+      }
 
-	      goto return_loc;
-	    }
-
-	  if ( notifyMsg.notifyMessageType 
-               != bgcios::toolctl::NotifyMessageType_Signal )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "NotifyMessageType_Signal wasn't delivered (%d)",
-		notifyMsg.notifyMessageType);
-
-	      goto return_loc;
-	    }
-
-	  if ( notifyMsg.type.signal.signum != SIGSTOP )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		 "Notified signal isn't SIGSTOP!");
-
-	      goto return_loc;
-	    }
-
-	  delete stopMsg;
-	  stopMsg = NULL;
-	  sequenceId++;
-	}
+      sequenceId++;
     }
+  }
 
   rc = LMON_OK;
 
@@ -2060,234 +1372,287 @@ return_loc:
   return rc;
 }
 
+static lmon_rc_e stop_all_wo_noti_reap(uint8_t cdtiVer, uint32_t &sequenceId,
+                                       uint64_t jobId, uint32_t toolId) {
+  lmon_rc_e rc = LMON_EINVAL;
 
-static lmon_rc_e
-fetch_mem_all ( uint8_t cdtiVer, uint32_t &sequenceId,
-                uint64_t jobId, uint32_t toolId, 
-                long unsigned int membase,
-                unsigned int numbytes,
-                unsigned int *fetchunit,
-                unsigned int *usecperunit )
-{
+  std::map<int, std::vector<int> >::iterator cn;
+
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      SendSignalMessage *stopMsg = NULL;
+      SendSignalAckMessage ackMsg;
+
+      stopMsg = create_SendSignalMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                         jobId, toolId, SIGSTOP);
+
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)stopMsg,
+                         sizeof(*stopMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent UpdateMessage to CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
+#endif
+
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv UpdateAckMessage from CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
+#endif
+
+      if (verify_SendSignalAckMessage(ackMsg, cdtiVer, (uint32_t)(*i),
+                                      sequenceId, jobId, toolId,
+                                      SIGSTOP) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_SendSignalAckMessage reports a failure");
+
+        goto return_loc;
+      }
+
+      delete stopMsg;
+      stopMsg = NULL;
+      sequenceId++;
+    }
+  }
+
+  rc = LMON_OK;
+
+return_loc:
+  return rc;
+}
+
+static lmon_rc_e stop_all(uint8_t cdtiVer, uint32_t &sequenceId, uint64_t jobId,
+                          uint32_t toolId) {
+  lmon_rc_e rc = LMON_EINVAL;
+
+  std::map<int, std::vector<int> >::iterator cn;
+
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      SendSignalMessage *stopMsg = NULL;
+      SendSignalAckMessage ackMsg;
+      bgcios::toolctl::NotifyMessage notifyMsg;
+
+      stopMsg = create_SendSignalMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                         jobId, toolId, SIGSTOP);
+
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)stopMsg,
+                         sizeof(*stopMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent UpdateMessage to CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
+#endif
+
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv UpdateAckMessage from CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
+#endif
+
+      if (verify_SendSignalAckMessage(ackMsg, cdtiVer, (uint32_t)(*i),
+                                      sequenceId, jobId, toolId,
+                                      SIGSTOP) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_SendSignalAckMessage reports a failure");
+
+        goto return_loc;
+      }
+
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&notifyMsg,
+                        sizeof(notifyMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv NotifyMessage from CN(%d) rank(%d) for stop signal",
+                   cn->first, *i);
+#endif
+
+      if (notifyMsg.header.returnCode != bgcios::Success) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "An error was returned in AttachMessageAck (%d)",
+                     notifyMsg.header.returnCode);
+
+        goto return_loc;
+      }
+
+      if (notifyMsg.notifyMessageType !=
+          bgcios::toolctl::NotifyMessageType_Signal) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "NotifyMessageType_Signal wasn't delivered (%d)",
+                     notifyMsg.notifyMessageType);
+
+        goto return_loc;
+      }
+
+      if (notifyMsg.type.signal.signum != SIGSTOP) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Notified signal isn't SIGSTOP!");
+
+        goto return_loc;
+      }
+
+      delete stopMsg;
+      stopMsg = NULL;
+      sequenceId++;
+    }
+  }
+
+  rc = LMON_OK;
+
+return_loc:
+  return rc;
+}
+
+static lmon_rc_e fetch_mem_all(uint8_t cdtiVer, uint32_t &sequenceId,
+                               uint64_t jobId, uint32_t toolId,
+                               long unsigned int membase, unsigned int numbytes,
+                               unsigned int *fetchunit,
+                               unsigned int *usecperunit) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator cn;
   int totalIter = 0;
-  double start_ts, end_ts, accum=0.0;
+  double start_ts, end_ts, accum = 0.0;
   *fetchunit = 4096;
   char memAckBuffer[bgcios::toolctl::MaxMemorySize];
   char *mabPtr;
-  memset((void*)memAckBuffer, '\0', bgcios::toolctl::MaxMemorySize);
+  memset((void *)memAckBuffer, '\0', bgcios::toolctl::MaxMemorySize);
 
-  for (cn = IOToolMap.CN2Ranks.begin();
-            cn != IOToolMap.CN2Ranks.end(); ++cn)
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin(); i != cn->second.end(); ++i)
-        {
-          int nIter = numbytes/(*fetchunit);
-          int j;
-          bgcios::toolctl::BG_Addr_t trav 
-            = (bgcios::toolctl::BG_Addr_t) membase;
-          for (j=0; j < nIter; ++j)
-            {  
-              FetchMemoryMessage *fetchMemMsg = NULL; 
-              bgcios::toolctl::QueryAckMessage ackMsg;
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      int nIter = numbytes / (*fetchunit);
+      int j;
+      bgcios::toolctl::BG_Addr_t trav = (bgcios::toolctl::BG_Addr_t)membase;
+      for (j = 0; j < nIter; ++j) {
+        FetchMemoryMessage *fetchMemMsg = NULL;
+        bgcios::toolctl::QueryAckMessage ackMsg;
 
-              fetchMemMsg = create_FetchMemoryMessage ( cdtiVer,
-		      (uint32_t)(*i),
-		      sequenceId,
-		      jobId,
-		      toolId,
-                      trav,
-                      (*fetchunit));
+        fetchMemMsg =
+            create_FetchMemoryMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                      jobId, toolId, trav, (*fetchunit));
 
-              start_ts = gettimeofdayD();
-	      if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                    (void *) fetchMemMsg,
-		    	            sizeof(*fetchMemMsg)) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error writing to a Unix domain socket" );
+        start_ts = gettimeofdayD();
+        if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)fetchMemMsg,
+                           sizeof(*fetchMemMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error writing to a Unix domain socket");
 
-	          goto return_loc;
-	        }
-	      if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) &ackMsg,
-		    	           sizeof(ackMsg)) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		    "Error reading from a Unix domain socket" );
-
-	          goto return_loc;
-	        }
-              mabPtr = memAckBuffer;
-	      if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) memAckBuffer,
-		    	           ackMsg.cmdList[0].length) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		    "Error reading from a Unix domain socket" );
-
-	          goto return_loc;
-	        }
-
-              end_ts = gettimeofdayD();
-              accum += (end_ts - start_ts);
-              totalIter++;
-              trav += (*fetchunit); 
-
-              delete fetchMemMsg;
-              fetchMemMsg = NULL;
-              sequenceId++;
-            }
-         
-          if ((j * (*fetchunit)) < numbytes)
-            {
-              int len = numbytes - (j * (*fetchunit));
-              FetchMemoryMessage *fetchMemMsg = NULL; 
-              bgcios::toolctl::QueryAckMessage ackMsg;
-
-              fetchMemMsg = create_FetchMemoryMessage ( cdtiVer,
-		      (uint32_t)(*i),
-		      sequenceId,
-		      jobId,
-		      toolId,
-                      trav,
-                      (*fetchunit));
-              start_ts = gettimeofdayD ();
-	      if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                    (void *) fetchMemMsg,
-		    	            sizeof(*fetchMemMsg)) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                    "Error writing to a Unix domain socket" );
-
-	          goto return_loc;
-	        }
-	      if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) &ackMsg,
-		    	           sizeof(ackMsg)) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		    "Error reading from a Unix domain socket" );
-
-	          goto return_loc;
-	        }
-              mabPtr = memAckBuffer;
-	      if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                                   (void *) memAckBuffer,
-		    	           ackMsg.cmdList[0].length) == -1 )
-	        {
-	          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		    "Error reading from a Unix domain socket" );
-
-	          goto return_loc;
-	        }
-                end_ts = gettimeofdayD();
-                accum += (end_ts - start_ts);
-                totalIter++;
-
-                delete fetchMemMsg;
-                fetchMemMsg = NULL;
-                sequenceId++;
-            }
+          goto return_loc;
         }
-     } 
-  
-  (*usecperunit) = (unsigned int) (accum * 1000000.0) / totalIter;  
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                          sizeof(ackMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
 
-#if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                   "MEMFETCH PERF: %d usec to fetch %d %d bytes",
-                   (int) (accum * 1000000), totalIter, *fetchunit); 
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-                   "MEMFETCH PERF: %d usec per %d bytes",
-                   *usecperunit, *fetchunit); 
-#endif
+          goto return_loc;
+        }
+        mabPtr = memAckBuffer;
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)memAckBuffer,
+                          ackMsg.cmdList[0].length) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
 
-  rc = LMON_OK;
+          goto return_loc;
+        }
 
-return_loc:
-  return rc;  
-}
+        end_ts = gettimeofdayD();
+        accum += (end_ts - start_ts);
+        totalIter++;
+        trav += (*fetchunit);
 
+        delete fetchMemMsg;
+        fetchMemMsg = NULL;
+        sequenceId++;
+      }
 
-static lmon_rc_e
-continue_all ( uint8_t cdtiVer, uint32_t &sequenceId,
-                 int signum,
-                 uint64_t jobId, uint32_t toolId )
-{
-  lmon_rc_e rc = LMON_EINVAL;
+      if ((j * (*fetchunit)) < numbytes) {
+        int len = numbytes - (j * (*fetchunit));
+        FetchMemoryMessage *fetchMemMsg = NULL;
+        bgcios::toolctl::QueryAckMessage ackMsg;
 
-  std::map<int, std::vector<int> >::iterator cn;
+        fetchMemMsg =
+            create_FetchMemoryMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                      jobId, toolId, trav, (*fetchunit));
+        start_ts = gettimeofdayD();
+        if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)fetchMemMsg,
+                           sizeof(*fetchMemMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error writing to a Unix domain socket");
 
-  for (cn = IOToolMap.CN2Ranks.begin();
-            cn != IOToolMap.CN2Ranks.end(); ++cn)
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin(); i != cn->second.end(); ++i)
-	{
-	  ContProcMessage *contMsg = NULL;
-	  ContProcAckMessage ackMsg;
+          goto return_loc;
+        }
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                          sizeof(ackMsg)) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
 
-	  contMsg = create_ContinueMessage ( cdtiVer,
-		      (uint32_t)(*i),
-		      sequenceId,
-                      signum,
-		      jobId,
-		      toolId );
+          goto return_loc;
+        }
+        mabPtr = memAckBuffer;
+        if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)memAckBuffer,
+                          ackMsg.cmdList[0].length) == -1) {
+          LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                       "Error reading from a Unix domain socket");
 
-	  if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                (void *) contMsg,
-			        sizeof(*contMsg)) == -1 )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
+          goto return_loc;
+        }
+        end_ts = gettimeofdayD();
+        accum += (end_ts - start_ts);
+        totalIter++;
 
-	      goto return_loc;
-	    }
-	 
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent ContProcMessage to CN(%d) rank(%d) for continue",
-            cn->first, *i );
-#endif
-
-	  if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-			       sizeof(ackMsg)) == -1 )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-		"Error reading from a Unix domain socket" );
-
-	      goto return_loc;
-	    }
-
-#if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv ContProcAckMessage from CN(%d) rank(%d) for continue",
-            cn->first, *i );
-#endif
-
-          if ( verify_ContinueAckMessage ( ackMsg,
-                                           cdtiVer,
-		                           (uint32_t)(*i),
-                                           sequenceId,
-		                           jobId,
-		                           toolId) != LMON_OK )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_ContinueAckMessage reports a failure");
-
-              goto return_loc;
-            }
-
-	  delete contMsg;
-	  contMsg = NULL;
-	  sequenceId++;
-	}
+        delete fetchMemMsg;
+        fetchMemMsg = NULL;
+        sequenceId++;
+      }
     }
+  }
+
+  (*usecperunit) = (unsigned int)(accum * 1000000.0) / totalIter;
+
+#if VERBOSE
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "MEMFETCH PERF: %d usec to fetch %d %d bytes",
+               (int)(accum * 1000000), totalIter, *fetchunit);
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "MEMFETCH PERF: %d usec per %d bytes",
+               *usecperunit, *fetchunit);
+#endif
 
   rc = LMON_OK;
 
@@ -2295,83 +1660,62 @@ return_loc:
   return rc;
 }
 
-
-
-
-static lmon_rc_e
-release_control_all(uint8_t cdtiVer, uint32_t &sequenceId,
-                 uint64_t jobId, uint32_t toolId)
-{
+static lmon_rc_e continue_all(uint8_t cdtiVer, uint32_t &sequenceId, int signum,
+                              uint64_t jobId, uint32_t toolId) {
   lmon_rc_e rc = LMON_EINVAL;
 
   std::map<int, std::vector<int> >::iterator cn;
 
-  for (cn = IOToolMap.CN2Ranks.begin();
-                    cn != IOToolMap.CN2Ranks.end(); ++cn)
-    {
-      std::vector<int>::iterator i;
-      for (i = cn->second.begin();
-                    i != cn->second.end(); ++i)
-	{
-	  ReleaseMessage *releaseMsg = NULL;
-	  ReleaseAckMessage ackMsg;
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      ContProcMessage *contMsg = NULL;
+      ContProcAckMessage ackMsg;
 
-	  releaseMsg = create_ReleaseMessage ( cdtiVer,
-		         (uint32_t)(*i),
-		         sequenceId,
-		         jobId,
-		         toolId );
+      contMsg = create_ContinueMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                       signum, jobId, toolId);
 
-	  if ( lmon_write_raw ( IOToolMap.CN2Sock[cn->first],
-                                (void *) releaseMsg,
-			        sizeof(*releaseMsg)) == -1 )
-	    {
-	      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Error writing to a Unix domain socket" );
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)contMsg,
+                         sizeof(*contMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
 
-	      goto return_loc;
-	    }
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Sent ReleaseMessage to CN(%d) rank(%d) for releaseControl",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent ContProcMessage to CN(%d) rank(%d) for continue",
+                   cn->first, *i);
 #endif
- 
-	  if ( lmon_read_raw ( IOToolMap.CN2Sock[cn->first],
-                               (void *) &ackMsg,
-			       sizeof ( ackMsg ) ) == -1 )
-	    {
-	      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-		"Error reading from a Unix domain socket");
 
-	      goto return_loc;
-	    }
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
 
 #if VERBOSE
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "Recv ReleaseAckMessage from CN(%d) rank(%d) for releaseControl",
-            cn->first, *i );
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Recv ContProcAckMessage from CN(%d) rank(%d) for continue",
+                   cn->first, *i);
 #endif
 
-          if ( verify_ReleaseAckMessage ( ackMsg,
-                                          cdtiVer,
-		                          (uint32_t)(*i),
-		                          sequenceId,
-		                          jobId,
-		                          toolId ) != LMON_OK ) 
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "verify_ReleaseAckMessage reports a failure");
+      if (verify_ContinueAckMessage(ackMsg, cdtiVer, (uint32_t)(*i), sequenceId,
+                                    jobId, toolId) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_ContinueAckMessage reports a failure");
 
-              goto return_loc;
-            }
+        goto return_loc;
+      }
 
-	  delete releaseMsg;
-	  releaseMsg = NULL;
-	  sequenceId++;
-	}
+      delete contMsg;
+      contMsg = NULL;
+      sequenceId++;
     }
+  }
 
   rc = LMON_OK;
 
@@ -2379,6 +1723,69 @@ return_loc:
   return rc;
 }
 
+static lmon_rc_e release_control_all(uint8_t cdtiVer, uint32_t &sequenceId,
+                                     uint64_t jobId, uint32_t toolId) {
+  lmon_rc_e rc = LMON_EINVAL;
+
+  std::map<int, std::vector<int> >::iterator cn;
+
+  for (cn = IOToolMap.CN2Ranks.begin(); cn != IOToolMap.CN2Ranks.end(); ++cn) {
+    std::vector<int>::iterator i;
+    for (i = cn->second.begin(); i != cn->second.end(); ++i) {
+      ReleaseMessage *releaseMsg = NULL;
+      ReleaseAckMessage ackMsg;
+
+      releaseMsg = create_ReleaseMessage(cdtiVer, (uint32_t)(*i), sequenceId,
+                                         jobId, toolId);
+
+      if (lmon_write_raw(IOToolMap.CN2Sock[cn->first], (void *)releaseMsg,
+                         sizeof(*releaseMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error writing to a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "Sent ReleaseMessage to CN(%d) rank(%d) for releaseControl",
+                   cn->first, *i);
+#endif
+
+      if (lmon_read_raw(IOToolMap.CN2Sock[cn->first], (void *)&ackMsg,
+                        sizeof(ackMsg)) == -1) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Error reading from a Unix domain socket");
+
+        goto return_loc;
+      }
+
+#if VERBOSE
+      LMON_say_msg(
+          LMON_BE_MSG_PREFIX, false,
+          "Recv ReleaseAckMessage from CN(%d) rank(%d) for releaseControl",
+          cn->first, *i);
+#endif
+
+      if (verify_ReleaseAckMessage(ackMsg, cdtiVer, (uint32_t)(*i), sequenceId,
+                                   jobId, toolId) != LMON_OK) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "verify_ReleaseAckMessage reports a failure");
+
+        goto return_loc;
+      }
+
+      delete releaseMsg;
+      releaseMsg = NULL;
+      sequenceId++;
+    }
+  }
+
+  rc = LMON_OK;
+
+return_loc:
+  return rc;
+}
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -2386,11 +1793,8 @@ return_loc:
 //           PUBLIC INTERFACE
 //
 
-lmon_rc_e
-LMON_be_procctl_init_bgq ( MPIR_PROCDESC_EXT *ptab,
-			   int islaunch,
-                           int psize )
-{
+lmon_rc_e LMON_be_procctl_init_bgq(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                   int psize) {
   int i;
   char *jobidStr;
   char *toolidStr;
@@ -2401,326 +1805,253 @@ LMON_be_procctl_init_bgq ( MPIR_PROCDESC_EXT *ptab,
   //
   jobidStr = getenv("BG_JOBID");
   toolidStr = getenv("BG_TOOLID");
-  if ( !jobidStr || !toolidStr )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "empty BG_JOBID or BG_TOOLID.");
+  if (!jobidStr || !toolidStr) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "empty BG_JOBID or BG_TOOLID.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  _jobid = (uint64_t) strtoll ( jobidStr, NULL, 10 );
-  _toolid = (uint32_t) strtol ( toolidStr, NULL, 10 );
-  cdtiVerPath = std::string ("/jobs/" )
-    + std::string ( jobidStr )
-    + std::string ( "/tools/protocol" );
+  _jobid = (uint64_t)strtoll(jobidStr, NULL, 10);
+  _toolid = (uint32_t)strtol(toolidStr, NULL, 10);
+  cdtiVerPath = std::string("/jobs/") + std::string(jobidStr) +
+                std::string("/tools/protocol");
 
   std::ifstream infile;
-  infile.open (cdtiVerPath.c_str(), std::ifstream::in);
+  infile.open(cdtiVerPath.c_str(), std::ifstream::in);
   std::stringstream ssBuf;
-  ssBuf << infile.rdbuf ();
-  _cdtiVer = (int) strtol ( ssBuf.str().c_str(), NULL, 10 );
-  infile.close ();
+  ssBuf << infile.rdbuf();
+  _cdtiVer = (int)strtol(ssBuf.str().c_str(), NULL, 10);
+  infile.close();
 
   //
   // Fill in IOToolMap structure
   //
   std::map<int, std::vector<int> >::iterator iter;
-  for ( i=0; i < psize; i++ )
-    {
-      iter = IOToolMap.CN2Ranks.find(ptab[i].cnodeid);
-      if (iter != IOToolMap.CN2Ranks.end())
-	{
-	  iter->second.push_back ( ptab[i].pd.pid );
-	}
-      else
-	{
-	  std::vector<int> pidVector;
-	  pidVector.push_back ( ptab[i].pd.pid );
-	  IOToolMap.CN2Ranks[ptab[i].cnodeid] = pidVector;
-	}
+  for (i = 0; i < psize; i++) {
+    iter = IOToolMap.CN2Ranks.find(ptab[i].cnodeid);
+    if (iter != IOToolMap.CN2Ranks.end()) {
+      iter->second.push_back(ptab[i].pd.pid);
+    } else {
+      std::vector<int> pidVector;
+      pidVector.push_back(ptab[i].pd.pid);
+      IOToolMap.CN2Ranks[ptab[i].cnodeid] = pidVector;
     }
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "_cdtiVer(%d), _seqNum(%d), _jobid(%d), _toolid(%d) psize(%d) IOToolMap.CN2Ranks.size(%d)",
-    _cdtiVer, _seqNum, _jobid, _toolid, psize, IOToolMap.CN2Ranks.size());
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+               "_cdtiVer(%d), _seqNum(%d), _jobid(%d), _toolid(%d) psize(%d) "
+               "IOToolMap.CN2Ranks.size(%d)",
+               _cdtiVer, _seqNum, _jobid, _toolid, psize,
+               IOToolMap.CN2Ranks.size());
 #endif
 
   //
-  // Open domain socket 
+  // Open domain socket
   //
-  if ( open_domain_socket () != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "open_domain_socket returned an error code.");
+  if (open_domain_socket() != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "open_domain_socket returned an error code.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "done open_domain_socekt." );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "done open_domain_socekt.");
 #endif
 
   //
   // Attach all ranks
   //
-  if ( attach_all ( _cdtiVer, _seqNum,
-		    _jobid, _toolid ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "attach_all returned an error code.");
+  if (attach_all(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "attach_all returned an error code.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "done attach_all." );
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "done attach_all.");
 #endif
 
   //
   // Acquire control authority
   //
-  if ( acquire_control_authority ( _cdtiVer, _seqNum,
-				   _jobid, _toolid ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "attach_all returned an error code." );
+  if (acquire_control_authority(_cdtiVer, _seqNum, _jobid, _toolid) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "attach_all returned an error code.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false, "done acquire_control_athority.");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "done acquire_control_athority.");
 #endif
 
   //
   // Stop all processes only when the tracing mode is not "launch"
-  // In launch mode, attach will leave the processes into 
+  // In launch mode, attach will leave the processes into
   // a stop state.
   //
-  
-  if ( islaunch == 1 )
-    {
-      if ( stop_all_wo_noti_reap ( _cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "stop_all returned an error code.");
 
-          return LMON_EINVAL;
-        }
-    }
-  else
-    {
-      if ( stop_all ( _cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "stop_all returned an error code.");
+  if (islaunch == 1) {
+    if (stop_all_wo_noti_reap(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "stop_all returned an error code.");
 
-          return LMON_EINVAL;
-        }
+      return LMON_EINVAL;
     }
+  } else {
+    if (stop_all(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "stop_all returned an error code.");
+
+      return LMON_EINVAL;
+    }
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "BGQ proc control init done.");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BGQ proc control init done.");
 #endif
 
   return LMON_OK;
 }
 
+lmon_rc_e LMON_be_procctl_stop_bgq(MPIR_PROCDESC_EXT *ptab, int psize) {
+  if (stop_all(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "stop_all returned an error code.");
 
-lmon_rc_e
-LMON_be_procctl_stop_bgq ( MPIR_PROCDESC_EXT *ptab,
-                           int psize)
-{
-  if ( stop_all ( _cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "stop_all returned an error code.");
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
+lmon_rc_e LMON_be_procctl_run_bgq(int signum, MPIR_PROCDESC_EXT *ptab,
+                                  int psize) {
+  if (continue_all(_cdtiVer, _seqNum, signum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "continue_all returned an error code.");
 
-lmon_rc_e
-LMON_be_procctl_run_bgq ( int signum,
-                          MPIR_PROCDESC_EXT *ptab,
-                          int psize)
-{
-  if ( continue_all ( _cdtiVer, _seqNum, signum, _jobid, _toolid) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "continue_all returned an error code.");
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "BGQ proc control run done ");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BGQ proc control run done ");
 #endif
 
   return LMON_OK;
 }
 
+lmon_rc_e LMON_be_procctl_perf_bgq(MPIR_PROCDESC_EXT *ptab, int psize,
+                                   long unsigned int membase,
+                                   unsigned int numbytes,
+                                   unsigned int *fetchunit,
+                                   unsigned int *usecperunit) {
+  if (fetch_mem_all(_cdtiVer, _seqNum, _jobid, _toolid, membase, numbytes,
+                    fetchunit, usecperunit) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "fetch_mem_all returned an error code.");
 
-lmon_rc_e
-LMON_be_procctl_perf_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
-  if ( fetch_mem_all ( _cdtiVer, _seqNum, _jobid, _toolid,
-                       membase, numbytes, fetchunit, usecperunit) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "fetch_mem_all returned an error code.");
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
+lmon_rc_e LMON_be_procctl_initdone_bgq(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                       int psize) {
+  if ((islaunch == 1) &&
+      reap_stop_noti(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "stop_all returned an error code.");
 
-lmon_rc_e
-LMON_be_procctl_initdone_bgq ( MPIR_PROCDESC_EXT *ptab,
-                               int islaunch,
-                               int psize )
-{
-  
-  if ( (islaunch == 1)
-       && reap_stop_noti ( _cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "stop_all returned an error code.");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if (hold_all_threads(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "hold_all_threads returned an error code.");
 
+    return LMON_EINVAL;
+  }
 
-  if ( hold_all_threads ( _cdtiVer, _seqNum, _jobid, _toolid ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "hold_all_threads returned an error code.");
+  if (release_control_all(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "release_control_all returned an error code.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( release_control_all ( _cdtiVer, _seqNum, _jobid, _toolid ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "release_control_all returned an error code.");
+  if (detach_all(_cdtiVer, _seqNum, _jobid, _toolid) != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "detach_all returned an error code.");
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  if (cleanup_resources() != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "cleanup_resources returned an error code.");
 
-  if ( detach_all ( _cdtiVer, _seqNum, _jobid, _toolid ) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "detach_all returned an error code.");
-      return LMON_EINVAL;
-    }
-
-  if ( cleanup_resources ( ) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "cleanup_resources returned an error code.");
-
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "BGQ proc control initdone ");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BGQ proc control initdone ");
 #endif
   return LMON_OK;
-
 }
 
-lmon_rc_e
-LMON_be_procctl_done_bgq ( MPIR_PROCDESC_EXT *ptab,
-                          int psize)
-{
-  if ( cleanup_resources ( ) != LMON_OK)
-    {
-      LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-        "cleanup_resources returned an error code.");
+lmon_rc_e LMON_be_procctl_done_bgq(MPIR_PROCDESC_EXT *ptab, int psize) {
+  if (cleanup_resources() != LMON_OK) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "cleanup_resources returned an error code.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-    "BGQ proc control done ");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "BGQ proc control done ");
 #endif
 
   return LMON_OK;
 }
 
+#else  // if SUB_ARCH_BGQ
 
-#else // if SUB_ARCH_BGQ
-
-lmon_rc_e
-LMON_be_procctl_init_bgq ( MPIR_PROCDESC_EXT *ptab,
-                           int islaunch,
-                           int psize)
-{
-   return LMON_EINVAL;
-}
-
-
-lmon_rc_e
-LMON_be_procctl_stop_bgq ( MPIR_PROCDESC_EXT *ptab,
-                           int psize)
-{
+lmon_rc_e LMON_be_procctl_init_bgq(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                   int psize) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_run_bgq ( int signum,
-                          MPIR_PROCDESC_EXT *ptab,
-                          int psize)
-{
+lmon_rc_e LMON_be_procctl_stop_bgq(MPIR_PROCDESC_EXT *ptab, int psize) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_perf_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
+lmon_rc_e LMON_be_procctl_run_bgq(int signum, MPIR_PROCDESC_EXT *ptab,
+                                  int psize) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_initdone_bgq ( MPIR_PROCDESC_EXT *ptab,
-                               int islaunch,
-                               int psize)
-{
+lmon_rc_e LMON_be_procctl_perf_bgq(MPIR_PROCDESC_EXT *ptab, int psize,
+                                   long unsigned int membase,
+                                   unsigned int numbytes,
+                                   unsigned int *fetchunit,
+                                   unsigned int *usecperunit) {
   return LMON_EINVAL;
 }
 
-lmon_rc_e
-LMON_be_procctl_done_bgq(MPIR_PROCDESC_EXT *ptab,
-                         int psize)
-{
+lmon_rc_e LMON_be_procctl_initdone_bgq(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                       int psize) {
+  return LMON_EINVAL;
+}
+
+lmon_rc_e LMON_be_procctl_done_bgq(MPIR_PROCDESC_EXT *ptab, int psize) {
   return LMON_EINVAL;
 }
 
 #endif
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bgq.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_bgq.hxx
@@ -1,29 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_be.cxx,v 1.12.2.5 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2011, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *              Oct 31 2011 DHA: File created
@@ -36,35 +37,27 @@
 #include "lmon_api/lmon_api_std.h"
 #include "lmon_api/lmon_proctab.h"
 
-extern lmon_rc_e LMON_be_procctl_init_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_init_bgq(MPIR_PROCDESC_EXT *ptab, int islaunch,
+                                          int psize);
 
-extern lmon_rc_e LMON_be_procctl_stop_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_stop_bgq(MPIR_PROCDESC_EXT *ptab, int psize);
 
-extern lmon_rc_e LMON_be_procctl_run_bgq (
-                   int signum,
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_run_bgq(int signum, MPIR_PROCDESC_EXT *ptab,
+                                         int psize);
 
-extern lmon_rc_e LMON_be_procctl_perf_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit);
+extern lmon_rc_e LMON_be_procctl_perf_bgq(MPIR_PROCDESC_EXT *ptab, int psize,
+                                          long unsigned int membase,
+                                          unsigned int numbytes,
+                                          unsigned int *fetchunit,
+                                          unsigned int *usecperunit);
 
-extern lmon_rc_e LMON_be_procctl_initdone_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int islaunch,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_initdone_bgq(MPIR_PROCDESC_EXT *ptab,
+                                              int islaunch, int psize);
 
-extern lmon_rc_e LMON_be_procctl_done_bgq (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize );
+extern lmon_rc_e LMON_be_procctl_done_bgq(MPIR_PROCDESC_EXT *ptab, int psize);
 
-#endif // LMON_BE_SYNC_MPI_BGQ_HXX
+#endif  // LMON_BE_SYNC_MPI_BGQ_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.cxx
@@ -1,34 +1,35 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_be.cxx,v 1.12.2.5 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 - 2012, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
  *  Update Log:
- *              Dec 12 2012 DHA: Add ptrace attach to implement a guaranteed 
+ *              Dec 12 2012 DHA: Add ptrace attach to implement a guaranteed
  *                               initial stop (i.e., subsequent SIGCONT
- *                               sent by an RM controller will not continue) 
+ *                               sent by an RM controller will not continue)
  *              Nov 23 2011 DHA: Added CDTI tool control messaging
  *              Oct 31 2011 DHA: File created
  *
@@ -44,18 +45,16 @@
 #error This source file requires a LINUX-like OS
 #endif
 
-#include <sys/types.h>
-#include <sys/ptrace.h>
-#include <sys/wait.h>
 #include <signal.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
-#include "lmon_daemon_internal.hxx"
 #include "../../sdbg_rm_map.hxx"
 #include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
 #include "lmon_be_sync_mpi_generic.hxx"
-
-
+#include "lmon_daemon_internal.hxx"
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -63,129 +62,99 @@
 //           PUBLIC INTERFACE
 //
 
-lmon_rc_e
-LMON_be_procctl_init_generic ( MPIR_PROCDESC_EXT* ptab,
-                               int islaunch,
-                               int psize )
-{
-  return LMON_be_procctl_stop_generic(ptab, psize); 
+lmon_rc_e LMON_be_procctl_init_generic(MPIR_PROCDESC_EXT* ptab, int islaunch,
+                                       int psize) {
+  return LMON_be_procctl_stop_generic(ptab, psize);
 }
 
-
-lmon_rc_e
-LMON_be_procctl_init_ptrace ( MPIR_PROCDESC_EXT* ptab,
-                               int islaunch,
-                               int psize )
-{
+lmon_rc_e LMON_be_procctl_init_ptrace(MPIR_PROCDESC_EXT* ptab, int islaunch,
+                                      int psize) {
   lmon_rc_e err_occurred = LMON_OK;
   int i, status;
 
-  for ( i = 0; i < psize; ++i )
-    {
-      int local_cond = LMON_OK;
-      if ( ptrace (PTRACE_ATTACH, ptab[i].pd.pid, NULL, NULL) != 0 )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "PTRACE_ATTACH for %d returned an error (%s).",
-              ptab[i].pd.pid, strerror(errno) );
-          errno = 0;
-          err_occurred = LMON_EINVAL;
-          local_cond = err_occurred;
-        }
-
-      while ( (local_cond != LMON_EINVAL) 
-              && (waitpid (ptab[i].pd.pid, &status, 0) 
-                  != ptab[i].pd.pid ))
-        {
-          if (errno == EINTR)
-            {
-              errno = 0;
-              continue;
-            }
-
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "waitpid returned an error for %d (%s).",
-            ptab[i].pd.pid, strerror(errno) );
-
-          errno = 0;
-          err_occurred = LMON_EINVAL;
-        }
+  for (i = 0; i < psize; ++i) {
+    int local_cond = LMON_OK;
+    if (ptrace(PTRACE_ATTACH, ptab[i].pd.pid, NULL, NULL) != 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "PTRACE_ATTACH for %d returned an error (%s).",
+                   ptab[i].pd.pid, strerror(errno));
+      errno = 0;
+      err_occurred = LMON_EINVAL;
+      local_cond = err_occurred;
     }
+
+    while ((local_cond != LMON_EINVAL) &&
+           (waitpid(ptab[i].pd.pid, &status, 0) != ptab[i].pd.pid)) {
+      if (errno == EINTR) {
+        errno = 0;
+        continue;
+      }
+
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "waitpid returned an error for %d (%s).", ptab[i].pd.pid,
+                   strerror(errno));
+
+      errno = 0;
+      err_occurred = LMON_EINVAL;
+    }
+  }
 
   return err_occurred;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_stop_generic ( MPIR_PROCDESC_EXT* ptab,
-                               int psize )
-{
+lmon_rc_e LMON_be_procctl_stop_generic(MPIR_PROCDESC_EXT* ptab, int psize) {
   lmon_rc_e rc = LMON_OK;
   int i;
 
-  for ( i = 0; i < psize; ++i )
-    {
-      if ( kill (ptab[i].pd.pid, SIGSTOP ) != 0 )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Sending SIGSTOP to %d returned an error (%s).",
-              ptab[i].pd.pid, strerror(errno) );
+  for (i = 0; i < psize; ++i) {
+    if (kill(ptab[i].pd.pid, SIGSTOP) != 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Sending SIGSTOP to %d returned an error (%s).",
+                   ptab[i].pd.pid, strerror(errno));
 
-          errno = 0;
-          rc = LMON_EINVAL;
-        }
+      errno = 0;
+      rc = LMON_EINVAL;
     }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_run_generic ( int signum, 
-                             MPIR_PROCDESC_EXT* ptab,
-                             int psize )
-{
+lmon_rc_e LMON_be_procctl_run_generic(int signum, MPIR_PROCDESC_EXT* ptab,
+                                      int psize) {
   lmon_rc_e rc = LMON_OK;
   int i;
-  
-  if (signum != SIGCONT)
-    {
-      for ( i = 0; i < psize; ++i )
-        {
-          if ( kill ( ptab[i].pd.pid, SIGCONT) != 0 )
-            {
-              LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-                "Sending a signal (%d) to %d returned an error (%s).", 
-              signum, ptab[i].pd.pid,
-              strerror(errno) );
 
-              errno = 0;
-              rc = LMON_EINVAL;
-            }
-        }
+  if (signum != SIGCONT) {
+    for (i = 0; i < psize; ++i) {
+      if (kill(ptab[i].pd.pid, SIGCONT) != 0) {
+        LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                     "Sending a signal (%d) to %d returned an error (%s).",
+                     signum, ptab[i].pd.pid, strerror(errno));
+
+        errno = 0;
+        rc = LMON_EINVAL;
+      }
     }
+  }
 
-  for ( i = 0; i < psize; ++i )
-    {
-      if ( kill ( ptab[i].pd.pid, signum) != 0 )
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "Sending a signal (%d) to %d returned an error (%s).", 
-            signum, ptab[i].pd.pid,
-            strerror(errno) );
+  for (i = 0; i < psize; ++i) {
+    if (kill(ptab[i].pd.pid, signum) != 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "Sending a signal (%d) to %d returned an error (%s).",
+                   signum, ptab[i].pd.pid, strerror(errno));
 
-            errno = 0;
-            rc = LMON_EINVAL;
-        }
+      errno = 0;
+      rc = LMON_EINVAL;
     }
+  }
 
   return rc;
 }
-
 
 #if 0
 lmon_rc_e
-LMON_be_procctl_run_ptrace ( int signum, 
+LMON_be_procctl_run_ptrace ( int signum,
                              MPIR_PROCDESC_EXT* ptab,
                              int psize )
 {
@@ -194,12 +163,12 @@ LMON_be_procctl_run_ptrace ( int signum,
 
   for ( i = 0; i < psize; ++i )
     {
-      if ( ptrace (PTRACE_CONT, ptab[i].pd.pid, 
-                   (signum==SIGCONT)?0:signum, NULL) 
+      if ( ptrace (PTRACE_CONT, ptab[i].pd.pid,
+                   (signum==SIGCONT)?0:signum, NULL)
            == -1 )
         {
           LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "PTRACE_CONT (%d) to %d returned an error (%s).", 
+            "PTRACE_CONT (%d) to %d returned an error (%s).",
             signum, ptab[i].pd.pid,
             strerror(errno) );
 
@@ -212,32 +181,19 @@ LMON_be_procctl_run_ptrace ( int signum,
 }
 #endif
 
-
-lmon_rc_e
-LMON_be_procctl_perf_generic ( 
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit)
-{
+lmon_rc_e LMON_be_procctl_perf_generic(MPIR_PROCDESC_EXT* ptab, int psize,
+                                       long unsigned int membase,
+                                       unsigned int numbytes,
+                                       unsigned int* fetchunit,
+                                       unsigned int* usecperunit) {
   return LMON_EINVAL;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_initdone_generic ( MPIR_PROCDESC_EXT* ptab,
-                                   int psize)
-{
+lmon_rc_e LMON_be_procctl_initdone_generic(MPIR_PROCDESC_EXT* ptab, int psize) {
   return LMON_OK;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_initdone_ptrace ( MPIR_PROCDESC_EXT* ptab,
-                                  int psize)
-{
+lmon_rc_e LMON_be_procctl_initdone_ptrace(MPIR_PROCDESC_EXT* ptab, int psize) {
   lmon_rc_e rc = LMON_OK;
   int i;
   int status;
@@ -250,51 +206,44 @@ LMON_be_procctl_initdone_ptrace ( MPIR_PROCDESC_EXT* ptab,
   // This can happen on a system because of a brittle code
   // desribed in Issue #16.
   //
-  for ( i = 0; i < psize; ++i )
-    {
-      while ( waitpid(ptab[i].pd.pid, &status, 0) != ptab[i].pd.pid)
-        {
+  for (i = 0; i < psize; ++i) {
+    while (waitpid(ptab[i].pd.pid, &status, 0) != ptab[i].pd.pid) {
+      if (errno == EINTR) continue;
 
-          if (errno == EINTR)
-            continue;
-
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, false,
-            "waitpid returned an error for %d (%s).",
-            ptab[i].pd.pid,
-            strerror(errno) );
-          errno = 0;
-          rc = LMON_EINVAL;
-        }
+      LMON_say_msg(LMON_BE_MSG_PREFIX, false,
+                   "waitpid returned an error for %d (%s).", ptab[i].pd.pid,
+                   strerror(errno));
+      errno = 0;
+      rc = LMON_EINVAL;
     }
+  }
 
 #endif
 
   //
-  // Send a SIGSTOP for the target processes so that you 
+  // Send a SIGSTOP for the target processes so that you
   // can leave them stopped.
   //
-  LMON_be_procctl_stop_generic ( ptab, psize );
+  LMON_be_procctl_stop_generic(ptab, psize);
 
-  for ( i = 0; i < psize; ++i )
-    {   
-      if ( ptrace (PTRACE_DETACH, ptab[i].pd.pid, 0, 0) != 0 ) 
-        {
-          LMON_say_msg ( LMON_BE_MSG_PREFIX, true,
-            "PTRACE_DETACH for %d returned an error (%s).",
-              ptab[i].pd.pid, strerror(errno) );
+  for (i = 0; i < psize; ++i) {
+    if (ptrace(PTRACE_DETACH, ptab[i].pd.pid, 0, 0) != 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                   "PTRACE_DETACH for %d returned an error (%s).",
+                   ptab[i].pd.pid, strerror(errno));
 
-          errno = 0;
-          rc = LMON_EINVAL;
-        }
-    } 
+      errno = 0;
+      rc = LMON_EINVAL;
+    }
+  }
 
   return rc;
 }
 
-
-lmon_rc_e
-LMON_be_procctl_done_generic ( MPIR_PROCDESC_EXT* ptab,
-                               int psize)
-{
+lmon_rc_e LMON_be_procctl_done_generic(MPIR_PROCDESC_EXT* ptab, int psize) {
   return LMON_OK;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_be_sync_mpi_generic.hxx
@@ -1,27 +1,28 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_be.cxx,v 1.12.2.5 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 - 2012, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -36,43 +37,34 @@
 #include "lmon_api/lmon_api_std.h"
 #include "lmon_api/lmon_proctab.h"
 
-extern lmon_rc_e LMON_be_procctl_init_generic (
-                   MPIR_PROCDESC_EXT* ptab,
-                   int islaunch,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_init_generic(MPIR_PROCDESC_EXT* ptab,
+                                              int islaunch, int psize);
 
-extern lmon_rc_e LMON_be_procctl_init_ptrace (
-                   MPIR_PROCDESC_EXT* ptab,
-                   int islaunch,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_init_ptrace(MPIR_PROCDESC_EXT* ptab,
+                                             int islaunch, int psize);
 
-extern lmon_rc_e LMON_be_procctl_stop_generic (
-                   MPIR_PROCDESC_EXT* ptab,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_stop_generic(MPIR_PROCDESC_EXT* ptab,
+                                              int psize);
 
-extern lmon_rc_e LMON_be_procctl_run_generic (
-                   int signum,
-                   MPIR_PROCDESC_EXT* ptab,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_run_generic(int signum,
+                                             MPIR_PROCDESC_EXT* ptab,
+                                             int psize);
 
-extern lmon_rc_e LMON_be_procctl_perf_generic (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize,
-                   long unsigned int membase,
-                   unsigned int numbytes,
-                   unsigned int *fetchunit,
-                   unsigned int *usecperunit);
+extern lmon_rc_e LMON_be_procctl_perf_generic(
+    MPIR_PROCDESC_EXT* ptab, int psize, long unsigned int membase,
+    unsigned int numbytes, unsigned int* fetchunit, unsigned int* usecperunit);
 
-extern lmon_rc_e LMON_be_procctl_initdone_generic (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_initdone_generic(MPIR_PROCDESC_EXT* ptab,
+                                                  int psize);
 
-extern lmon_rc_e LMON_be_procctl_initdone_ptrace (
-                   MPIR_PROCDESC_EXT *ptab,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_initdone_ptrace(MPIR_PROCDESC_EXT* ptab,
+                                                 int psize);
 
-extern lmon_rc_e LMON_be_procctl_done_generic(
-                   MPIR_PROCDESC_EXT* ptab,
-                   int psize);
+extern lmon_rc_e LMON_be_procctl_done_generic(MPIR_PROCDESC_EXT* ptab,
+                                              int psize);
 
-#endif // LMON_BE_SYNC_MPI_GENERIC_HXX
+#endif  // LMON_BE_SYNC_MPI_GENERIC_HXX
+
+/*
+ * ts=2 sw=2 expandtab *
+ */

--- a/launchmon/src/linux/lmon_api/lmon_coloc_spawner.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_coloc_spawner.cxx
@@ -1,33 +1,34 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
- *
  *  Update Log:
- *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support branch.
+ *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support
+ *                         branch.
  *        Jul 07 2010 DHA: Created file.
  */
 
@@ -37,199 +38,164 @@
 #error This source file requires a LINUX OS
 #endif
 
+#include <string.h>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
-#include <string.h>
 #include <vector>
+#include "lmon_api/lmon_api_std.h"
 #include "lmon_api/lmon_be.h"
+#include "lmon_api/lmon_coloc_spawner.hxx"
 #include "lmon_api/lmon_lmonp_msg.h"
 #include "lmon_api/lmon_say_msg.hxx"
-#include "lmon_api/lmon_api_std.h"
-#include "lmon_api/lmon_coloc_spawner.hxx"
-
 
 ////////////////////////////////////////////////////////////
 //
 //  Public Interface
 //
-bool
-spawner_coloc_t::spawn()
-{
+bool spawner_coloc_t::spawn() {
   bool rc;
 
-  if (m_is_fe)
-    {
-      rc = do_frontend();
+  if (m_is_fe) {
+    rc = do_frontend();
+  } else {
+    if (m_is_master) {
+      rc = do_bemaster();
+    } else {
+      rc = do_beslave();
     }
-  else
-    {
-      if (m_is_master)
-        {
-          rc = do_bemaster();
-        }
-      else
-        {
-          rc = do_beslave();
-        }
-    }
+  }
 
   return rc;
 }
-
 
 ////////////////////////////////////////////////////////////
 //
 //  Private Methods
 //
-bool
-spawner_coloc_t::do_frontend()
-{
-  if (!m_is_fe || m_be_master_sockfd < 0)
-    {
-      set_err_str(std::string("do_frontend invoked by non-front-end"));
-      return false;
-    }
+bool spawner_coloc_t::do_frontend() {
+  if (!m_is_fe || m_be_master_sockfd < 0) {
+    set_err_str(std::string("do_frontend invoked by non-front-end"));
+    return false;
+  }
 
   lmonp_t *msg = NULL;
 
   int plsize = get_daemon_path().size() + 1;
   std::vector<std::string>::const_iterator iter;
-  for(iter = get_daemon_args().begin(); iter != get_daemon_args().end(); ++iter)
-    {
-      plsize += (*iter).size() + 1;
-    }
+  for (iter = get_daemon_args().begin(); iter != get_daemon_args().end();
+       ++iter) {
+    plsize += (*iter).size() + 1;
+  }
   plsize += 1; /* ending null */
   int msgsize = sizeof(*msg) + plsize;
-  if ( !(msg = (lmonp_t *) malloc(msgsize)) )
-    {
-      set_err_str(std::string("malloc returned null"));
-      return false;
-    }
+  if (!(msg = (lmonp_t *)malloc(msgsize))) {
+    set_err_str(std::string("malloc returned null"));
+    return false;
+  }
 
-  set_msg_header(msg,
-                 lmonp_fetobe,
-                 lmonp_febe_assist_mw_coloc,
-                 0, 0, 0, 0, 0, plsize, 0);
+  set_msg_header(msg, lmonp_fetobe, lmonp_febe_assist_mw_coloc, 0, 0, 0, 0, 0,
+                 plsize, 0);
 
   char *lmonpl = get_lmonpayload_begin(msg);
-  memcpy( (void *) lmonpl,
-         get_daemon_path().c_str(),
+  memcpy((void *)lmonpl, get_daemon_path().c_str(),
          get_daemon_path().size() + 1);
   lmonpl += get_daemon_path().size() + 1;
-  for(iter = get_daemon_args().begin(); iter != get_daemon_args().end(); ++iter)
-    {
-      memcpy(lmonpl, (*iter).c_str(), (*iter).size() + 1);
-      lmonpl += (*iter).size() + 1;
-    }
+  for (iter = get_daemon_args().begin(); iter != get_daemon_args().end();
+       ++iter) {
+    memcpy(lmonpl, (*iter).c_str(), (*iter).size() + 1);
+    lmonpl += (*iter).size() + 1;
+  }
   *lmonpl = '\0'; /* ending null */
 
-  if (write_lmonp_long_msg(m_be_master_sockfd, msg, msgsize) < 0)
-    {
-      set_err_str(std::string("write_lmonp_long_msg failed"));
-      return false;
-    }
+  if (write_lmonp_long_msg(m_be_master_sockfd, msg, msgsize) < 0) {
+    set_err_str(std::string("write_lmonp_long_msg failed"));
+    return false;
+  }
 
   free(msg);
 
   return true;
 }
 
-static inline char *
-get_next_cstr(char *s)
-{
-  if (!s || *s == '\0')
-    return NULL;
+static inline char *get_next_cstr(char *s) {
+  if (!s || *s == '\0') return NULL;
 
-  while (*s != '\0')
-    {
-      s++;
-    }
+  while (*s != '\0') {
+    s++;
+  }
 
-  return (s+1);
+  return (s + 1);
 }
 
-bool
-spawner_coloc_t::parse_mw_assist_lmonpl(char *pl)
-{
-  if (!pl)
-    return false;
+bool spawner_coloc_t::parse_mw_assist_lmonpl(char *pl) {
+  if (!pl) return false;
 
   char *trav = pl;
   set_daemon_path(std::string(trav));
 
-  while ((trav = get_next_cstr(trav)))
-    {
-      get_daemon_args().push_back(std::string(trav));
-    }
+  while ((trav = get_next_cstr(trav))) {
+    get_daemon_args().push_back(std::string(trav));
+  }
 
   return true;
 }
 
-bool
-spawner_coloc_t::do_bemaster()
-{
-  if (m_is_fe || !m_is_master)
-    return false;
+bool spawner_coloc_t::do_bemaster() {
+  if (m_is_fe || !m_is_master) return false;
 
   lmonp_t msg;
 
   read_lmonp_msgheader(m_be_master_sockfd, &msg);
-  if ((msg.msgclass != lmonp_fetobe) 
-      || (msg.type.fetobe_type != lmonp_febe_assist_mw_coloc)
-      || msg.lmon_payload_length == 0)
-    {
-      set_err_str(
+  if ((msg.msgclass != lmonp_fetobe) ||
+      (msg.type.fetobe_type != lmonp_febe_assist_mw_coloc) ||
+      msg.lmon_payload_length == 0) {
+    set_err_str(
         std::string("msg mismatch: expecting lmonp_febe_assist_mw_coloc"));
-      return false;
-    }
+    return false;
+  }
 
-  lmonp_t *msg_with_pl 
-    = (lmonp_t *) malloc (sizeof(lmonp_t) + msg.lmon_payload_length);
-  memcpy(msg_with_pl, &msg, sizeof(msg)); 
+  lmonp_t *msg_with_pl =
+      (lmonp_t *)malloc(sizeof(lmonp_t) + msg.lmon_payload_length);
+  memcpy(msg_with_pl, &msg, sizeof(msg));
   char *lmonpl = get_lmonpayload_begin(msg_with_pl);
-  int bytesread 
-    = read_lmonp_payloads (m_be_master_sockfd, 
-                           lmonpl,
-                           msg_with_pl->lmon_payload_length);
+  int bytesread = read_lmonp_payloads(m_be_master_sockfd, lmonpl,
+                                      msg_with_pl->lmon_payload_length);
 
-  int bsanity = msg_with_pl->lmon_payload_length+msg_with_pl->usr_payload_length;
-  if ( bytesread != bsanity )
-    {
-      set_err_str(
-        std::string("Bytes read don't equal the size specified in the received msg"));
-      return false;
-    }
+  int bsanity =
+      msg_with_pl->lmon_payload_length + msg_with_pl->usr_payload_length;
+  if (bytesread != bsanity) {
+    set_err_str(std::string(
+        "Bytes read don't equal the size specified in the received msg"));
+    return false;
+  }
 
-  uint32_t leng = static_cast<uint32_t> (msg_with_pl->lmon_payload_length);
+  uint32_t leng = static_cast<uint32_t>(msg_with_pl->lmon_payload_length);
 
-  //fprintf(stdout, "do_bemaster: before bcast\n"); 
+  // fprintf(stdout, "do_bemaster: before bcast\n");
 
-  if (m_broadcast(&leng, sizeof(leng)) != LMON_OK)
-    {
-      set_err_str(std::string("broadcast failed: mw assist lmon payload length"));
-      return false;
-    }
+  if (m_broadcast(&leng, sizeof(leng)) != LMON_OK) {
+    set_err_str(std::string("broadcast failed: mw assist lmon payload length"));
+    return false;
+  }
 
-  //fprintf(stdout, "do_bemaster: before bcast lmonpl\n"); 
+  // fprintf(stdout, "do_bemaster: before bcast lmonpl\n");
 
-  if (m_broadcast(lmonpl, leng) != LMON_OK)
-    {
-      set_err_str(std::string("broadcast failed:  mw assist lmon payload"));
-      return false;
-    }
+  if (m_broadcast(lmonpl, leng) != LMON_OK) {
+    set_err_str(std::string("broadcast failed:  mw assist lmon payload"));
+    return false;
+  }
 
-  //fprintf(stdout, "do_bemaster: before parse_mw_assist\n"); 
+  // fprintf(stdout, "do_bemaster: before parse_mw_assist\n");
 
-  if(!parse_mw_assist_lmonpl(lmonpl))
-    {
-      set_err_str(std::string("can't parse the mw assist lmon payload"));
-      return false;
-    }
+  if (!parse_mw_assist_lmonpl(lmonpl)) {
+    set_err_str(std::string("can't parse the mw assist lmon payload"));
+    return false;
+  }
 
   free(msg_with_pl);
 
-  //fprintf(stdout, "do_bemaster: before fork and exec\n"); 
+  // fprintf(stdout, "do_bemaster: before fork and exec\n");
 
   //
   // TODO: if LMON will have to deal with more than one daemon per node model
@@ -237,58 +203,50 @@ spawner_coloc_t::do_bemaster()
   //
 
   pid_t id;
-  if ( !(id = fork()))
-    {
-      //
-      // Child process
-      //
-      if (!execute_daemon())
-        {
-          /* SINK */
-          return false;
-        }
+  if (!(id = fork())) {
+    //
+    // Child process
+    //
+    if (!execute_daemon()) {
+      /* SINK */
+      return false;
     }
+  }
 
   m_pid_vect.push_back(id);
 
   return true;
 }
 
-bool
-spawner_coloc_t::do_beslave()
-{
-  if (m_is_fe || m_is_master)
-    return false;
+bool spawner_coloc_t::do_beslave() {
+  if (m_is_fe || m_is_master) return false;
 
-  //fprintf(stdout, "do_beslave: before bcast\n"); 
+  // fprintf(stdout, "do_beslave: before bcast\n");
 
   uint32_t leng;
-  if (m_broadcast(&leng, sizeof(leng)) != LMON_OK)
-    {
-      set_err_str(std::string("broadcast failed: mw assist lmon payload length"));
-      return false;
-    }
+  if (m_broadcast(&leng, sizeof(leng)) != LMON_OK) {
+    set_err_str(std::string("broadcast failed: mw assist lmon payload length"));
+    return false;
+  }
 
-  //fprintf(stdout, "do_beslave: before bcast lmonpl\n"); 
+  // fprintf(stdout, "do_beslave: before bcast lmonpl\n");
 
-  char *lmonpl = (char *) malloc(leng);
-  if (m_broadcast(lmonpl, leng) != LMON_OK)
-    {
-      set_err_str(std::string("broadcast failed:  mw assist lmon payload"));
-      return false;
-    }
+  char *lmonpl = (char *)malloc(leng);
+  if (m_broadcast(lmonpl, leng) != LMON_OK) {
+    set_err_str(std::string("broadcast failed:  mw assist lmon payload"));
+    return false;
+  }
 
-  //fprintf(stdout, "do_beslave: before parse_mw_assist\n"); 
+  // fprintf(stdout, "do_beslave: before parse_mw_assist\n");
 
-  if (!parse_mw_assist_lmonpl(lmonpl))
-    {
-      set_err_str(std::string("can't parse the mw assist lmon payload"));
-      return false;
-    }
+  if (!parse_mw_assist_lmonpl(lmonpl)) {
+    set_err_str(std::string("can't parse the mw assist lmon payload"));
+    return false;
+  }
 
-  free (lmonpl);
+  free(lmonpl);
 
-  //fprintf(stdout, "do_beslave: before fork and exec\n"); 
+  // fprintf(stdout, "do_beslave: before fork and exec\n");
 
   //
   // TODO: if LMON will have to deal with more than one daemon per node model
@@ -296,44 +254,39 @@ spawner_coloc_t::do_beslave()
   //
 
   pid_t id;
-  if ( !(id = fork()))
-    {
-      //
-      // Child process
-      //
-      if (!execute_daemon()) 
-        {
-          /* SINK */
-          return false; 
-        }
+  if (!(id = fork())) {
+    //
+    // Child process
+    //
+    if (!execute_daemon()) {
+      /* SINK */
+      return false;
     }
+  }
 
   m_pid_vect.push_back(id);
 
   return true;
 }
 
-bool
-spawner_coloc_t::execute_daemon()
-{
+bool spawner_coloc_t::execute_daemon() {
   //
   // compute required malloc size
   // 1: deamonpath
-  // m: daemonargs 
+  // m: daemonargs
   // 1: null-termination
 
   int nargvs = get_daemon_args().size() + 2;
   int i = 0;
-  char **av = (char **) malloc (nargvs * sizeof(av));
+  char **av = (char **)malloc(nargvs * sizeof(av));
   std::vector<std::string>::const_iterator iter;
 
   av[i++] = strdup(get_daemon_path().c_str());
 
-  for (iter = get_daemon_args().begin(); 
-         iter != get_daemon_args().end(); ++iter)
-    {
-      av[i++] = strdup ((*iter).c_str());
-    }
+  for (iter = get_daemon_args().begin(); iter != get_daemon_args().end();
+       ++iter) {
+    av[i++] = strdup((*iter).c_str());
+  }
 
   av[i++] = NULL;
 
@@ -341,10 +294,9 @@ spawner_coloc_t::execute_daemon()
   // We use excvp so that we don't have to copy environ
   // If works, this is SINK
   //
-  if ( execvp ( av[0], av) < 0 )
-    {
-      return false;
-    }
+  if (execvp(av[0], av) < 0) {
+    return false;
+  }
 
   //
   // Unreachable but to satisfy the compiler
@@ -352,3 +304,6 @@ spawner_coloc_t::execute_daemon()
   return true;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_coloc_spawner.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_coloc_spawner.hxx
@@ -1,33 +1,34 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2012, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
- *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support branch.
+ *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support
+ *                         branch.
  *        Jul 02 2010 DHA: Created file.
  */
 
@@ -36,61 +37,52 @@
 
 #include "sdbg_std.hxx"
 
-#include <string>
 #include <string.h>
+#include <string>
 #include <vector>
 #include "sdbg_base_spawner.hxx"
 
 const std::string colocstr("coloc");
 
-class spawner_coloc_t : public spawner_base_t
-{
-public:
+class spawner_coloc_t : public spawner_base_t {
+ public:
   ////////////////////////////////////////////////////////////
   //
   //  Public Interfaces
   //
-  spawner_coloc_t()
-    {
+  spawner_coloc_t() {}
 
-    }
+  spawner_coloc_t(int bemasterfd, const std::string &dpath,
+                  const std::vector<std::string> &dmonopts,
+                  const std::vector<std::string> &hostvect)
+      : spawner_base_t(colocstr, std::vector<std::string>(), dpath, dmonopts,
+                       hostvect) {
+    m_is_master = false;
+    m_is_fe = true;
+    m_be_master_sockfd = bemasterfd;
+    m_broadcast = NULL;
+  }
 
-  spawner_coloc_t(int bemasterfd,
-    const std::string &dpath,
-    const std::vector<std::string> &dmonopts,
-    const std::vector<std::string> &hostvect)
-      : spawner_base_t(colocstr, std::vector<std::string>(), dpath, dmonopts, hostvect)
-    {
-      m_is_master = false;
-      m_is_fe = true;
-      m_be_master_sockfd = bemasterfd;
-      m_broadcast = NULL;
-    }
+  spawner_coloc_t(bool ismaster, int bemasterfd, int (*bcast)(void *, int))
+      : spawner_base_t(colocstr, std::vector<std::string>()) {
+    m_is_fe = false;
+    m_is_master = ismaster;
+    m_be_master_sockfd = bemasterfd;
+    m_broadcast = bcast;
+  }
 
-  spawner_coloc_t(bool ismaster, int bemasterfd, int (*bcast)(void*, int))
-      : spawner_base_t(colocstr, std::vector<std::string>())
-    {
-      m_is_fe = false;
-      m_is_master = ismaster;
-      m_be_master_sockfd = bemasterfd;
-      m_broadcast = bcast;
+  virtual ~spawner_coloc_t() {
+    if (!m_pid_vect.empty()) {
+      m_pid_vect.clear();
     }
-
-  virtual ~spawner_coloc_t()
-    {
-      if (!m_pid_vect.empty())
-        {
-          m_pid_vect.clear();
-        }
-    }
+  }
 
   virtual bool spawn();
 
-private:
-  explicit spawner_coloc_t(const spawner_coloc_t & s)
-   {
-     // does nothing
-   }
+ private:
+  explicit spawner_coloc_t(const spawner_coloc_t &s) {
+    // does nothing
+  }
 
   bool execute_daemon();
 
@@ -102,9 +94,13 @@ private:
   bool m_is_fe;
   bool m_is_master;
   int m_be_master_sockfd;
-  int (*m_broadcast)(void*, int);
+  int (*m_broadcast)(void *, int);
 
   std::vector<pid_t> m_pid_vect;
 };
 
-#endif // SDBG_COLOC_SPAWNER_HXX
+#endif  // SDBG_COLOC_SPAWNER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_daemon_internal.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_daemon_internal.cxx
@@ -1,30 +1,30 @@
 /*
- * $Header: dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2012, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *
  *
  *  Note:
  *        LMON BE|MW API is designed to leverage any efficient underlying
@@ -38,23 +38,23 @@
  *                          to support middleware daemons
  *        Oct  07 2011 DHA: Deprecated PMGR Collective support
  *        May  11 2010 DHA: Added MEASURE_TRACING_COST for the PMGR layer
- *        Feb  05 2010 DHA: Added pmgr_register_hname to register the local 
- *                          hostname to the PMGR Collective layer. This is to work 
- *                          around the system in which gethostname followed by
- *                          gethostbyname doesn't resolve the hostname into
- *                          an IP.
+ *        Feb  05 2010 DHA: Added pmgr_register_hname to register the local
+ *                          hostname to the PMGR Collective layer. This is to
+ *                          work around the system in which gethostname
+ *                          followed by gethostbyname doesn't resolve the
+ *                          hostname into an IP.
  *        Dec  23 2009 DHA: Added explict config.h inclusion
  *        Dec  16 2008 DHA: Added COBO support
  *        Mar  26 2008 DHA: Added the END_DEBUG message support
  *                          for BlueGene with a debugger protocol version >= 3
- *        Mar  14 2008 DHA: Added PMGR Collective support. 
- *                          The changes are contained in the PMGR_BASED 
+ *        Mar  14 2008 DHA: Added PMGR Collective support.
+ *                          The changes are contained in the PMGR_BASED
  *                          macro.
  *        Feb  09 2008 DHA: Added LLNS Copyright
  *        Jul  25 2007 DHA: bracket MPI dependent codes using
  *                          LMON_BE_MPI_BASED macro.
  *        Mar  16 2007 DHA: Added MPI_Allreduce support
- *        Dec  29 2006 DHA: Created file. Most routines are lifted 
+ *        Dec  29 2006 DHA: Created file. Most routines are lifted
  *                          from lmon_be.cxx
  */
 
@@ -64,28 +64,27 @@
 #error This source file requires a LINUX OS
 #endif
 
+#include <string.h>
 #include <cstdio>
 #include <cstdlib>
-#include <string.h>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <vector>
 
 extern "C" {
+#include <arpa/inet.h>
 #include <limits.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
 }
 
 #include "lmon_api/lmon_api_std.h"
-#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_be.h"
 #include "lmon_api/lmon_lmonp_msg.h"
+#include "lmon_api/lmon_proctab.h"
 #include "lmon_api/lmon_say_msg.hxx"
 #include "lmon_daemon_internal.hxx"
-
 
 #if MPI_BASED
 extern "C" {
@@ -97,11 +96,10 @@ extern "C" {
 }
 #endif
 
-static int ICCL_rank      = -1;
-static int ICCL_size      = -1;
+static int ICCL_rank = -1;
+static int ICCL_size = -1;
 static int ICCL_global_id = -1;
 static per_be_data_t *bedataPtr = NULL;
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -110,39 +108,30 @@ static per_be_data_t *bedataPtr = NULL;
 //
 //
 
-lmon_rc_e
-LMON_daemon_internal_tester_init ( per_be_data_t *d )
-{
-  if (!d)
-    {
-      return LMON_EINVAL;
-    } 
+lmon_rc_e LMON_daemon_internal_tester_init(per_be_data_t *d) {
+  if (!d) {
+    return LMON_EINVAL;
+  }
 
   bedataPtr = d;
   return LMON_OK;
 }
 
-
-lmon_rc_e
-LMON_daemon_internal_tester_getBeData ( per_be_data_t **d )
-{
-  if (!bedataPtr)
-    {
-      return LMON_EINVAL;
-    }
+lmon_rc_e LMON_daemon_internal_tester_getBeData(per_be_data_t **d) {
+  if (!bedataPtr) {
+    return LMON_EINVAL;
+  }
 
   (*d) = bedataPtr;
   return LMON_OK;
 }
 
-
 //! LMON_daemon_internal_init(int* argc, char*** argv)
 /*!
 
 */
-lmon_rc_e
-LMON_daemon_internal_init ( int* argc, char*** argv, char *myhn, int is_be )
-{
+lmon_rc_e LMON_daemon_internal_init(int *argc, char ***argv, char *myhn,
+                                    int is_be) {
   int rc;
   char **nargv = *argv;
   int n_lmonopt = 0;
@@ -152,22 +141,19 @@ LMON_daemon_internal_init ( int* argc, char*** argv, char *myhn, int is_be )
    * The following code assumes lmon's options are specified after all other
    * options (e.g., PMGR's ) are given.
    */
-  for (i=1; i < (*argc); ++i) {
-    if ( (nargv[i][0] == '-') && (nargv[i][1]) ) {
-      if ( strncmp (&(nargv[i][2]), "lmonsharedsec=", 14)== 0 )
-	{
-	   /* exporting a commandline option to an envVar */
-           setenv (TOOL_SS_ENV, &(nargv[i][2])+14, 1); 
-	   n_lmonopt++;
-	}
-      else if ( strncmp (&(nargv[i][2]), "lmonsecchk=", 11)== 0 )
-	{
-	  /* exporting a commandline option to an envVar */
-          setenv (TOOL_SCH_ENV, &(nargv[i][2])+11, 1); 
-	  n_lmonopt++;
-	}
+  for (i = 1; i < (*argc); ++i) {
+    if ((nargv[i][0] == '-') && (nargv[i][1])) {
+      if (strncmp(&(nargv[i][2]), "lmonsharedsec=", 14) == 0) {
+        /* exporting a commandline option to an envVar */
+        setenv(TOOL_SS_ENV, &(nargv[i][2]) + 14, 1);
+        n_lmonopt++;
+      } else if (strncmp(&(nargv[i][2]), "lmonsecchk=", 11) == 0) {
+        /* exporting a commandline option to an envVar */
+        setenv(TOOL_SCH_ENV, &(nargv[i][2]) + 11, 1);
+        n_lmonopt++;
       }
-    } /* for */
+    }
+  } /* for */
 
   if (n_lmonopt != 2) {
     LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
@@ -179,50 +165,47 @@ LMON_daemon_internal_init ( int* argc, char*** argv, char *myhn, int is_be )
   }
 
   (*argc) -= n_lmonopt;
-  nargv[(*argc)+0] = NULL;
+  nargv[(*argc) + 0] = NULL;
   char tmpbuf[PATH_MAX];
-  for (i=1; i < (n_lmonopt+1); ++i )
-    {
-      sprintf(tmpbuf, "LMONNOOP%d=%d", i,i);
-       /* this region of memory might not be safe to be freed, so we just leak */
-       /* and nargv[(*argc_p)+n_pmgropt] must be null */
-      nargv[(*argc)+i] = strdup (tmpbuf); 
-    }
+  for (i = 1; i < (n_lmonopt + 1); ++i) {
+    sprintf(tmpbuf, "LMONNOOP%d=%d", i, i);
+    /* this region of memory might not be safe to be freed, so we just leak */
+    /* and nargv[(*argc_p)+n_pmgropt] must be null */
+    nargv[(*argc) + i] = strdup(tmpbuf);
+  }
 
 #if MPI_BASED
   /*
    * with Message Passing Interface
    */
-  if ( ( rc = MPI_Init (argc, argv)) < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        " MPI_Init failed");
-      return LMON_EINVAL;
-    }
+  if ((rc = MPI_Init(argc, argv)) < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " MPI_Init failed");
+    return LMON_EINVAL;
+  }
   //
-  // register an MPI error handler to change the behavior of 
+  // register an MPI error handler to change the behavior of
   // MPI calls such that they return on failure
   //
-  MPI_Errhandler_set (MPI_COMM_WORLD, MPI_ERRORS_RETURN);
-  MPI_Comm_size (MPI_COMM_WORLD, &ICCL_size);
-  MPI_Comm_rank (MPI_COMM_WORLD, &ICCL_rank);
+  MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+  MPI_Comm_size(MPI_COMM_WORLD, &ICCL_size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &ICCL_rank);
   ICCL_global_id = ICCL_rank;
 
 #elif COBO_BASED
 
-# if MEASURE_TRACING_COST
-  /* Hack, but the MEASURE_TRACING_COST macro doesn't 
-   * propagate to the iccl layer 
+#if MEASURE_TRACING_COST
+  /* Hack, but the MEASURE_TRACING_COST macro doesn't
+   * propagate to the iccl layer
    * so we use the global variable trick here
    */
   __cobo_ts = gettimeofdayD();
-# endif
+#endif
 
 #if defined(MUNGE)
   cobo_sec_protocol.mechanism = hs_munge;
 #elif defined(KEYFILE)
   char kp[PATH_MAX];
-  snprintf (kp, PATH_MAX, "%s/keyfile.%d", SEC_KEYDIR, getuid());
+  snprintf(kp, PATH_MAX, "%s/keyfile.%d", SEC_KEYDIR, getuid());
   cobo_sec_protocol.mechanism = hs_key_in_file;
   cobo_sec_protocol.data.key_in_file.key_filepath = strdup(kp);
   cobo_sec_protocol.data.key_in_file.key_length_bytes = 8;
@@ -232,862 +215,712 @@ LMON_daemon_internal_init ( int* argc, char*** argv, char *myhn, int is_be )
 #error No recognized handshake mechanism enabled
 #endif
 
-   int iccl_begin_port, iccl_tmp_session;
+  int iccl_begin_port, iccl_tmp_session;
 
-   //
-   //TODO: session id=10 for now.
-   //
-   iccl_begin_port = (is_be) ? COBO_BEGIN_PORT : COBO_BEGIN_PORT + COBO_PORT_RANGE;
-   iccl_tmp_session = (is_be) ? 10 : 11;
+  //
+  // TODO: session id=10 for now.
+  //
+  iccl_begin_port =
+      (is_be) ? COBO_BEGIN_PORT : COBO_BEGIN_PORT + COBO_PORT_RANGE;
+  iccl_tmp_session = (is_be) ? 10 : 11;
 
-   int j;
-   int *portlist = (int *) malloc (COBO_PORT_RANGE * sizeof(int));
+  int j;
+  int *portlist = (int *)malloc(COBO_PORT_RANGE * sizeof(int));
 
-   if (portlist == NULL)
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "malloc returned NULL");
+  if (portlist == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "malloc returned NULL");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-   for (j=0; j < COBO_PORT_RANGE; ++j)
-     portlist[j] = iccl_begin_port + j;
+  for (j = 0; j < COBO_PORT_RANGE; ++j) portlist[j] = iccl_begin_port + j;
 
-   if ( ( rc = cobo_open (iccl_tmp_session,
-                          portlist,
-                          COBO_PORT_RANGE,
-                          &ICCL_rank, &ICCL_size) )
-            != COBO_SUCCESS )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "cobo_open failed");
+  if ((rc = cobo_open(iccl_tmp_session, portlist, COBO_PORT_RANGE, &ICCL_rank,
+                      &ICCL_size)) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "cobo_open failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   free(portlist);
 
-# if VERBOSE
-    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,
-      "My rank is %d, My size is %d", ICCL_rank, ICCL_size);
-# endif
-
-# if MEASURE_TRACING_COST
-#  if VERBOSE
-    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,
-      "__cobo_ts: %f", __cobo_ts);
-#  endif
-    if (ICCL_size <= 0)
-      {
-        LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-          "cobo_open failed; checked during MEASURE_TRACING_COST");
-
-        return LMON_EINVAL;
-      }
-
-    double *tsvector = NULL;
-    if (ICCL_rank == 0)
-      {
-        tsvector = (double *) malloc (ICCL_size * sizeof(double));
-      }
-
-    if ( ( rc = cobo_gather(&__cobo_ts, sizeof(__cobo_ts), tsvector, 0)) != COBO_SUCCESS )
-      {
-        LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-          "cobo_gather failed during MEASURE_TRACING_COST");
-
-        return LMON_EINVAL;
-      }
-
-    if (ICCL_rank == 0)
-      {
-        long rix;
-        double maxts=0.0f;
-        int parentfd = -1;
-        for ( rix=0; rix < ICCL_size; ++rix) 
-          {
-            maxts = (tsvector[rix] > maxts) ? tsvector[rix] : maxts; 
-          }
-        if ( cobo_get_parent_socket(&parentfd) != COBO_SUCCESS )
-          {
-            LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-	      "cobo_client_get_parent_socket failed during MEASURE_TRACING_COST");
-
-            return LMON_EINVAL;
-          } 
-#  if VERBOSE
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,
-        "sending maxts: %f", maxts);
-#  endif
-
-       if (lmon_write_raw(parentfd, &maxts, sizeof(maxts)) < 0 )
-         {
-            LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-              "write failed during MEASURE_TRACING_COST");
-
-            return LMON_EINVAL;
-         }
-      }
-# endif
-
-#else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal communication fabric to leverage");
-  return LMON_EINVAL;
+#if VERBOSE
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false, "My rank is %d, My size is %d",
+               ICCL_rank, ICCL_size);
 #endif
 
-  if ( (ICCL_rank == -1) || (ICCL_size == -1 ) )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "ICCL_rank and/or ICCL_size have not been assigned");
+#if MEASURE_TRACING_COST
+#if VERBOSE
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false, "__cobo_ts: %f", __cobo_ts);
+#endif
+  if (ICCL_size <= 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "cobo_open failed; checked during MEASURE_TRACING_COST");
+
+    return LMON_EINVAL;
+  }
+
+  double *tsvector = NULL;
+  if (ICCL_rank == 0) {
+    tsvector = (double *)malloc(ICCL_size * sizeof(double));
+  }
+
+  if ((rc = cobo_gather(&__cobo_ts, sizeof(__cobo_ts), tsvector, 0)) !=
+      COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "cobo_gather failed during MEASURE_TRACING_COST");
+
+    return LMON_EINVAL;
+  }
+
+  if (ICCL_rank == 0) {
+    long rix;
+    double maxts = 0.0f;
+    int parentfd = -1;
+    for (rix = 0; rix < ICCL_size; ++rix) {
+      maxts = (tsvector[rix] > maxts) ? tsvector[rix] : maxts;
+    }
+    if (cobo_get_parent_socket(&parentfd) != COBO_SUCCESS) {
+      LMON_say_msg(
+          LMON_DAEMON_MSG_PREFIX, true,
+          "cobo_client_get_parent_socket failed during MEASURE_TRACING_COST");
 
       return LMON_EINVAL;
     }
+#if VERBOSE
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false, "sending maxts: %f", maxts);
+#endif
+
+    if (lmon_write_raw(parentfd, &maxts, sizeof(maxts)) < 0) {
+      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                   "write failed during MEASURE_TRACING_COST");
+
+      return LMON_EINVAL;
+    }
+  }
+#endif
+
+#else
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal communication fabric to leverage");
+  return LMON_EINVAL;
+#endif
+
+  if ((ICCL_rank == -1) || (ICCL_size == -1)) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "ICCL_rank and/or ICCL_size have not been assigned");
+
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_daemon_internal_getConnFd
 /*!
 
 */
-lmon_rc_e
-LMON_daemon_internal_getConnFd ( int *fd )
-{
+lmon_rc_e LMON_daemon_internal_getConnFd(int *fd) {
 #if COBO_BASED
-  if ( ICCL_rank == 0)
-    {
-      if ( cobo_get_parent_socket (fd) != COBO_SUCCESS )
-        {
-          LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,"no connection estabilished with FE");
-          return LMON_EDUNAV;
-        }
-      return LMON_OK;
-    }
-  else
-    {
+  if (ICCL_rank == 0) {
+    if (cobo_get_parent_socket(fd) != COBO_SUCCESS) {
+      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,
+                   "no connection estabilished with FE");
       return LMON_EDUNAV;
     }
+    return LMON_OK;
+  } else {
+    return LMON_EDUNAV;
+  }
 #else
   return LMON_EDUNAV;
 #endif
 }
-
 
 //! lmon_rc_e LMON_daemon_internal_getMyRank
 /*!
   Returns my rank thru rank argument.
         Returns: LMON_OK if OK, LMON_EINVAL on error
 */
-lmon_rc_e
-LMON_daemon_internal_getMyRank ( int *rank )
-{
-  if ( ICCL_rank < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "ICCL_rank has not been filled." );
+lmon_rc_e LMON_daemon_internal_getMyRank(int *rank) {
+  if (ICCL_rank < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "ICCL_rank has not been filled.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  (*rank) = ICCL_rank; 
+  (*rank) = ICCL_rank;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_deamon_internal_getSize
 /*!
   Returns the number of backend daemons thru size argument.
         Returns: LMON_OK if OK, LMON_EINVAL on error
 */
-lmon_rc_e 
-LMON_daemon_internal_getSize ( int *size )
-{
-  if ( ICCL_size < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "ICCL_size has not been filled." );
+lmon_rc_e LMON_daemon_internal_getSize(int *size) {
+  if (ICCL_size < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "ICCL_size has not been filled.");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   (*size) = ICCL_size;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_daemon_internal_barrier()
 /*!
   Barrier call for tool daemons.
 */
-lmon_rc_e
-LMON_daemon_internal_barrier ()
-{
+lmon_rc_e LMON_daemon_internal_barrier() {
   int rc;
 
 #if MPI_BASED
-  if ( (rc = MPI_Barrier(MPI_COMM_WORLD)) < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "MPI_Barrier failed ");
+  if ((rc = MPI_Barrier(MPI_COMM_WORLD)) < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "MPI_Barrier failed ");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #elif COBO_BASED
-  if ( (rc = cobo_barrier ()) != COBO_SUCCESS )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "pmgr_barrier failed ");
+  if ((rc = cobo_barrier()) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "pmgr_barrier failed ");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal comm fabric to leverage");
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal comm fabric to leverage");
   return LMON_EINVAL;
 #endif
 
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_daemon_internal_broadcast
+//! lmon_rc_e LMON_daemon_internal_broadcast
 /*!
-   This call restricts the root of the broadcast call to the master 
+   This call restricts the root of the broadcast call to the master
    backend daemon and the width of the communicator to be "all daemons"
 
    This call is also datatype agnostic. It sends buf as a BYTE stream.
  */
-lmon_rc_e 
-LMON_daemon_internal_broadcast ( void *buf, int numbyte ) 
-{
+lmon_rc_e LMON_daemon_internal_broadcast(void *buf, int numbyte) {
   int rc;
 
 #if MPI_BASED
-  if ( (rc = MPI_Bcast ( buf,
-                         numbyte,
-                         MPI_BYTE,
-                         LMON_BE_MASTER,
-                         MPI_COMM_WORLD)) < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true," MPI_Bcast failed");
+  if ((rc = MPI_Bcast(buf, numbyte, MPI_BYTE, LMON_BE_MASTER, MPI_COMM_WORLD)) <
+      0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " MPI_Bcast failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #elif COBO_BASED
-  if ( (rc = cobo_bcast( buf,
-                         numbyte,
-                         LMON_DAEMON_MASTER ))
-       != COBO_SUCCESS )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true," cobo_bcast failed");
+  if ((rc = cobo_bcast(buf, numbyte, LMON_DAEMON_MASTER)) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " cobo_bcast failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal comm fabric to leverage");
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal comm fabric to leverage");
   return LMON_EINVAL;
 #endif
 
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_daemon_internal_gather 
+//! lmon_rc_e LMON_daemon_internal_gather
 /*!
-   Gathers data from all tool daemons and returns it via recvbuf 
+   Gathers data from all tool daemons and returns it via recvbuf
    of the master tool daemon. The data must be in contiguous memory and
    be constant size across all backend daemons. FIXME:
 */
-lmon_rc_e
-LMON_daemon_internal_gather (
-                void *sendbuf,
-                int numbyte_per_elem,
-                void *recvbuf )
-{
+lmon_rc_e LMON_daemon_internal_gather(void *sendbuf, int numbyte_per_elem,
+                                      void *recvbuf) {
   int rc;
 
 #if MPI_BASED
-  rc = MPI_Gather (sendbuf,
-                   numbyte_per_elem,
-                   MPI_BYTE,
-                   recvbuf,
-                   numbyte_per_elem,
-                   MPI_BYTE,
-                   LMON_BE_MASTER,
-                   MPI_COMM_WORLD);
+  rc = MPI_Gather(sendbuf, numbyte_per_elem, MPI_BYTE, recvbuf,
+                  numbyte_per_elem, MPI_BYTE, LMON_BE_MASTER, MPI_COMM_WORLD);
 
-  if (rc < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"MPI_Gather failed");
+  if (rc < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "MPI_Gather failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #elif COBO_BASED
-  rc = cobo_gather (sendbuf,
-                    numbyte_per_elem, 
-                    recvbuf,
-                    LMON_DAEMON_MASTER);
-  if (rc != COBO_SUCCESS )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"cobo_gather failed");
+  rc = cobo_gather(sendbuf, numbyte_per_elem, recvbuf, LMON_DAEMON_MASTER);
+  if (rc != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "cobo_gather failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal comm fabric to leverage");
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal comm fabric to leverage");
   return LMON_EINVAL;
 #endif
 
   return LMON_OK;
 }
 
-
-//!lmon_rc_e LMON_daemon_internal_scatter
+//! lmon_rc_e LMON_daemon_internal_scatter
 /*!
    Scatter data to all tool daemons. Each daemon receives its portion
    via recvbuf. sendbuf is only meaningful to the source.
    The data type of send buf must be in contiguous memory and
    packed so that every daemon receives the constant size per-daemon data.
 */
-lmon_rc_e
-LMON_daemon_internal_scatter (
-                void *sendbuf,
-                int numbyte_per_element,
-                void *recvbuf )
-{
+lmon_rc_e LMON_daemon_internal_scatter(void *sendbuf, int numbyte_per_element,
+                                       void *recvbuf) {
   int rc;
 
 #if MPI_BASED
-  rc = MPI_Scatter(sendbuf,
-                   numbyte_per_element,
-                   MPI_BYTE,
-                   recvbuf,
-                   numbyte_per_element,
-                   MPI_BYTE,
-                   LMON_BE_MASTER,
+  rc = MPI_Scatter(sendbuf, numbyte_per_element, MPI_BYTE, recvbuf,
+                   numbyte_per_element, MPI_BYTE, LMON_BE_MASTER,
                    MPI_COMM_WORLD);
- 
-  if (rc < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true," MPI_Scatter failed");
 
-      return LMON_EINVAL;
-    }
+  if (rc < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " MPI_Scatter failed");
+
+    return LMON_EINVAL;
+  }
 #elif COBO_BASED
-  rc = cobo_scatter (sendbuf,
-                     numbyte_per_element,
-                     recvbuf,
-                     LMON_DAEMON_MASTER);
+  rc = cobo_scatter(sendbuf, numbyte_per_element, recvbuf, LMON_DAEMON_MASTER);
 
-  if (rc != COBO_SUCCESS)
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true," cobo_scatter failed");
+  if (rc != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " cobo_scatter failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal comm fabric to leverage");
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal comm fabric to leverage");
   return LMON_EINVAL;
 #endif
 
   return LMON_OK;
 }
-
 
 //! LMON_daemon_internal_finalize();
 /*
-  Finalizes the LMON BACKEND API. Every daemon must call this to 
+  Finalizes the LMON BACKEND API. Every daemon must call this to
   propertly finalize LMON BACKEND
 */
-lmon_rc_e
-LMON_daemon_internal_finalize (int is_be)
-{
+lmon_rc_e LMON_daemon_internal_finalize(int is_be) {
   int rc;
 
 #if MPI_BASED
-  if ( (rc = MPI_Finalize()) < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true," MPI_Finalize failed");
+  if ((rc = MPI_Finalize()) < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, " MPI_Finalize failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #elif COBO_BASED
-  if ( ( rc = cobo_close () ) != COBO_SUCCESS ) 
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "cobo_close failed");
+  if ((rc = cobo_close()) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "cobo_close failed");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #else
-  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,"no internal comm fabric to leverage");
+  LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+               "no internal comm fabric to leverage");
   return LMON_EINVAL;
 #endif
 
   return LMON_OK;
 }
 
-
-lmon_rc_e
-LMON_daemon_enable_verbose(const char *vdir, const char *local_hostname, int is_be)
-{
+lmon_rc_e LMON_daemon_enable_verbose(const char *vdir,
+                                     const char *local_hostname, int is_be) {
   char debugfn[PATH_MAX];
-  snprintf (debugfn, PATH_MAX, vdir);
+  snprintf(debugfn, PATH_MAX, vdir);
 
-  if (!local_hostname)
-    {
-      LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-        "local_hostname arg is null" );
+  if (!local_hostname) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "local_hostname arg is null");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( mkdir (debugfn, S_IRWXU) < 0 )
-    {
-      if ( errno != EEXIST )
-        {
-          LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-            "LMON daemon fails to mkdir %s", debugfn );
-
-          return LMON_EINVAL;
-        }
-    }
-
-  if (is_be)
-    {
-      snprintf(debugfn, PATH_MAX, "%s/be.stdout.%d.%s",
-               vdir, getpid(), local_hostname);
-    }
-  else
-    {
-      snprintf(debugfn, PATH_MAX, "%s/mw.stdout.%d.%s",
-               vdir, getpid(), local_hostname);
-    }
-
-  if ( freopen (debugfn, "w", stdout) == NULL )
-    {
-      LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-        "LMON daemon fails to reopen stdout: %s", debugfn );
+  if (mkdir(debugfn, S_IRWXU) < 0) {
+    if (errno != EEXIST) {
+      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                   "LMON daemon fails to mkdir %s", debugfn);
 
       return LMON_EINVAL;
     }
+  }
 
-  handshake_enable_debug_prints (stdout);
+  if (is_be) {
+    snprintf(debugfn, PATH_MAX, "%s/be.stdout.%d.%s", vdir, getpid(),
+             local_hostname);
+  } else {
+    snprintf(debugfn, PATH_MAX, "%s/mw.stdout.%d.%s", vdir, getpid(),
+             local_hostname);
+  }
 
-  if (is_be)
-    {
-      snprintf(debugfn, PATH_MAX, "%s/be.stderr.%d.%s",
-               vdir, getpid(), local_hostname);
-    }
-  else
-    {
-      snprintf(debugfn, PATH_MAX, "%s/mw.stderr.%d.%s",
-               vdir, getpid(), local_hostname);
-    }
+  if (freopen(debugfn, "w", stdout) == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "LMON daemon fails to reopen stdout: %s", debugfn);
 
-  if ( freopen (debugfn, "w", stderr) == NULL )
-    {
-      LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-        "LMON daemon fails to reopen stderr: %s", debugfn );
+    return LMON_EINVAL;
+  }
 
-      return LMON_EINVAL;
-    }
+  handshake_enable_debug_prints(stdout);
+
+  if (is_be) {
+    snprintf(debugfn, PATH_MAX, "%s/be.stderr.%d.%s", vdir, getpid(),
+             local_hostname);
+  } else {
+    snprintf(debugfn, PATH_MAX, "%s/mw.stderr.%d.%s", vdir, getpid(),
+             local_hostname);
+  }
+
+  if (freopen(debugfn, "w", stderr) == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "LMON daemon fails to reopen stderr: %s", debugfn);
+
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_daemon_return_ver
 /*!
 
 */
-int
-LMON_daemon_return_ver()
-{
-  return LMON_VERSION;
-}
-
+int LMON_daemon_return_ver() { return LMON_VERSION; }
 
 //! lmon_rc_e LMON_daemon_getSharedKeyAndID
 /*!
-    returns info on authentication; 
+    returns info on authentication;
     shared_key must be 128 bits
 */
-lmon_rc_e
-LMON_daemon_getSharedKeyAndID ( char *shared_key, int *id )
-{
+lmon_rc_e LMON_daemon_getSharedKeyAndID(char *shared_key, int *id) {
   char *sk;
   char *char_id;
 
-  if ( shared_key == NULL )
-    {
-      LMON_say_msg (LMON_DAEMON_MSG_PREFIX, true,
-        "one of the arguments is NULL" );
+  if (shared_key == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "one of the arguments is NULL");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( (sk = getenv (LMON_SHRD_SEC_ENVNAME)) == NULL )
-    {
-      LMON_say_msg (LMON_DAEMON_MSG_PREFIX, true, 
-        "LMON_SHRD_SEC_ENVNAME envVar not found");
+  if ((sk = getenv(LMON_SHRD_SEC_ENVNAME)) == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "LMON_SHRD_SEC_ENVNAME envVar not found");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  sprintf (shared_key, "%s", sk);
-  if ( (char_id = getenv (LMON_SEC_CHK_ENVNAME)) == NULL )
-    {
-      LMON_say_msg (LMON_DAEMON_MSG_PREFIX, true,
-        "LMON_SEC_CHK_ENVNAME envVar not found");
+  sprintf(shared_key, "%s", sk);
+  if ((char_id = getenv(LMON_SEC_CHK_ENVNAME)) == NULL) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                 "LMON_SEC_CHK_ENVNAME envVar not found");
 
-      return LMON_EINVAL;
-    } 
+    return LMON_EINVAL;
+  }
 
-  (*id) = atoi (char_id);
+  (*id) = atoi(char_id);
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_daemon_getWhereToConnect
 /*!
     returns info on the LAUNCHMON front-end's
     listening server socket.
 */
-lmon_rc_e
-LMON_daemon_getWhereToConnect ( struct sockaddr_in *servaddr )
-{
+lmon_rc_e LMON_daemon_getWhereToConnect(struct sockaddr_in *servaddr) {
   char *portinfo;
   char *ipinfo;
 
-  if (servaddr == NULL)
-    {
-      LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-        "servaddr is NULL");
+  if (servaddr == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "servaddr is NULL");
 
-      return LMON_EBDARG;
-    }
-
-  //
-  // fetching the port number from the 
-  // LMON_FE_WHERETOCONNECT_PORT
-  // envVar which should have been sent by FE 
-  //
-  if ( (portinfo = getenv (LMON_FE_PORT_ENVNAME)) == NULL )
-    {
-      LMON_say_msg (LMON_BE_MSG_PREFIX, true, 
-        "LMON_FE_PORT_ENVNAME envVar not found");
-
-      return LMON_EINVAL;
-    }
+    return LMON_EBDARG;
+  }
 
   //
   // fetching the port number from the
   // LMON_FE_WHERETOCONNECT_PORT
   // envVar which should have been sent by FE
   //
-  if ( (ipinfo = getenv (LMON_FE_ADDR_ENVNAME)) == NULL )
-    {
-      LMON_say_msg (LMON_BE_MSG_PREFIX, true, 
-        "LMON_FE_ADDR_ENVNAME envVar not found");
+  if ((portinfo = getenv(LMON_FE_PORT_ENVNAME)) == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON_FE_PORT_ENVNAME envVar not found");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
+
+  //
+  // fetching the port number from the
+  // LMON_FE_WHERETOCONNECT_PORT
+  // envVar which should have been sent by FE
+  //
+  if ((ipinfo = getenv(LMON_FE_ADDR_ENVNAME)) == NULL) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "LMON_FE_ADDR_ENVNAME envVar not found");
+
+    return LMON_EINVAL;
+  }
 
   servaddr->sin_family = AF_INET;
-  servaddr->sin_port = htons((uint16_t) atoi(portinfo));
+  servaddr->sin_port = htons((uint16_t)atoi(portinfo));
 
   //
   // converting the text IP to the binary format
   //
-  if ( inet_pton(AF_INET, (const char *) ipinfo,
-                 &(servaddr->sin_addr)) < 0 )
-    {
-      LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-        "inet_pton failed");
+  if (inet_pton(AF_INET, (const char *)ipinfo, &(servaddr->sin_addr)) < 0) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true, "inet_pton failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
   return LMON_OK;
 }
-
 
 //! bool getPersonalityField
 /*!
     returns info on the LAUNCHMON front-end's
     listening server socket.
 */
-bool
-getPersonalityField ( std::string& pFilePath,
-                      std::string &fieldName,
-                      std::string &value )
-{
-  try
-    {
-      using namespace std;
+bool getPersonalityField(std::string &pFilePath, std::string &fieldName,
+                         std::string &value) {
+  try {
+    using namespace std;
 
-      char line[PATH_MAX];
-      ifstream ifs(pFilePath.c_str());
-      string delim = "=";
-      bool found = false;
+    char line[PATH_MAX];
+    ifstream ifs(pFilePath.c_str());
+    string delim = "=";
+    bool found = false;
 
-      //
-      // checking if pFilePath is valid 
-      //
-      if ( access(pFilePath.c_str(), R_OK) < 0)
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-            "%s doesn't exist", pFilePath.c_str());
-          return found;
-        }
-
-      //
-      // ios_base::failure exception can be thrown
-      //
-      while ( !ifs.getline (line, PATH_MAX).eof() )
-        {
-          string strLine (line);
-          string::size_type lastPos = strLine.find_first_not_of ( delim, 0 );
-          string::size_type pos = strLine.find_first_of ( delim, lastPos );
-
-          if ( pos != string::npos || lastPos != string::npos )
-            {
-              if ( fieldName == strLine.substr(lastPos, pos - lastPos) ) 
-                {
-                  lastPos = strLine.find_first_not_of(delim, pos);
-	          pos = strLine.find_first_of(delim, lastPos);
-                  value = strLine.substr(lastPos, pos - lastPos);
-                  found = true;
-                  break;
-                }
-             } 
-          }
-
-      ifs.close();
+    //
+    // checking if pFilePath is valid
+    //
+    if (access(pFilePath.c_str(), R_OK) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "%s doesn't exist",
+                   pFilePath.c_str());
       return found;
     }
-  catch (std::ios_base::failure f)
-   {
-     LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-       "ios_base::failure exception thrown "
-       "while parsing the personality file");
-     return false;
-   }
-}
 
+    //
+    // ios_base::failure exception can be thrown
+    //
+    while (!ifs.getline(line, PATH_MAX).eof()) {
+      string strLine(line);
+      string::size_type lastPos = strLine.find_first_not_of(delim, 0);
+      string::size_type pos = strLine.find_first_of(delim, lastPos);
+
+      if (pos != string::npos || lastPos != string::npos) {
+        if (fieldName == strLine.substr(lastPos, pos - lastPos)) {
+          lastPos = strLine.find_first_not_of(delim, pos);
+          pos = strLine.find_first_of(delim, lastPos);
+          value = strLine.substr(lastPos, pos - lastPos);
+          found = true;
+          break;
+        }
+      }
+    }
+
+    ifs.close();
+    return found;
+  } catch (std::ios_base::failure f) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "ios_base::failure exception thrown "
+                 "while parsing the personality file");
+    return false;
+  }
+}
 
 //! bool resolvHNAlias
 /*!
-    Resolves an alias to an IP using the hosts file 
+    Resolves an alias to an IP using the hosts file
     whose path is given by the first argument.
     This function can throw ios_base::failure
 */
-bool
-resolvHNAlias ( std::string& hostsFilePath, std::string &alias, std::string &IP)
-{
-  try
-    {
-      using namespace std;
-      char line[PATH_MAX];
-      ifstream ifs(hostsFilePath.c_str());
-      string delim = "\t ";
-      bool found = false;
+bool resolvHNAlias(std::string &hostsFilePath, std::string &alias,
+                   std::string &IP) {
+  try {
+    using namespace std;
+    char line[PATH_MAX];
+    ifstream ifs(hostsFilePath.c_str());
+    string delim = "\t ";
+    bool found = false;
 
-      //
-      // checking if hostsFilePath is valid 
-      //
-      if ( access(hostsFilePath.c_str(), R_OK) < 0)
-        {
-          LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-            "%s doesn't exist", hostsFilePath.c_str()); 
+    //
+    // checking if hostsFilePath is valid
+    //
+    if (access(hostsFilePath.c_str(), R_OK) < 0) {
+      LMON_say_msg(LMON_BE_MSG_PREFIX, true, "%s doesn't exist",
+                   hostsFilePath.c_str());
 
-          return found;
-        }
-
-      //
-      // ios_base::failure exception can be thrown
-      //
-      while (!ifs.getline (line, PATH_MAX).eof())
-        {
-          string strLine (line);
-          string::size_type lastPos = strLine.find_first_not_of(delim, 0);
-
-          //
-          // assuming a comment always occupies whole lines
-          //
-          //
-          if (strLine[lastPos] == '#')
-            continue;
-
-          string::size_type pos = strLine.find_first_of(delim, lastPos);
-          vector<string> tokens;
-          vector<string>::const_iterator iter;
-
-          while (pos != string::npos || lastPos != string::npos)
-            {
-              tokens.push_back(strLine.substr(lastPos, pos - lastPos));
-              lastPos = strLine.find_first_not_of(delim, pos);
-              // Find next "non-delimiter"
-              pos = strLine.find_first_of(delim, lastPos);
-              // Found a token, add it to the vector.
-              //tokens.push_back(strLine.substr(lastPos, pos - lastPos));
-            }
-
-          for (iter = tokens.begin(); iter != tokens.end(); iter++)
-            {
-              if (*iter == alias)
-                {
-                  IP = tokens[0];
-                  found = true;
-                  break;
-                }
-            }
-        }
-
-      ifs.close();
       return found;
     }
-  catch (std::ios_base::failure f)
-   {
-     LMON_say_msg (LMON_BE_MSG_PREFIX, true,
-       "ios_base::failure exception thrown "
-       "while parsing lines in the hosts file.");
 
-     return false;
-   }
+    //
+    // ios_base::failure exception can be thrown
+    //
+    while (!ifs.getline(line, PATH_MAX).eof()) {
+      string strLine(line);
+      string::size_type lastPos = strLine.find_first_not_of(delim, 0);
+
+      //
+      // assuming a comment always occupies whole lines
+      //
+      //
+      if (strLine[lastPos] == '#') continue;
+
+      string::size_type pos = strLine.find_first_of(delim, lastPos);
+      vector<string> tokens;
+      vector<string>::const_iterator iter;
+
+      while (pos != string::npos || lastPos != string::npos) {
+        tokens.push_back(strLine.substr(lastPos, pos - lastPos));
+        lastPos = strLine.find_first_not_of(delim, pos);
+        // Find next "non-delimiter"
+        pos = strLine.find_first_of(delim, lastPos);
+        // Found a token, add it to the vector.
+        // tokens.push_back(strLine.substr(lastPos, pos - lastPos));
+      }
+
+      for (iter = tokens.begin(); iter != tokens.end(); iter++) {
+        if (*iter == alias) {
+          IP = tokens[0];
+          found = true;
+          break;
+        }
+      }
+    }
+
+    ifs.close();
+    return found;
+  } catch (std::ios_base::failure f) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "ios_base::failure exception thrown "
+                 "while parsing lines in the hosts file.");
+
+    return false;
+  }
 }
-
 
 //! lmon_rc_e LMON_daemon_gethostname
 /*!
 
 */
-lmon_rc_e
-LMON_daemon_gethostname(bool bgion, char *my_hostname, int hlen, char *my_ip, int ilen, std::vector<std::string>& aliases)
-{
-  memset ( my_hostname, 0, hlen );
-  memset ( my_ip, 0, ilen );
+lmon_rc_e LMON_daemon_gethostname(bool bgion, char *my_hostname, int hlen,
+                                  char *my_ip, int ilen,
+                                  std::vector<std::string> &aliases) {
+  memset(my_hostname, 0, hlen);
+  memset(my_ip, 0, ilen);
 
-  if ( gethostname ( my_hostname, hlen ) < 0 )
-    {
-      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
-        "gethostname failed");
+  if (gethostname(my_hostname, hlen) < 0) {
+    LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true, "gethostname failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
   struct hostent *hent = gethostbyname(my_hostname);
-  if (hent == NULL)
-    {
-      if (bgion)
-        {
-          std::string resIP;
-          std::string pFile("/proc/personality.sh");
-          std::string fieldStr("BG_IP");
+  if (hent == NULL) {
+    if (bgion) {
+      std::string resIP;
+      std::string pFile("/proc/personality.sh");
+      std::string fieldStr("BG_IP");
 
-          LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, false,
-            "BES: this machine does not know how to resolve %s into an IP",
-            my_hostname);
-          LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, false,
-            "BES: parsing /proc/personality.sh to try to resolve");
+      LMON_say_msg(
+          LMON_DAEMON_MSG_PREFIX, false,
+          "BES: this machine does not know how to resolve %s into an IP",
+          my_hostname);
+      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, false,
+                   "BES: parsing /proc/personality.sh to try to resolve");
 
-          if (!getPersonalityField (pFile, fieldStr, resIP))
-            {
-              LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-                "BES: getPersonalityField also failed to resolve %s through %s",
-                my_hostname, fieldStr.c_str());
+      if (!getPersonalityField(pFile, fieldStr, resIP)) {
+        LMON_say_msg(
+            LMON_DAEMON_MSG_PREFIX, true,
+            "BES: getPersonalityField also failed to resolve %s through %s",
+            my_hostname, fieldStr.c_str());
 
-              return LMON_ESYS;
-            }
-          snprintf(my_ip, ilen, "%s", resIP.c_str());
-          snprintf(my_hostname, hlen, "%s", resIP.c_str());
-        }
-      else 
-        {
-          LMON_say_msg ( LMON_DAEMON_MSG_PREFIX, true,
-                         "BES: gethostbyname returned NULL.");
-          return LMON_ESYS;
-        }
+        return LMON_ESYS;
+      }
+      snprintf(my_ip, ilen, "%s", resIP.c_str());
+      snprintf(my_hostname, hlen, "%s", resIP.c_str());
+    } else {
+      LMON_say_msg(LMON_DAEMON_MSG_PREFIX, true,
+                   "BES: gethostbyname returned NULL.");
+      return LMON_ESYS;
     }
-  else // hent returns valid data 
-    {
-      int i=0;
-      std::string my_hostnameStr(my_hostname);
-      std::string notAvail("na");
-      std::string my_ipStr(notAvail);
+  } else  // hent returns valid data
+  {
+    int i = 0;
+    std::string my_hostnameStr(my_hostname);
+    std::string notAvail("na");
+    std::string my_ipStr(notAvail);
 
-      aliases.push_back(my_hostnameStr);
-      if (inet_ntop(hent->h_addrtype, hent->h_addr, my_ip, ilen) != NULL) 
-        {
-          my_ipStr = my_ip; 
-          aliases.push_back(my_ipStr);
+    aliases.push_back(my_hostnameStr);
+    if (inet_ntop(hent->h_addrtype, hent->h_addr, my_ip, ilen) != NULL) {
+      my_ipStr = my_ip;
+      aliases.push_back(my_ipStr);
+    }
+
+    std::string h_nameStr(notAvail);
+    if ((h_nameStr = hent->h_name) != my_hostnameStr) {
+      aliases.push_back(h_nameStr);
+    }
+
+    for (i = 0; hent->h_aliases[i] != NULL; i++) {
+      std::string al(hent->h_aliases[i]);
+      if ((al != my_hostnameStr) && (al != h_nameStr)) {
+        aliases.push_back(al);
+      }
+    }
+    for (i = 0; hent->h_addr_list[i] != NULL; i++) {
+      char tmp_ip[LMON_DAEMON_HN_MAX];
+      if (inet_ntop(hent->h_addrtype, hent->h_addr_list[i], tmp_ip,
+                    LMON_DAEMON_HN_MAX) != NULL) {
+        std::string al_ip(tmp_ip);
+        if (al_ip != my_ipStr) {
+          aliases.push_back(al_ip);
         }
-
-      std::string h_nameStr(notAvail); 
-      if ((h_nameStr = hent->h_name) != my_hostnameStr)
-        {
-          aliases.push_back(h_nameStr);
-        }
-
-      for (i=0; hent->h_aliases[i] != NULL; i++)
-        {
-          std::string al(hent->h_aliases[i]);
-          if ((al != my_hostnameStr) && (al != h_nameStr))
-            {
-              aliases.push_back(al);
-             }
-         }
-       for (i=0; hent->h_addr_list[i] != NULL; i++)
-         {
-           char tmp_ip[LMON_DAEMON_HN_MAX];
-           if (inet_ntop(hent->h_addrtype, hent->h_addr_list[i], 
-                          tmp_ip, LMON_DAEMON_HN_MAX) != NULL)
-             {
-               std::string al_ip(tmp_ip);
-               if (al_ip != my_ipStr)
-                 {
-                   aliases.push_back(al_ip);
-                 }
-             }
-         }
+      }
+    }
 #if LMON_SGI_HOSTNAMES
-      if ((h_nameStr = hent->h_name) != my_hostnameStr)
-        {
-          size_t dot_pos = h_nameStr.find(".");
-          if (dot_pos < h_nameStr.length())
-            {
-              std::string h_nameStr_ib0, h_nameStr_ib1;
+    if ((h_nameStr = hent->h_name) != my_hostnameStr) {
+      size_t dot_pos = h_nameStr.find(".");
+      if (dot_pos < h_nameStr.length()) {
+        std::string h_nameStr_ib0, h_nameStr_ib1;
 
-              h_nameStr_ib0 = h_nameStr.substr(0, dot_pos);
-              h_nameStr_ib0 += ".ib0";
-              h_nameStr_ib0 += h_nameStr.substr(dot_pos);
-              aliases.push_back(h_nameStr_ib0);
+        h_nameStr_ib0 = h_nameStr.substr(0, dot_pos);
+        h_nameStr_ib0 += ".ib0";
+        h_nameStr_ib0 += h_nameStr.substr(dot_pos);
+        aliases.push_back(h_nameStr_ib0);
 
-              h_nameStr_ib1 = h_nameStr.substr(0, dot_pos);
-              h_nameStr_ib1 += ".ib1";
-              h_nameStr_ib1 += h_nameStr.substr(dot_pos);
-              aliases.push_back(h_nameStr_ib1);
-            }
-        }
+        h_nameStr_ib1 = h_nameStr.substr(0, dot_pos);
+        h_nameStr_ib1 += ".ib1";
+        h_nameStr_ib1 += h_nameStr.substr(dot_pos);
+        aliases.push_back(h_nameStr_ib1);
+      }
+    }
 #endif
-     }
+  }
 
   return LMON_OK;
 }
 
-bool is_bluegene_ion()
-{
+bool is_bluegene_ion() {
   bool rc = false;
-  if ((access ("/proc/personality.sh", R_OK) != -1)
-      || (access ("/jobs/tools/protocol", R_OK) != -1))
-    {
-      rc = true;
-    }
+  if ((access("/proc/personality.sh", R_OK) != -1) ||
+      (access("/jobs/tools/protocol", R_OK) != -1)) {
+    rc = true;
+  }
 
   return rc;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_daemon_internal.hxx
+++ b/launchmon/src/linux/lmon_api/lmon_daemon_internal.hxx
@@ -1,36 +1,38 @@
 /*
- * $Header: dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008-2010, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Aug  02 2010 DHA: Changed the file name to lmon_daemon_internal.hxx
- *                          from lmon_be_internal.hxx to cover middleware support
+ *                          from lmon_be_internal.hxx to cover middleware
+ *                          support
  *        Feb  05 2010 DHA: Changed the LMON_be_internal_init prototype and
  *                          augmented the per_be_data_t data structure to
- *                          support registering the local host name into 
+ *                          support registering the local host name into
  *                          lower layers if needed.
  *        Feb  09 2008 DHA: Added LLNS Copyright
  *        Jul  25 2007 DHA: Data structure change to deal with
@@ -41,24 +43,26 @@
 #ifndef LMON_DAEMON_INTERNAL_HXX
 #define LMON_DAEMON_INTERNAL_HXX 1
 
-#include "sdbg_std.hxx"
 #include <string>
 #include "sdbg_base_spawner.hxx"
 #include "sdbg_rsh_spawner.hxx"
+#include "sdbg_std.hxx"
 //#include "sdbg_rm_spawner.hxx"
-#include "lmon_api/lmon_lmonp_msg.h"
 #include "lmon_api/lmon_coloc_spawner.hxx"
+#include "lmon_api/lmon_lmonp_msg.h"
 
-#define LMON_DAEMON_HN_MAX       108
-#define LMON_DAEMON_MASTER       0
-#define LMON_INIT                -1
-#define LMON_BE_MSG_PREFIX       "<LMON BE API>"
-#define LMON_MW_MSG_PREFIX       "<LMON MW API>"
-#define LMON_DAEMON_MSG_PREFIX   "<LMON DAEMON INTERNAL>"
-#define BEGIN_MASTER_ONLY(pdmon) if ( pdmon.daemon_data.myrank == LMON_DAEMON_MASTER ) {
-#define END_MASTER_ONLY          }
-#define BEGIN_SLAVE_ONLY(pdmon)  if ( pdmon.daemon_data.myrank != LMON_DAEMON_MASTER ) {
-#define END_SLAVE_ONLY           }
+#define LMON_DAEMON_HN_MAX 108
+#define LMON_DAEMON_MASTER 0
+#define LMON_INIT -1
+#define LMON_BE_MSG_PREFIX "<LMON BE API>"
+#define LMON_MW_MSG_PREFIX "<LMON MW API>"
+#define LMON_DAEMON_MSG_PREFIX "<LMON DAEMON INTERNAL>"
+#define BEGIN_MASTER_ONLY(pdmon) \
+  if (pdmon.daemon_data.myrank == LMON_DAEMON_MASTER) {
+#define END_MASTER_ONLY }
+#define BEGIN_SLAVE_ONLY(pdmon) \
+  if (pdmon.daemon_data.myrank != LMON_DAEMON_MASTER) {
+#define END_SLAVE_ONLY }
 
 typedef enum _tracingmode_e {
   trm_attach = 0,
@@ -79,21 +83,21 @@ typedef struct _per_daemon_data_t {
   int width;
 
   /*
-   * user pack function 
+   * user pack function
    */
-  int (*pack) (void*,void*,int,int*); 
+  int (*pack)(void *, void *, int, int *);
 
   /*
-   * user unpack function 
+   * user unpack function
    */
-  int (*unpack) (void*,int, void*);
+  int (*unpack)(void *, int, void *);
 
   /*
    * my_hostname and my_ip
    */
   char my_hostname[LMON_DAEMON_HN_MAX];
   char my_ip[LMON_DAEMON_HN_MAX];
-  std::vector<std::string> host_aliases; 
+  std::vector<std::string> host_aliases;
 
   /*
    * for mw colocation assistant
@@ -102,17 +106,17 @@ typedef struct _per_daemon_data_t {
 
 } per_daemon_data_t;
 
-
 typedef struct _per_be_data_t {
   /*
-   * per Daemon data 
+   * per Daemon data
    */
   per_daemon_data_t daemon_data;
 
   /*
-   * is this launch case or attach case? 
+   * is this launch case or attach case?
    */
-  int is_launch; /*  1: launch, 2: launch and dontstop, 0: attach, 3: attach and stop */
+  int is_launch; /*  1: launch, 2: launch and dontstop, 0: attach, 3: attach and
+                    stop */
 
   /*
    * what rmtype is this
@@ -120,17 +124,16 @@ typedef struct _per_be_data_t {
   rm_catalogue_e rmtype_instance;
 
   /*
-   * this points to the raw proctab message 
+   * this points to the raw proctab message
    */
-  lmonp_t *proctab_msg; 
+  lmonp_t *proctab_msg;
 
   /*
-   * the size of proctab_msg including its lmon_payload_length 
+   * the size of proctab_msg including its lmon_payload_length
    */
-  int proctab_msg_size; /* to hold the size of proctab_msg */  
+  int proctab_msg_size; /* to hold the size of proctab_msg */
 
 } per_be_data_t;
-
 
 typedef struct _per_mw_data_t {
   /*
@@ -140,42 +143,47 @@ typedef struct _per_mw_data_t {
 
 } per_mw_data_t;
 
-
 extern int LMON_daemon_return_ver();
 
-extern lmon_rc_e LMON_daemon_getSharedKeyAndID ( char *shared_key, int *id );
-extern lmon_rc_e LMON_daemon_internal_tester_init ( per_be_data_t *d );
-extern lmon_rc_e LMON_daemon_internal_tester_getBeData ( per_be_data_t **d );
-extern lmon_rc_e LMON_daemon_internal_init( int *argc, char ***argv,
-                                            char *myhn, int is_be);
+extern lmon_rc_e LMON_daemon_getSharedKeyAndID(char *shared_key, int *id);
+extern lmon_rc_e LMON_daemon_internal_tester_init(per_be_data_t *d);
+extern lmon_rc_e LMON_daemon_internal_tester_getBeData(per_be_data_t **d);
+extern lmon_rc_e LMON_daemon_internal_init(int *argc, char ***argv, char *myhn,
+                                           int is_be);
 
-extern lmon_rc_e LMON_daemon_internal_getConnFd( int *fd );
-extern lmon_rc_e LMON_daemon_internal_getMyRank( int *rank );
-extern lmon_rc_e LMON_daemon_internal_getSize( int *size );
+extern lmon_rc_e LMON_daemon_internal_getConnFd(int *fd);
+extern lmon_rc_e LMON_daemon_internal_getMyRank(int *rank);
+extern lmon_rc_e LMON_daemon_internal_getSize(int *size);
 extern lmon_rc_e LMON_daemon_internal_barrier();
-extern lmon_rc_e LMON_daemon_internal_broadcast( void *buf, int numbyte );
-extern lmon_rc_e LMON_daemon_internal_gather( void *sendbuf,
-                     int numbyte_per_elem,
-                     void* recvbuf );
+extern lmon_rc_e LMON_daemon_internal_broadcast(void *buf, int numbyte);
+extern lmon_rc_e LMON_daemon_internal_gather(void *sendbuf,
+                                             int numbyte_per_elem,
+                                             void *recvbuf);
 
-extern lmon_rc_e LMON_daemon_internal_scatter( void *sendbuf,
-                     int numbyte_per_element,
-                     void* recvbuf );
+extern lmon_rc_e LMON_daemon_internal_scatter(void *sendbuf,
+                                              int numbyte_per_element,
+                                              void *recvbuf);
 
 extern lmon_rc_e LMON_daemon_internal_finalize(int is_be);
-extern lmon_rc_e LMON_daemon_getWhereToConnect( struct sockaddr_in *servaddr );
-extern lmon_rc_e LMON_daemon_gethostname(bool bgion,
-                     char *my_hostname, int hlen, char *my_ip, int ilen, std::vector<std::string> &aliases);
+extern lmon_rc_e LMON_daemon_getWhereToConnect(struct sockaddr_in *servaddr);
+extern lmon_rc_e LMON_daemon_gethostname(bool bgion, char *my_hostname,
+                                         int hlen, char *my_ip, int ilen,
+                                         std::vector<std::string> &aliases);
 
-extern lmon_rc_e LMON_daemon_enable_verbose(const char *vdir, 
-                     const char *local_hostname, int is_be);
+extern lmon_rc_e LMON_daemon_enable_verbose(const char *vdir,
+                                            const char *local_hostname,
+                                            int is_be);
 
-extern bool getPersonalityField(std::string &pFilePath,
-                     std::string &fieldName, std::string &value);
+extern bool getPersonalityField(std::string &pFilePath, std::string &fieldName,
+                                std::string &value);
 
-extern bool resolvHNAlias ( std::string &hostsFilePath,
-                     std::string &alias, std::string &IP);
+extern bool resolvHNAlias(std::string &hostsFilePath, std::string &alias,
+                          std::string &IP);
 
 extern bool is_bluegene_ion();
 
-#endif // LMON_DAEMON_INTERNAL_HXX
+#endif  // LMON_DAEMON_INTERNAL_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_fe.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_fe.cxx
@@ -1,27 +1,28 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_fe.cxx,v 1.14.2.13 2008/03/07 02:22:54 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -29,10 +30,10 @@
  *        Apr 01 2015 ADG: Added Cray CTI support.
  *        Apr 22 2014 DHA: Applied a patch to store RM args/opts into
  *                         a std::list object instead of a std:string string.
- *        Apr 15 2014 DHA: Integrate COBO secure handshake 
+ *        Apr 15 2014 DHA: Integrate COBO secure handshake
  *        Jan 09 2013 DHA: Remove verbosity ref to the deprecated
  *                         thread tracer module.
- *        May 31 2012 DHA: Merged with the middleware support 
+ *        May 31 2012 DHA: Merged with the middleware support
  *                         from the 0.8-middleware-support branch.
  *        May 30 2012 DHA: (ID: 3530680) Added better debug info.
  *        Jan 17 2011 JDG: Bug fix in LMON_fe_regPackForFeToMw, variable typo.
@@ -42,85 +43,88 @@
  *        Jun 28 2010 DHA: Added LMON_fe_getRMInfo support
  *        Apr 27 2010 DHA: Added MEASURE_TRACING_COST support.
  *        Feb 04 2010 DHA: Added LMON_FE_HOSTNAME_TO_CONN support
- *        Dec 23 2009 DHA: Added explict config.h inclusion 
+ *        Dec 23 2009 DHA: Added explict config.h inclusion
  *        Dec 16 2009 DHA: COBO support
- *        Dec 11 2009 DHA: BE hostname list generation in preparation for 
+ *        Dec 11 2009 DHA: BE hostname list generation in preparation for
  *                         scalable PMGR Collective bootstrapping
- *        Jun 01 2009 DHA: Changed LMON_fe_regStatusCB to be aware of 
+ *        Jun 01 2009 DHA: Changed LMON_fe_regStatusCB to be aware of
  *                         a target session.
- *        May 19 2009 DHA: Changed static int (*statusCB) (void *status) 
+ *        May 19 2009 DHA: Changed static int (*statusCB) (void *status)
  *                         to static int (*statusCB) (int *status):
  *                         the argument type for the status callback function
- *                         is now a pointer to an interger. 
- *        May 19 2009 DHA: Added LMON_fe_regErrorCB ( int (*errorCB)(char *msg) )
+ *                         is now a pointer to an interger.
+ *        May 19 2009 DHA: Added LMON_fe_regErrorCB ( int (*errorCB)(char *msg)
+ *)
  *                         support.
  *        Mar 13 2009 DHA: Added large nTasks support
  *        Mar 11 2009 DHA: Bug fix in the pthread_cond_timedwait
- *                         return code checking logic for launchmon engine 
+ *                         return code checking logic for launchmon engine
  *                         connection.
  *                         Added ENVCMD, SSHCMD, and TVCMD.
  *                         Added comm_pair_e for readability.
  *                         which the new configure check would detect.
- *        Mar 04 2009 DHA: Added BlueGene/P support. 
- *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN 
+ *        Mar 04 2009 DHA: Added BlueGene/P support.
+ *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN
  *                         to genericize BlueGene Support
- *        Sep 24 2008 DHA: Enforced the error handling semantics 
+ *        Sep 24 2008 DHA: Enforced the error handling semantics
  *                         defined in README.ERROR_HANDLING.
- *        Mar 17 2008 DHA: Added PMGR Collective support 
- *        Mar 06 2008 DHA: Added timeout for daemon control 
- *                         interfaces (detach, kill, and shutdown) 
- *        Mar 05 2008 DHA: Added more engine timeout support (fe-engine, fe-be); 
+ *        Mar 17 2008 DHA: Added PMGR Collective support
+ *        Mar 06 2008 DHA: Added timeout for daemon control
+ *                         interfaces (detach, kill, and shutdown)
+ *        Mar 05 2008 DHA: Added more engine timeout support (fe-engine, fe-be);
  *                         added a timedaccept call into lmon_lmonp_msg.cxx
  *                         and added the O_NONBLOCK flag to part of listening
- *                         sockets to prevent any indefinte hang. 
- *        Mar 05 2008 DHA: Added better verbosity support for remote use 
+ *                         sockets to prevent any indefinte hang.
+ *        Mar 05 2008 DHA: Added better verbosity support for remote use
  *                         of launchmon engine
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Dec 07 2007 DHA: Added support for secure connection between
  *                         frontend and backend daemons.
  *                         The frontend first sends the shared key
- *                         random session ID, unencrypted, to the 
- *                         daemons via the environment variables. 
+ *                         random session ID, unencrypted, to the
+ *                         daemons via the environment variables.
  *                         (This is secure since we rely on the RM
  *                         to do this job.)
- *                         Then, the master daemons encrypts the 
+ *                         Then, the master daemons encrypts the
  *                         random session ID using the shared key
- *                         and send it back to the front-end. 
+ *                         and send it back to the front-end.
  *                         The received session ID gets decrypted and
- *                         compared with the original session ID. 
+ *                         compared with the original session ID.
  *                         I'm currently using libgcrypt's blowfish
  *                         encryption algorithm.
- *                         The only way this can be hijacked is 
- *                         when the target RM does not provide 
- *                         a secure mechanism in propagating 
+ *                         The only way this can be hijacked is
+ *                         when the target RM does not provide
+ *                         a secure mechanism in propagating
  *                         the environment variables to the daemons.
- *        Dec 04 2007 DHA: More rigorous sessionHandle validity check 
+ *        Dec 04 2007 DHA: More rigorous sessionHandle validity check
  *        Sep 24 2007 DHA: Change FEBESessionHandle to sessionHandle
  *                         in anticipation for adding middleware API support
- *                         Along the same line, fe_shutdownBe changed to 
+ *                         Along the same line, fe_shutdownBe changed to
  *                         fe_shutdownDaemons.
  *                         Expanding LMON_fe_sendUsrData into
  *                         LMON_fe_sendUsrDataBe and LMON_fe_sendUsrDataMw
- *                         vice versa for LMON_fe_recvUsrDataBe and 
+ *                         vice versa for LMON_fe_recvUsrDataBe and
  *                         LMON_fe_recvUsrDataMw
  *        Aug 13 2007 DHA: LMON_fe_sendUsrData added
- *        Aug 10 2007 DHA: LMON_fe_detach added 
- *        Jul 25 2007 DHA: Change the lmonp protocol to better handle the flowing 
- *                         of proctab info 
- *        Mar 09 2007 DHA: Low-quality implementation to get the correct 
- *                         behavior for FE to BE proctab packing. Now it uses 
- *                         hostname reference array FE gets from the master BE daemon. 
+ *        Aug 10 2007 DHA: LMON_fe_detach added
+ *        Jul 25 2007 DHA: Change the lmonp protocol to better handle the
+ *                         flowing of proctab info
+ *        Mar 09 2007 DHA: Low-quality implementation to get the correct
+ *                         behavior for FE to BE proctab packing. Now it uses
+ *                         hostname reference array FE gets from the master BE
+ *                         daemon.
  *                         This portion of the code needs to be optimized.
- *        Dec 29 2006 DHA: 1. LMON_freeDaemonEnvList function prototype now takes 
- *                         lmon_daemon_env_t** as function argument data type. 
+ *        Dec 29 2006 DHA: 1. LMON_freeDaemonEnvList function prototype now
+ *                         takes lmon_daemon_env_t** as function argument
+ *                         data type.
  *                         It used to be lmon_daemon_env_t*. Along with function
- *                         definition changes, it allows NULL assignment to the 
+ *                         definition changes, it allows NULL assignment to the
  *                         passed argument effective on function exit. Bug fix
- *                         on a segfault violation from 
- *                         test.basic_multisession_launch.tst test case. 
- *                         2.  LMON_destroy_sess calls LMON_init_sess at the end 
+ *                         on a segfault violation from
+ *                         test.basic_multisession_launch.tst test case.
+ *                         2.  LMON_destroy_sess calls LMON_init_sess at the end
  *                         so that cleaned session descriptor can be reused. Bug
- *                         fix for a segfault violation from 
+ *                         fix for a segfault violation from
  *                         test.stress_sess_descriptor.sh test case.
  *        Dec 27 2006 DHA: Polishing up the data types
  *        Dec 22 2006 DHA: proctab communication sequence done
@@ -136,34 +140,34 @@
 #error This source file requires a LINUX OS
 #endif
 
-#include <cstdio>
-#include <ctime>
-#include <map>
-#include <vector>
-#include <list>
-#include <cstdlib>
-#include <string.h>
-#include <unistd.h>
-#include <netdb.h>
-#include <pthread.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
-#include <netinet/in.h>
-#include <signal.h>
-#include <time.h>
-#include "gcrypt.h"
 #include <fcntl.h>
 #include <limits.h>
-#include <iostream>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
+#include <list>
+#include <map>
 #include <sstream>
+#include <vector>
+#include "gcrypt.h"
 
-#include "sdbg_self_trace.hxx"
+#include "sdbg_base_spawner.hxx"
 #include "sdbg_opt.hxx"
 #include "sdbg_rm_map.hxx"
-#include "sdbg_base_spawner.hxx"
+#include "sdbg_self_trace.hxx"
 //
 // spawners to support Middleware
 //
@@ -172,9 +176,9 @@
 #include "lmon_api/lmon_coloc_spawner.hxx"
 #include "lmon_api/lmon_say_msg.hxx"
 
-#include "lmon_api/lmon_proctab.h"
-#include "lmon_api/lmon_lmonp_msg.h"
 #include "lmon_api/lmon_fe.h"
+#include "lmon_api/lmon_lmonp_msg.h"
+#include "lmon_api/lmon_proctab.h"
 
 #if COBO_BASED
 extern "C" {
@@ -184,22 +188,21 @@ extern "C" {
 #endif
 
 #ifdef DEBUG_SESSION_DESC
-const int   MAX_LMON_SESSION    = 3;
-#else /* DEBUG_SESSION_DESC */
+const int MAX_LMON_SESSION = 3;
+#else  /* DEBUG_SESSION_DESC */
 //
 // The default number of session descriptors is 100
 //
-const int   MAX_LMON_SESSION    = 100;
+const int MAX_LMON_SESSION = 100;
 #endif /* DEBUG_SESSION_DESC */
 
-const int   MAX_LMON_STRING     = 4096;
-const int   LMON_INIT           = -1;
-const int   DFLT_FE_ENGINE_TOUT = 120;
-const int   DFLT_FE_BE_TOUT     = 120;
-const int   DFLT_FE_MW_TOUT     = 120;
-const int   MAX_TIMEOUT         = 6000;
-const char *LMON_FE_MSG_PREFIX  = "<LMON FE API>";
-
+const int MAX_LMON_STRING = 4096;
+const int LMON_INIT = -1;
+const int DFLT_FE_ENGINE_TOUT = 120;
+const int DFLT_FE_BE_TOUT = 120;
+const int DFLT_FE_MW_TOUT = 120;
+const int MAX_TIMEOUT = 6000;
+const char *LMON_FE_MSG_PREFIX = "<LMON FE API>";
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -208,14 +211,10 @@ const char *LMON_FE_MSG_PREFIX  = "<LMON FE API>";
 //
 //
 
-
-typedef enum _mboolean_e {
-  LMON_TRUE,
-  LMON_FALSE 
-} boolean_e;
+typedef enum _mboolean_e { LMON_TRUE, LMON_FALSE } boolean_e;
 
 //
-// Don't change the integer value for the 
+// Don't change the integer value for the
 // following enumerator.
 //
 typedef enum _comm_pair_e {
@@ -227,77 +226,72 @@ const int conn_size = 3;
 
 typedef int lmon_reshandle_t;
 
-class lexGraphCmp
-{
-public:
-  bool operator() (const std::string &s1, const std::string &s2)
-    {
-      return ( s1 < s2 );
-    }
+class lexGraphCmp {
+ public:
+  bool operator()(const std::string &s1, const std::string &s2) {
+    return (s1 < s2);
+  }
 };
 
 //! lmon_session_comm_desc_t
-/*!  
+/*!
   This data type describes per-session resources
-  - servAddr: 
+  - servAddr:
             The TCP server socket FE listens in on
-  - ipInfo:   
+  - ipInfo:
             The string info on the server socket
-  - sessionListenSockFd: 
+  - sessionListenSockFd:
             The actual file descriptor for the server socket
   - sessionAcceptSockFd:
             The file descriptor for "accept"
-    
+
 */
 typedef struct _lmon_session_comm_desc_t {
-  
-  /* 
-   * listening server address 
+  /*
+   * listening server address
    */
   struct sockaddr_in servAddr;
 
-  /* 
-   * additional info for the server socket 
+  /*
+   * additional info for the server socket
    */
   char ipInfo[MAX_LMON_STRING];
 
-  /* 
+  /*
    * listening server socket descriptor
    */
   int sessionListenSockFd;
 
-  /* 
-   * accept socket descriptor 
+  /*
+   * accept socket descriptor
    */
   int sessionAcceptSockFd;
 
-  /* 
-   * # of daemons 
+  /*
+   * # of daemons
    */
   int nDaemons;
 
-  /* 
-   * file descriptors that aid in setting ICCL 
+  /*
+   * file descriptors that aid in setting ICCL
    */
   int ICCL_assist_fds[LMON_MAX_NDAEMONS];
 
 } lmon_session_comm_desc_t;
 
-
 //! lmon_thr_desc_t
-/*!  
+/*!
     This data type describes per-thread resources
-  
+
     FE API spawns a launchmon engine process and a pthread that
     handles communcation with the launchmon process. This
     data type describes the resources needed for each
     of those threads.
-    
+
 */
 typedef struct _lmon_thr_desc_t {
-
-  /* 
-   * thread id that monitors a forked launchmon 
+  /*
+   * thread id that monitors a forked launchmon
    */
   pthread_t fetofeMonitoringThr;
   pthread_cond_t condVar;
@@ -305,105 +299,88 @@ typedef struct _lmon_thr_desc_t {
 
 } lmon_thr_desc_t;
 
-
 //! lmon_session_desc_t
 /*!
-  huge data type to describe per-session resources 
+  huge data type to describe per-session resources
 
 */
-typedef struct _lmon_session_desc_t { 
-  
-  /* 
-   * boolean to indicate this descriptor slot is taken 
+typedef struct _lmon_session_desc_t {
+  /*
+   * boolean to indicate this descriptor slot is taken
    */
   boolean_e registered;
 
-
-  /* 
-   * boolean to indicate tool backend daemons have spawned 
+  /*
+   * boolean to indicate tool backend daemons have spawned
    */
   boolean_e spawned;
 
-
-  /* 
-   * boolean to indicate middleware daemons have spawned 
+  /*
+   * boolean to indicate middleware daemons have spawned
    */
   boolean_e mw_spawned;
 
-
-  /* 
-   * indicator whether the launchmon engine detached from 
-   * the target or not 
+  /*
+   * indicator whether the launchmon engine detached from
+   * the target or not
    */
   boolean_e detached;
 
-
-  /* 
-   * indicator whether the launchmon engine killed 
-   * the target or not 
+  /*
+   * indicator whether the launchmon engine killed
+   * the target or not
    */
   boolean_e killed;
-
 
   /*
    * the pid of the launchmon engine process
    */
   pid_t le_pid;
 
-
   /*
-   * the pid of the job launcher process 
+   * the pid of the job launcher process
    */
   pid_t rm_launcher_pid;
-
 
   /*
    * the RM type that the launchmon engine is handling
    */
   lmon_rm_info_t rm_info;
 
-
   /*
    * cipher handler
    */
   gcry_cipher_hd_t cipher_hndl;
-
 
   /*
    * the 128 bit shared key
    */
   char shared_key[LMON_KEY_LENGTH];
 
-
   /*
    * random ID
    */
   int32_t randomID;
 
-
-  /* 
+  /*
    * user pack function for a message from BE
    */
-  int (*pack) (void*,void*,int,int*); 
+  int (*pack)(void *, void *, int, int *);
 
-
-  /* 
+  /*
    * user unpack function for a message from BE
    */
-  int (*unpack) (void*,int, void*); 
+  int (*unpack)(void *, int, void *);
 
-
-  /* 
+  /*
    * user pack function for a message to MW
    */
-  int (*mw_pack) (void*,void*,int,int*); 
+  int (*mw_pack)(void *, void *, int, int *);
 
-
-  /* 
+  /*
    * user unpack function for a message from MW
    */
-  int (*mw_unpack) (void*,int, void*); 
- 
+  int (*mw_unpack)(void *, int, void *);
 
   /*
    * communication descriptors
@@ -414,79 +391,68 @@ typedef struct _lmon_session_desc_t {
    */
   lmon_session_comm_desc_t commDesc[conn_size];
 
-
   /*
    * watchdog thread descriptors
    */
   lmon_thr_desc_t watchdogThr;
 
-
-  /* 
-   * resource handle such as "totalview_jobid": type is int for now 
+  /*
+   * resource handle such as "totalview_jobid": type is int for now
    */
   lmon_reshandle_t resourceHandle;
 
- 
-  /* 
-   * envVar list to write into remote systems 
+  /*
+   * envVar list to write into remote systems
    *
    * daemonEnvList[0]: for backends
    * daemonEnvList[1]: for middleware
    */
-  lmon_daemon_env_t* daemonEnvList[2];
+  lmon_daemon_env_t *daemonEnvList[2];
 
-
-  /* 
-   * the raw RPDTAB msg received from launchmon engine 
+  /*
+   * the raw RPDTAB msg received from launchmon engine
    */
   lmonp_t *proctab_msg;
 
-
-  /* 
+  /*
    * the raw hostname table msg received from the master BE daemon
    */
   lmonp_t *hntab_msg;
-
 
   /*
    * the raw hostname table msg received from the master MW daemon
    */
   lmonp_t *hntab_mw_msg;
 
-
-  /* 
+  /*
    * the host list constructed from proctab_msg
    */
-  std::map<std::string,std::vector<MPIR_PROCDESC_EXT *>,lexGraphCmp> pMap;
-
+  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *>, lexGraphCmp> pMap;
 
   /*
    * the vector of spawner objects
    */
   std::vector<spawner_base_t *> spawner_vector;
 
-
   /*
-   * status check callback for this function 
-   */ 
-  int (*statusCB) (int *status);
+   * status check callback for this function
+   */
+  int (*statusCB)(int *status);
 
 } lmon_session_desc_t;
-
 
 //! lmon_session_array_t
 /*!
     Data type to hold an array of elements of lmon_session_desc_t type.
-    MAX_LMON_SESSION should be reasonably big; otherwise, (an) element(s) 
-    describing live sessions could be overwritten: this is a circular 
-    array. 
+    MAX_LMON_SESSION should be reasonably big; otherwise, (an) element(s)
+    describing live sessions could be overwritten: this is a circular
+    array.
 */
 typedef struct _lmon_session_array_t {
-  /* 
+  /*
    * session descriptor array, circular array
    */
-  lmon_session_desc_t sessionDescArray[MAX_LMON_SESSION]; 
-
+  lmon_session_desc_t sessionDescArray[MAX_LMON_SESSION];
 
   /*
    * always pointing to the next available desc element
@@ -495,16 +461,14 @@ typedef struct _lmon_session_array_t {
 
 } lmon_session_array_t;
 
-
 //////////////////////////////////////////////////////////////////////////////////
 //
-// STATIC DATA AREA 
+// STATIC DATA AREA
 //
 //
 //
 static lmon_session_array_t sess;
 static rc_rm_t resmanager;
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -513,20 +477,17 @@ static rc_rm_t resmanager;
 //
 //
 
-
 //! LMON_handle_signals (int sig)
 /*!
   signal handler
 */
-static void
-LMON_handle_signals (int sig)
-{
+static void LMON_handle_signals(int sig) {
   int i;
   int numbytes;
   lmonp_t msg;
-  lmon_session_desc_t* mydesc;
+  lmon_session_desc_t *mydesc;
 
-  init_msg_header (&msg);
+  init_msg_header(&msg);
   msg.msgclass = lmonp_fetofe;
   msg.type.fetofe_type = lmonp_shutdownbe;
 
@@ -534,136 +495,106 @@ LMON_handle_signals (int sig)
   // it is an exception to the share memory access policy
   //
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  for (i=0; i < MAX_LMON_SESSION; ++i)
-    {
-      mydesc = &sess.sessionDescArray[i];   
- 
-      if ( mydesc->registered != LMON_TRUE )
-        continue;
+  for (i = 0; i < MAX_LMON_SESSION; ++i) {
+    mydesc = &sess.sessionDescArray[i];
 
-      if ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd != LMON_INIT )
-        {
-          //
-          // assuming this isn't a watchdog thread, a watchdog thread should 
-          // get the ack msg.
-          //
-          numbytes = write_lmonp_long_msg ( 
-            mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd,
-	    &msg,
-	    sizeof(msg) );
-        }
+    if (mydesc->registered != LMON_TRUE) continue;
+
+    if (mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd != LMON_INIT) {
+      //
+      // assuming this isn't a watchdog thread, a watchdog thread should
+      // get the ack msg.
+      //
+      numbytes = write_lmonp_long_msg(
+          mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, &msg,
+          sizeof(msg));
     }
+  }
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
 
-  abort ();
+  abort();
 }
-
 
 //! LMON_return_ver ()
 /*!
   returns version info
 */
-static int 
-LMON_return_ver ()
-{
-  return LMON_VERSION;
-}
-
+static int LMON_return_ver() { return LMON_VERSION; }
 
 //! LMON_freeDaemonEnvList ( lmon_daemon_env_t** n )
 /*!
   A helper routine to free the memory allocated for
   an element of lmon_daemon_env_t type.
 */
-static void 
-LMON_freeDaemonEnvList ( lmon_daemon_env_t **n )
-{
+static void LMON_freeDaemonEnvList(lmon_daemon_env_t **n) {
+  if ((*n) == NULL) return;
 
-  if ( (*n) == NULL )
-    return;
+  LMON_freeDaemonEnvList(&((*n)->next));
 
-  LMON_freeDaemonEnvList (&((*n)->next));
-
-  free (*n);
+  free(*n);
   *n = NULL;
 
   return;
 }
 
-
-static 
-lmon_rc_e 
-LMON_fe_putToDaemonEnv ( lmon_daemon_env_t **sessEnv, 
-		lmon_daemon_env_t *dmonEnv, 
-		int numElem )
-{
-
+static lmon_rc_e LMON_fe_putToDaemonEnv(lmon_daemon_env_t **sessEnv,
+                                        lmon_daemon_env_t *dmonEnv,
+                                        int numElem) {
   int i;
   lmon_rc_e rc = LMON_OK;
 
-  if ( (dmonEnv == NULL) || (numElem <= 0 ))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "no daemon environment variable is passed in!" );
+  if ((dmonEnv == NULL) || (numElem <= 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "no daemon environment variable is passed in!");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  i = 0; 
-  if ( *sessEnv == NULL )
-    {
-      lmon_daemon_env_t *anode 
-	= (lmon_daemon_env_t *) malloc (sizeof(lmon_daemon_env_t));
-	  
-      if ( anode == NULL )
-        return LMON_ENOMEM;
+  i = 0;
+  if (*sessEnv == NULL) {
+    lmon_daemon_env_t *anode =
+        (lmon_daemon_env_t *)malloc(sizeof(lmon_daemon_env_t));
 
-      anode->envName  = strdup(dmonEnv[i].envName);	  
-      anode->envValue = strdup(dmonEnv[i].envValue);
-      anode->next = NULL;
-      (*sessEnv) = anode;
-      i++;
-    }
+    if (anode == NULL) return LMON_ENOMEM;
+
+    anode->envName = strdup(dmonEnv[i].envName);
+    anode->envValue = strdup(dmonEnv[i].envValue);
+    anode->next = NULL;
+    (*sessEnv) = anode;
+    i++;
+  }
 
   lmon_daemon_env_t *trav = (*sessEnv);
-  while (trav->next != NULL)
+  while (trav->next != NULL) trav = trav->next;
+
+  while (i < numElem) {
+    lmon_daemon_env_t *anode =
+        (lmon_daemon_env_t *)malloc(sizeof(lmon_daemon_env_t));
+
+    if (anode == NULL) return LMON_ENOMEM;
+
+    anode->envName = strdup(dmonEnv[i].envName);
+    anode->envValue = strdup(dmonEnv[i].envValue);
+    anode->next = NULL;
+    trav->next = anode;
     trav = trav->next;
-
-  while ( i < numElem )
-    {	  
-      lmon_daemon_env_t *anode 
-	= (lmon_daemon_env_t *) malloc (sizeof(lmon_daemon_env_t));
-
-      if ( anode == NULL )
-        return LMON_ENOMEM;
-
-      anode->envName  = strdup(dmonEnv[i].envName);
-      anode->envValue = strdup(dmonEnv[i].envValue);	  
-      anode->next     = NULL;	  
-      trav->next      = anode;
-      trav            = trav->next;
-      i++;
-    }
+    i++;
+  }
 
   return rc;
 }
-
 
 //! LMON_init_sess ( lmon_session_desc_t* s )
 /*!
   Initialize a session
   return 0 on success; -1 on failure
 */
-static int
-LMON_init_sess ( lmon_session_desc_t* s )
-{
-  if ( s == NULL )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session descriptor is null!");
+static int LMON_init_sess(lmon_session_desc_t *s) {
+  if (s == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session descriptor is null!");
 
-      return -1;
-    }
+    return -1;
+  }
 
   s->pack = NULL;
   s->unpack = NULL;
@@ -683,61 +614,55 @@ LMON_init_sess ( lmon_session_desc_t* s )
 
   std::vector<resource_manager_t> tmpinfo;
   tmpinfo = resmanager.get_supported_rms();
-  if (!tmpinfo.empty())
-    {
-      s->rm_info.rm_supported_types
-        = (rm_catalogue_e *) malloc(sizeof(rm_catalogue_e)*tmpinfo.size());
-      s->rm_info.num_supported_types = tmpinfo.size();
+  if (!tmpinfo.empty()) {
+    s->rm_info.rm_supported_types =
+        (rm_catalogue_e *)malloc(sizeof(rm_catalogue_e) * tmpinfo.size());
+    s->rm_info.num_supported_types = tmpinfo.size();
 
-      int ix;
-      for (ix=0; ix < tmpinfo.size(); ++ix)
-        {
-          s->rm_info.rm_supported_types[ix] = tmpinfo[ix].get_rm();
-        }
-      s->rm_info.index_to_cur_instance = -1;
-      s->rm_info.rm_launcher_pid = -1;
+    int ix;
+    for (ix = 0; ix < tmpinfo.size(); ++ix) {
+      s->rm_info.rm_supported_types[ix] = tmpinfo[ix].get_rm();
     }
-  else
-    {
-      s->rm_info.rm_supported_types = NULL;
-      s->rm_info.num_supported_types = 0;
-      s->rm_info.index_to_cur_instance = -1;
-      s->rm_info.rm_launcher_pid = -1;
-    }
+    s->rm_info.index_to_cur_instance = -1;
+    s->rm_info.rm_launcher_pid = -1;
+  } else {
+    s->rm_info.rm_supported_types = NULL;
+    s->rm_info.num_supported_types = 0;
+    s->rm_info.index_to_cur_instance = -1;
+    s->rm_info.rm_launcher_pid = -1;
+  }
 
-  bzero (s->shared_key, LMON_KEY_LENGTH);
+  bzero(s->shared_key, LMON_KEY_LENGTH);
   s->randomID = LMON_FALSE;
 
   //
   // FE-BE comm
   //
   bzero(&(s->commDesc[fe_be_conn].servAddr),
-    sizeof(s->commDesc[fe_be_conn].servAddr));
-  bzero(s->commDesc[fe_be_conn].ipInfo,
-    sizeof(MAX_LMON_STRING));
+        sizeof(s->commDesc[fe_be_conn].servAddr));
+  bzero(s->commDesc[fe_be_conn].ipInfo, sizeof(MAX_LMON_STRING));
   s->commDesc[fe_be_conn].sessionListenSockFd = LMON_INIT;
   s->commDesc[fe_be_conn].sessionAcceptSockFd = LMON_INIT;
 
   //
   // FE-MW comm
   //
-  bzero(&(s->commDesc[fe_mw_conn].servAddr), 
-    sizeof(s->commDesc[fe_mw_conn].servAddr));
-  bzero(s->commDesc[fe_mw_conn].ipInfo, 
-    sizeof(MAX_LMON_STRING));  
+  bzero(&(s->commDesc[fe_mw_conn].servAddr),
+        sizeof(s->commDesc[fe_mw_conn].servAddr));
+  bzero(s->commDesc[fe_mw_conn].ipInfo, sizeof(MAX_LMON_STRING));
   s->commDesc[fe_mw_conn].sessionListenSockFd = LMON_INIT;
-  s->commDesc[fe_mw_conn].sessionAcceptSockFd = LMON_INIT;  
+  s->commDesc[fe_mw_conn].sessionAcceptSockFd = LMON_INIT;
 
   //
   // FE-Engine comm
   //
-  bzero(&(s->commDesc[fe_engine_conn].servAddr), 
-    sizeof(s->commDesc[fe_engine_conn].servAddr));
-  bzero(s->commDesc[fe_engine_conn].ipInfo, sizeof(MAX_LMON_STRING)); 
+  bzero(&(s->commDesc[fe_engine_conn].servAddr),
+        sizeof(s->commDesc[fe_engine_conn].servAddr));
+  bzero(s->commDesc[fe_engine_conn].ipInfo, sizeof(MAX_LMON_STRING));
   s->commDesc[fe_engine_conn].sessionListenSockFd = LMON_INIT;
-  s->commDesc[fe_engine_conn].sessionAcceptSockFd = LMON_INIT; 
+  s->commDesc[fe_engine_conn].sessionAcceptSockFd = LMON_INIT;
 
-  s->proctab_msg = NULL; 
+  s->proctab_msg = NULL;
   s->hntab_msg = NULL;
 
   // make_sure: s->pMap.size == 0
@@ -749,16 +674,13 @@ LMON_init_sess ( lmon_session_desc_t* s )
   return 0;
 }
 
-
 //! LMON_destroy_sess ( lmon_session_desc_t* s )
 /*!
     destroys a session
     return 0 on success; -1 on failure
 */
-static int 
-LMON_destroy_sess ( lmon_session_desc_t* s )
-{
-  int rc=0;
+static int LMON_destroy_sess(lmon_session_desc_t *s) {
+  int rc = 0;
 
   s->pack = NULL;
   s->unpack = NULL;
@@ -776,546 +698,424 @@ LMON_destroy_sess ( lmon_session_desc_t* s )
   s->le_pid = LMON_FALSE;
   s->rm_launcher_pid = LMON_FALSE;
 
-  if (s->rm_info.rm_supported_types)
-    {
-      free(s->rm_info.rm_supported_types);
-      s->rm_info.rm_supported_types = NULL;
-    }
+  if (s->rm_info.rm_supported_types) {
+    free(s->rm_info.rm_supported_types);
+    s->rm_info.rm_supported_types = NULL;
+  }
   s->rm_info.num_supported_types = LMON_FALSE;
   s->rm_info.index_to_cur_instance = LMON_FALSE;
   s->rm_info.rm_launcher_pid = LMON_FALSE;
 
-  bzero (s->shared_key, LMON_KEY_LENGTH);
+  bzero(s->shared_key, LMON_KEY_LENGTH);
   s->randomID = LMON_FALSE;
 
-  gcry_cipher_close (s->cipher_hndl);
+  gcry_cipher_close(s->cipher_hndl);
 
-  bzero(&(s->commDesc[fe_be_conn].servAddr), 
-    sizeof(s->commDesc[fe_be_conn].servAddr));
-  bzero(s->commDesc[fe_be_conn].ipInfo, 
-    sizeof(MAX_LMON_STRING));
+  bzero(&(s->commDesc[fe_be_conn].servAddr),
+        sizeof(s->commDesc[fe_be_conn].servAddr));
+  bzero(s->commDesc[fe_be_conn].ipInfo, sizeof(MAX_LMON_STRING));
   close(s->commDesc[fe_be_conn].sessionListenSockFd);
   close(s->commDesc[fe_be_conn].sessionAcceptSockFd);
 
-  bzero(&(s->commDesc[fe_mw_conn].servAddr), 
-    sizeof(s->commDesc[fe_mw_conn].servAddr));
-  bzero(s->commDesc[fe_mw_conn].ipInfo, 
-    sizeof(MAX_LMON_STRING));
+  bzero(&(s->commDesc[fe_mw_conn].servAddr),
+        sizeof(s->commDesc[fe_mw_conn].servAddr));
+  bzero(s->commDesc[fe_mw_conn].ipInfo, sizeof(MAX_LMON_STRING));
   close(s->commDesc[fe_mw_conn].sessionListenSockFd);
   close(s->commDesc[fe_mw_conn].sessionAcceptSockFd);
 
-  bzero(&(s->commDesc[fe_engine_conn].servAddr), 
-    sizeof(s->commDesc[fe_engine_conn].servAddr));
+  bzero(&(s->commDesc[fe_engine_conn].servAddr),
+        sizeof(s->commDesc[fe_engine_conn].servAddr));
   bzero(s->commDesc[fe_engine_conn].ipInfo, sizeof(MAX_LMON_STRING));
   close(s->commDesc[fe_engine_conn].sessionListenSockFd);
   close(s->commDesc[fe_engine_conn].sessionAcceptSockFd);
- 
-  if (s->proctab_msg)
-    free(s->proctab_msg);
-  s->proctab_msg = NULL; 
-  if (s->hntab_msg)
-    free(s->hntab_msg);
-  s->hntab_msg = NULL; 
-  if (s->hntab_mw_msg)
-    free(s->hntab_mw_msg);
+
+  if (s->proctab_msg) free(s->proctab_msg);
+  s->proctab_msg = NULL;
+  if (s->hntab_msg) free(s->hntab_msg);
+  s->hntab_msg = NULL;
+  if (s->hntab_mw_msg) free(s->hntab_mw_msg);
 
   s->resourceHandle = LMON_INIT;
 
-  if (s->pMap.size() != 0) 
-    {
-      //
-      // TODO: ugly, someday, change pointers to smart pointers
-      // that mix well with STL
-      //
-      std::map<std::string,std::vector<MPIR_PROCDESC_EXT *>,lexGraphCmp>::iterator iter;
-      std::vector<MPIR_PROCDESC_EXT *>::iterator vectiter;
-      for (iter=s->pMap.begin(); iter != s->pMap.end(); ++iter)
-        {
-          for (vectiter = iter->second.begin(); vectiter != iter->second.end(); ++vectiter)
-            {
-              free((*vectiter)->pd.executable_name);
-              free((*vectiter)->pd.host_name);
-              free((*vectiter));
-            }
-        }
-        s->pMap.clear(); 
+  if (s->pMap.size() != 0) {
+    //
+    // TODO: ugly, someday, change pointers to smart pointers
+    // that mix well with STL
+    //
+    std::map<std::string, std::vector<MPIR_PROCDESC_EXT *>,
+             lexGraphCmp>::iterator iter;
+    std::vector<MPIR_PROCDESC_EXT *>::iterator vectiter;
+    for (iter = s->pMap.begin(); iter != s->pMap.end(); ++iter) {
+      for (vectiter = iter->second.begin(); vectiter != iter->second.end();
+           ++vectiter) {
+        free((*vectiter)->pd.executable_name);
+        free((*vectiter)->pd.host_name);
+        free((*vectiter));
+      }
     }
+    s->pMap.clear();
+  }
 
-  if (!s->spawner_vector.empty())
-    {
-      std::vector<spawner_base_t *>::iterator iter;
-      for (iter=s->spawner_vector.begin(); 
-             iter != s->spawner_vector.end(); ++iter)
-        {
-          delete (*iter);
-        }
-      s->spawner_vector.clear();
+  if (!s->spawner_vector.empty()) {
+    std::vector<spawner_base_t *>::iterator iter;
+    for (iter = s->spawner_vector.begin(); iter != s->spawner_vector.end();
+         ++iter) {
+      delete (*iter);
     }
+    s->spawner_vector.clear();
+  }
 
   s->statusCB = NULL;
 
   return rc;
 }
 
-
-static lmon_rc_e
-LMON_fe_handleFeBeUsrData ( int sessionHandle,
-			    void *febe_data )
-{
-  lmon_session_desc_t* mydesc;
-  lmon_rc_e lrc = LMON_EINVAL;
-
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid");
-
-      return LMON_EBDARG;    
-    }
-
-  mydesc = &sess.sessionDescArray[sessionHandle];   
-
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job has been killed?");
-      return LMON_EBDARG;
-    }
-  
-  if ( febe_data == NULL )
-    {
-      lmonp_t empty_udata_msg;
-
-      set_msg_header ( 
-	          &empty_udata_msg,
-		  lmonp_fetobe, 
-		  lmonp_febe_usrdata, 
-		  0, 0, 0, 0, 0, 0, 0 );
-
-      write_lmonp_long_msg ( 
-		  mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-		  &empty_udata_msg,
-		  sizeof ( empty_udata_msg ));	
-
-      lrc = LMON_ENOPLD;
-    }
-  else
-    {
-      if ( mydesc->pack == NULL )
-	{
-	  lmonp_t empty_udata_msg;
-	  
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	     "did you register a FEBE pack function?");
-		
-	  set_msg_header ( 
-		      &empty_udata_msg,
-		      lmonp_fetobe, 
-		      lmonp_febe_usrdata, 
-		      0, 0, 0, 0, 0, 0, 0 );
-	  //
-	  // sending a short message
-	  //
-	  write_lmonp_long_msg ( 
-		      mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-		      &empty_udata_msg,
-		      sizeof ( empty_udata_msg ));
-
-          lrc = LMON_ENCLLB;
-        }
-      else
-	{
-	  lmonp_t *udata_msg;
-	  char *udata; 
-	  int outlen;
-
-	  udata_msg = (lmonp_t *) malloc ( sizeof (*udata_msg) + LMON_MAX_USRPAYLOAD );	  
-	  if ( udata_msg == NULL )
-	    return LMON_ENOMEM;
-
-	  set_msg_header ( 
-		      udata_msg,
-		      lmonp_fetobe, 
-		      lmonp_febe_usrdata, 
-		      0, 0, 0, 0, 0, 0,
-		      LMON_MAX_USRPAYLOAD );
-
-	  udata = get_usrpayload_begin ( udata_msg );
-
-	  //
-	  // pack func must serialize febe_data into udata
-	  // serialized stream cannot be bigger than febe_data_len
-	  //
-	  if ( mydesc->pack ( febe_data, udata, LMON_MAX_USRPAYLOAD, &outlen ) 
-               < 0 )
-            {  
-              return LMON_EINVAL;
-            }
-
-          if ( outlen > LMON_MAX_USRPAYLOAD )
-            return LMON_EINVAL;
-
-	  udata_msg->usr_payload_length = outlen;
-	  write_lmonp_long_msg ( 
-			  mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-			  udata_msg,
-			  sizeof (lmonp_t) + udata_msg->usr_payload_length );
-
-	  lrc = LMON_OK;
-
-	  free (udata_msg);
-	}
-    }
-
-  return lrc;
-}
-
-
-static lmon_rc_e
-LMON_fe_handleFeMwUsrData (int sessionHandle,
-			   void* femw_data )
-{
+static lmon_rc_e LMON_fe_handleFeBeUsrData(int sessionHandle, void *febe_data) {
   lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid for LMON_fe_handleFeMwUsrData");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &sess.sessionDescArray[sessionHandle];   
+  mydesc = &sess.sessionDescArray[sessionHandle];
 
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid for LMON_fe_handleFeMwUsrData,"
-        " the job has been killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job has been killed?");
+    return LMON_EBDARG;
+  }
 
-      return LMON_EBDARG;
-    }
-  
-  if ( femw_data == NULL )
-    {
+  if (febe_data == NULL) {
+    lmonp_t empty_udata_msg;
+
+    set_msg_header(&empty_udata_msg, lmonp_fetobe, lmonp_febe_usrdata, 0, 0, 0,
+                   0, 0, 0, 0);
+
+    write_lmonp_long_msg(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                         &empty_udata_msg, sizeof(empty_udata_msg));
+
+    lrc = LMON_ENOPLD;
+  } else {
+    if (mydesc->pack == NULL) {
       lmonp_t empty_udata_msg;
 
-      set_msg_header ( 
-	          &empty_udata_msg,
-		  lmonp_fetomw, 
-		  lmonp_femw_usrdata, 
-		  0, 0, 0, 0, 0, 0, 0 );
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "did you register a FEBE pack function?");
 
-      write_lmonp_long_msg ( 
-		  mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-		  &empty_udata_msg,
-		  sizeof ( empty_udata_msg ));	
+      set_msg_header(&empty_udata_msg, lmonp_fetobe, lmonp_febe_usrdata, 0, 0,
+                     0, 0, 0, 0, 0);
+      //
+      // sending a short message
+      //
+      write_lmonp_long_msg(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                           &empty_udata_msg, sizeof(empty_udata_msg));
 
-      lrc = LMON_ENOPLD;
+      lrc = LMON_ENCLLB;
+    } else {
+      lmonp_t *udata_msg;
+      char *udata;
+      int outlen;
+
+      udata_msg = (lmonp_t *)malloc(sizeof(*udata_msg) + LMON_MAX_USRPAYLOAD);
+      if (udata_msg == NULL) return LMON_ENOMEM;
+
+      set_msg_header(udata_msg, lmonp_fetobe, lmonp_febe_usrdata, 0, 0, 0, 0, 0,
+                     0, LMON_MAX_USRPAYLOAD);
+
+      udata = get_usrpayload_begin(udata_msg);
+
+      //
+      // pack func must serialize febe_data into udata
+      // serialized stream cannot be bigger than febe_data_len
+      //
+      if (mydesc->pack(febe_data, udata, LMON_MAX_USRPAYLOAD, &outlen) < 0) {
+        return LMON_EINVAL;
+      }
+
+      if (outlen > LMON_MAX_USRPAYLOAD) return LMON_EINVAL;
+
+      udata_msg->usr_payload_length = outlen;
+      write_lmonp_long_msg(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                           udata_msg,
+                           sizeof(lmonp_t) + udata_msg->usr_payload_length);
+
+      lrc = LMON_OK;
+
+      free(udata_msg);
     }
-  else
-    {
-      if ( mydesc->mw_pack == NULL )
-	{
-	  lmonp_t empty_udata_msg;
-	  
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "did you register a FEMW pack function?");
-		
-	  set_msg_header ( 
-		      &empty_udata_msg,
-		      lmonp_fetomw, 
-		      lmonp_femw_usrdata, 
-		      0, 0, 0, 0, 0, 0, 0 );
-
-	  //
-	  // sending a short message
-	  //
-	  write_lmonp_long_msg ( 
-		      mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-		      &empty_udata_msg,
-		      sizeof ( empty_udata_msg ));
-
-          lrc = LMON_ENCLLB;
-        }
-      else
-	{
-	  lmonp_t *udata_msg;
-	  char *udata; 
-	  int outlen;
-
-	  udata_msg = (lmonp_t *) 
-            malloc ( sizeof (*udata_msg) + LMON_MAX_USRPAYLOAD );	  
-
-	  if ( udata_msg == NULL )
-            return LMON_ENOMEM;
-
-	  set_msg_header ( 
-		      udata_msg,
-		      lmonp_fetomw, 
-		      lmonp_femw_usrdata, 
-		      0, 0, 0, 0, 0, 0,
-		      LMON_MAX_USRPAYLOAD );
-
-	  udata = get_usrpayload_begin ( udata_msg );
-
-	  //
-	  // pack func must serialize febe_data into udata
-	  // serialized stream cannot be bigger than febe_data_len
-	  //
-	  mydesc->mw_pack ( femw_data, 
-			    udata, 
-			    LMON_MAX_USRPAYLOAD, 
-			    &outlen );
-
-	  if (outlen > LMON_MAX_USRPAYLOAD )
-            return LMON_EINVAL;    
-
-	  udata_msg->usr_payload_length = outlen;
-	  write_lmonp_long_msg ( 
-			  mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-			  udata_msg,
-			  sizeof (lmonp_t) + udata_msg->usr_payload_length );
-
-	  lrc = LMON_OK;
-	  free (udata_msg);
-	}
-    }
+  }
 
   return lrc;
 }
 
+static lmon_rc_e LMON_fe_handleFeMwUsrData(int sessionHandle, void *femw_data) {
+  lmon_session_desc_t *mydesc;
+  lmon_rc_e lrc = LMON_EINVAL;
 
-static lmon_rc_e 
-LMON_fe_handleBeFeUsrData (int sessionHandle, 
-			   void *befe_data )
-{
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid for LMON_fe_handleFeMwUsrData");
+
+    return LMON_EBDARG;
+  }
+
+  mydesc = &sess.sessionDescArray[sessionHandle];
+
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid for LMON_fe_handleFeMwUsrData,"
+                 " the job has been killed?");
+
+    return LMON_EBDARG;
+  }
+
+  if (femw_data == NULL) {
+    lmonp_t empty_udata_msg;
+
+    set_msg_header(&empty_udata_msg, lmonp_fetomw, lmonp_femw_usrdata, 0, 0, 0,
+                   0, 0, 0, 0);
+
+    write_lmonp_long_msg(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                         &empty_udata_msg, sizeof(empty_udata_msg));
+
+    lrc = LMON_ENOPLD;
+  } else {
+    if (mydesc->mw_pack == NULL) {
+      lmonp_t empty_udata_msg;
+
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "did you register a FEMW pack function?");
+
+      set_msg_header(&empty_udata_msg, lmonp_fetomw, lmonp_femw_usrdata, 0, 0,
+                     0, 0, 0, 0, 0);
+
+      //
+      // sending a short message
+      //
+      write_lmonp_long_msg(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                           &empty_udata_msg, sizeof(empty_udata_msg));
+
+      lrc = LMON_ENCLLB;
+    } else {
+      lmonp_t *udata_msg;
+      char *udata;
+      int outlen;
+
+      udata_msg = (lmonp_t *)malloc(sizeof(*udata_msg) + LMON_MAX_USRPAYLOAD);
+
+      if (udata_msg == NULL) return LMON_ENOMEM;
+
+      set_msg_header(udata_msg, lmonp_fetomw, lmonp_femw_usrdata, 0, 0, 0, 0, 0,
+                     0, LMON_MAX_USRPAYLOAD);
+
+      udata = get_usrpayload_begin(udata_msg);
+
+      //
+      // pack func must serialize febe_data into udata
+      // serialized stream cannot be bigger than febe_data_len
+      //
+      mydesc->mw_pack(femw_data, udata, LMON_MAX_USRPAYLOAD, &outlen);
+
+      if (outlen > LMON_MAX_USRPAYLOAD) return LMON_EINVAL;
+
+      udata_msg->usr_payload_length = outlen;
+      write_lmonp_long_msg(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                           udata_msg,
+                           sizeof(lmonp_t) + udata_msg->usr_payload_length);
+
+      lrc = LMON_OK;
+      free(udata_msg);
+    }
+  }
+
+  return lrc;
+}
+
+static lmon_rc_e LMON_fe_handleBeFeUsrData(int sessionHandle, void *befe_data) {
   lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
   lmonp_t msg;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "session is invalid for handling backend-frontend user payload");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &sess.sessionDescArray[sessionHandle];   
+  mydesc = &sess.sessionDescArray[sessionHandle];
 
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "session is invalid for handling backend-frontend user payload,"
         " the job has been killed?");
-      return LMON_EBDARG;
-    }
-  
-  read_lmonp_msgheader ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-                        &msg );
+    return LMON_EBDARG;
+  }
 
-  if ( ( msg.msgclass != lmonp_fetobe )
-       || !(( msg.type.fetobe_type == lmonp_befe_ready ) 
-	    || ( msg.type.fetobe_type == lmonp_befe_usrdata ))
-       || ( msg.lmon_payload_length != 0 ) )
-    {
-      return LMON_EBDMSG;
-    }
-  
-  if ( msg.usr_payload_length > 0 )
-    {
+  read_lmonp_msgheader(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd, &msg);
+
+  if ((msg.msgclass != lmonp_fetobe) ||
+      !((msg.type.fetobe_type == lmonp_befe_ready) ||
+        (msg.type.fetobe_type == lmonp_befe_usrdata)) ||
+      (msg.lmon_payload_length != 0)) {
+    return LMON_EBDMSG;
+  }
+
+  if (msg.usr_payload_length > 0) {
+    //
+    // BE shipped user data via the ready msg
+    //
+    char *usrdatabuf = NULL;
+
+    usrdatabuf = (char *)malloc(msg.usr_payload_length);
+
+    if (usrdatabuf == NULL) return LMON_ENOMEM;
+
+    read_lmonp_payloads(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                        usrdatabuf, msg.usr_payload_length);
+
+    if ((mydesc->unpack == NULL) || (befe_data == NULL)) {
       //
-      // BE shipped user data via the ready msg
+      // if FE fails to have registered unpack func,
+      // do nothiing
       //
-      char* usrdatabuf = NULL;
-      
-      usrdatabuf = (char *) 
-        malloc (msg.usr_payload_length);
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "did you register a BEFE unpack function?");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "or pass a null pointer?");
 
-      if ( usrdatabuf == NULL )
-        return LMON_ENOMEM;
+      lrc = LMON_ENCLLB;
+    } else {
+      //
+      // we invoke the unpack callback, which will
+      // unpack usrpayload to befe_data.
+      //
+      if ((mydesc->unpack(usrdatabuf, msg.usr_payload_length, befe_data)) < 0) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "the unpack function you had registered returned a "
+                     "negative return code");
 
-      read_lmonp_payloads ( 
-		      mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-		      usrdatabuf,
-		      msg.usr_payload_length );
-
-      if ( ( mydesc->unpack == NULL ) || ( befe_data == NULL ) )
-	{
-	  //
-	  // if FE fails to have registered unpack func, 
-	  // do nothiing
-	  //
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "did you register a BEFE unpack function?");
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "or pass a null pointer?");
-	  
-          lrc = LMON_ENCLLB;
-	}
-      else
-	{
-	  //
-	  // we invoke the unpack callback, which will 
-	  // unpack usrpayload to befe_data.
-	  //
-	  if ( ( mydesc->unpack ( usrdatabuf, 
-			          msg.usr_payload_length, 
-			          befe_data )) < 0 )
-            {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		"the unpack function you had registered returned a negative return code");
-
-              lrc = LMON_ENEGCB;
-            }
-          else 
-            {
-	      lrc = LMON_OK;
-            }
-	}
-    }  
-  else
-    {
-      lrc = LMON_ENOPLD;
+        lrc = LMON_ENEGCB;
+      } else {
+        lrc = LMON_OK;
+      }
     }
+  } else {
+    lrc = LMON_ENOPLD;
+  }
 
   return lrc;
 }
 
-
-static lmon_rc_e 
-LMON_fe_handleMwFeUsrData (int sessionHandle, 
-			   void *mwfe_data )
-{
+static lmon_rc_e LMON_fe_handleMwFeUsrData(int sessionHandle, void *mwfe_data) {
   lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
   lmonp_t msg;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid in handling middleware-frontent user payload");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "session is invalid in handling middleware-frontent user payload");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &sess.sessionDescArray[sessionHandle];   
-  
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  mydesc = &sess.sessionDescArray[sessionHandle];
+
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "session is invalid in handling middleware-frontent user payload,"
         " the job has been killed?");
 
-      return LMON_EBDARG;
-    }
-  
+    return LMON_EBDARG;
+  }
 
-  read_lmonp_msgheader ( mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-                        &msg );
+  read_lmonp_msgheader(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd, &msg);
 
-  if ( ( msg.msgclass != lmonp_fetomw )
-       || !(( msg.type.fetomw_type == lmonp_mwfe_ready ) 
-           || ( msg.type.fetomw_type == lmonp_mwfe_usrdata ))
-       || ( msg.lmon_payload_length != 0 ) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "invalid LMONP Msg received in LMON_fe_handleMwFeUsrData");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "  A msg of {Class(%s),"
-                     "Type(%s),"
-                     "LMON_payload_size(%s),"
-                     "USR_payload_size(%s)} has been received.",
-        lmon_msg_to_str(field_class, &msg),
-        lmon_msg_to_str(field_type, &msg),
-        lmon_msg_to_str(field_lmon_payload_length, &msg),
-        lmon_msg_to_str(field_usr_payload_length, &msg));
+  if ((msg.msgclass != lmonp_fetomw) ||
+      !((msg.type.fetomw_type == lmonp_mwfe_ready) ||
+        (msg.type.fetomw_type == lmonp_mwfe_usrdata)) ||
+      (msg.lmon_payload_length != 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "invalid LMONP Msg received in LMON_fe_handleMwFeUsrData");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A msg of {Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s),"
+                 "USR_payload_size(%s)} has been received.",
+                 lmon_msg_to_str(field_class, &msg),
+                 lmon_msg_to_str(field_type, &msg),
+                 lmon_msg_to_str(field_lmon_payload_length, &msg),
+                 lmon_msg_to_str(field_usr_payload_length, &msg));
 
-      return LMON_EBDMSG;
-    }
+    return LMON_EBDMSG;
+  }
 
-  if ( msg.usr_payload_length > 0 )
-    {
+  if (msg.usr_payload_length > 0) {
+    //
+    // BE shipped user data via the ready msg
+    //
+    char *usrdatabuf = NULL;
+
+    usrdatabuf = (char *)malloc(msg.usr_payload_length);
+    if (usrdatabuf == NULL) return LMON_ENOMEM;
+
+    read_lmonp_payloads(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                        usrdatabuf, msg.usr_payload_length);
+
+    if ((mydesc->mw_unpack == NULL) || (mwfe_data == NULL)) {
       //
-      // BE shipped user data via the ready msg
+      // if FE fails to have registered unpack func,
+      // do nothiing
       //
-      char *usrdatabuf = NULL;
-      
-      usrdatabuf = (char *) malloc (msg.usr_payload_length);
-      if ( usrdatabuf == NULL )
-        return LMON_ENOMEM;
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "did you register a BEMW unpack function?");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "or pass a null pointer?");
 
-      read_lmonp_payloads ( 
-		      mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-		      usrdatabuf,
-		      msg.usr_payload_length );
+      lrc = LMON_ENCLLB;
+    } else {
+      //
+      // we invoke the unpack callback, which will
+      // unpack usrpayload to befe_data.
+      //
+      if ((mydesc->mw_unpack(usrdatabuf, msg.usr_payload_length, mwfe_data)) <
+          0) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "the unpack function that you registered returned a "
+                     "negative return code");
 
-      if ( ( mydesc->mw_unpack == NULL ) || ( mwfe_data == NULL ) )
-	{
-	  //
-	  // if FE fails to have registered unpack func, 
-	  // do nothiing
-	  //
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "did you register a BEMW unpack function?");
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "or pass a null pointer?");
-	  
-          lrc = LMON_ENCLLB;
-	}
-      else
-	{
-	  //
-	  // we invoke the unpack callback, which will 
-	  // unpack usrpayload to befe_data.
-	  //
-	  if ( ( mydesc->mw_unpack ( usrdatabuf, 
-			             msg.usr_payload_length, 
-			             mwfe_data )) < 0 )
-            {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		"the unpack function that you registered returned a negative return code");
-
-              lrc = LMON_ECLLB;
-            }
-          else 
-            {
-	      lrc = LMON_OK;
-            }
-	}
-    }  
-  else
-    {
-      lrc = LMON_ENOPLD;
+        lrc = LMON_ECLLB;
+      } else {
+        lrc = LMON_OK;
+      }
     }
+  } else {
+    lrc = LMON_ENOPLD;
+  }
 
   return lrc;
 }
 
-
-static lmon_rc_e
-LMON_fe_acceptEngine ( int sessionHandle )
-{
+static lmon_rc_e LMON_fe_acceptEngine(int sessionHandle) {
   //
   // Mar 05 2008 DHA:
   //
-  // We need to perform non-blocking accept in order to 
+  // We need to perform non-blocking accept in order to
   // be able to return to the tool client when a connection
-  // error occurs (LMON_ETOUT), hence, "select" followed by 
+  // error occurs (LMON_ETOUT), hence, "select" followed by
   // accept. Also, the upper layer must set O_NONBLOCK attribute
-  // for the listening socket. 
+  // for the listening socket.
   //
   struct sockaddr_in clientaddr;
   socklen_t clientaddr_len;
-  lmon_session_desc_t *mydesc = NULL; 
+  lmon_session_desc_t *mydesc = NULL;
   lmonp_t msg;
-  char *tout = NULL; 
+  char *tout = NULL;
   int listenfd = -1;
   int tosec = 0;
 
@@ -1325,73 +1125,67 @@ LMON_fe_acceptEngine ( int sessionHandle )
 
   listenfd = mydesc->commDesc[fe_engine_conn].sessionListenSockFd;
 
-  tout = getenv ( "LMON_FE_ENGINE_TIMEOUT" );
-  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
+  tout = getenv("LMON_FE_ENGINE_TIMEOUT");
+  if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
     tosec = atoi(tout);
   else
     tosec = DFLT_FE_ENGINE_TOUT;
 
-  mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd
-    = lmon_timedaccept ( listenfd,
-                     (struct sockaddr *) &clientaddr,
-                     &clientaddr_len,
-                     tosec );
+  mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd = lmon_timedaccept(
+      listenfd, (struct sockaddr *)&clientaddr, &clientaddr_len, tosec);
 
-  if ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd == -2 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"connection to the launchmon engine timed out");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"the launchmon engine has been crashed or never been invoked?");
+  if (mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd == -2) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "connection to the launchmon engine timed out");
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "the launchmon engine has been crashed or never been invoked?");
 
-      return LMON_ETOUT;
-    }
-  else if ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"connection to the launchmon engine failed");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"the launchmon engine has been crashed or never been invoked?");
+    return LMON_ETOUT;
+  } else if (mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "connection to the launchmon engine failed");
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "the launchmon engine has been crashed or never been invoked?");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if ( read_lmonp_msgheader(mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, &msg) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"reading an LMON msg from the launchmon engine returns a negative return code");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"LMONP protocol mismatch or problems while invoking the launchmon engine?");
+  if (read_lmonp_msgheader(mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd,
+                           &msg) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "reading an LMON msg from the launchmon engine returns a "
+                 "negative return code");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LMONP protocol mismatch or problems while invoking the "
+                 "launchmon engine?");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if (msg.type.fetofe_type == lmonp_conn_ack_parse_error) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"the launchmon engine encountered an error while parsing its command line.");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"for example, has an incorrect pid been provided?");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"please check the command line provided to the engine.");
-   
-      return LMON_EINVAL;
-    }
-  else if (msg.type.fetofe_type != lmonp_conn_ack_no_error) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"the engine sent an unexpected msg type. LMONP version mismatch?");
-   
-      return LMON_EINVAL;
-    }
+  if (msg.type.fetofe_type == lmonp_conn_ack_parse_error) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "the launchmon engine encountered an error while parsing its "
+                 "command line.");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "for example, has an incorrect pid been provided?");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "please check the command line provided to the engine.");
+
+    return LMON_EINVAL;
+  } else if (msg.type.fetofe_type != lmonp_conn_ack_no_error) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "the engine sent an unexpected msg type. LMONP version mismatch?");
+
+    return LMON_EINVAL;
+  }
 
   return LMON_OK;
 }
 
-
-static int
-set_cobosec_mode ()
-{
+static int set_cobosec_mode() {
   int rc = 0;
 #if defined(MUNGE)
   cobo_sec_protocol.mechanism = hs_munge;
@@ -1399,52 +1193,42 @@ set_cobosec_mode ()
   int fd;
   unsigned char akey[8];
   char kp[PATH_MAX];
-  snprintf (kp, PATH_MAX, "%s/keyfile.%d", SEC_KEYDIR, getuid());
+  snprintf(kp, PATH_MAX, "%s/keyfile.%d", SEC_KEYDIR, getuid());
   cobo_sec_protocol.mechanism = hs_key_in_file;
   cobo_sec_protocol.data.key_in_file.key_filepath = strdup(kp);
   cobo_sec_protocol.data.key_in_file.key_length_bytes = 8;
 
-  if ( (fd = open ("/dev/urandom", O_RDONLY) ) < 0)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "opening /dev/urandom failed");
-      rc = -1;
-      goto done;
-    }
-  if ( lmon_read_raw (fd, akey, sizeof(akey)) < 0)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "read from /dev/urandom failed.");
-      rc = -1;
-      goto done;
-    }
-  close (fd);  
-  remove (kp);
-  if (( fd = open (cobo_sec_protocol.data.key_in_file.key_filepath, 
-                   O_WRONLY|O_CREAT, 
-                   S_IRUSR|S_IWUSR)) < 0)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "Failed to open %s.", cobo_sec_protocol.data.key_in_file.key_filepath);
-      rc = -1;
-      goto done;
-    }
-  if ( lmon_write_raw (fd, akey, sizeof(akey)) < 0)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "write to %s failed.", SEC_KEYDIR );
-      rc = -1;
-      goto done;
-    }
-  if ( fchmod (fd, S_IRUSR) < 0)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "chmod %s failed.", 
-	cobo_sec_protocol.data.key_in_file.key_filepath);
-      rc = -1;
-      goto done;
-    }
-  close (fd);
+  if ((fd = open("/dev/urandom", O_RDONLY)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "opening /dev/urandom failed");
+    rc = -1;
+    goto done;
+  }
+  if (lmon_read_raw(fd, akey, sizeof(akey)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "read from /dev/urandom failed.");
+    rc = -1;
+    goto done;
+  }
+  close(fd);
+  remove(kp);
+  if ((fd = open(cobo_sec_protocol.data.key_in_file.key_filepath,
+                 O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "Failed to open %s.",
+                 cobo_sec_protocol.data.key_in_file.key_filepath);
+    rc = -1;
+    goto done;
+  }
+  if (lmon_write_raw(fd, akey, sizeof(akey)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "write to %s failed.", SEC_KEYDIR);
+    rc = -1;
+    goto done;
+  }
+  if (fchmod(fd, S_IRUSR) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "chmod %s failed.",
+                 cobo_sec_protocol.data.key_in_file.key_filepath);
+    rc = -1;
+    goto done;
+  }
+  close(fd);
 #elif defined(ENABLE_NULL_ENCRYPTION)
   cobo_sec_protocol.mechanism = hs_none;
 #else
@@ -1455,171 +1239,156 @@ done:
   return rc;
 }
 
-
-static lmon_rc_e 
-LMON_assist_ICCL_BE_init (lmon_session_desc_t *mydesc)
-{
+static lmon_rc_e LMON_assist_ICCL_BE_init(lmon_session_desc_t *mydesc) {
 #if MEASURE_TRACING_COST
-   double be_ts;
-   double be_ts_buf;
-   double c_start_ts;
-   double c_end_ts;
-   c_start_ts = gettimeofdayD();
-   be_ts = 0.0f;
-   {
-     LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-       "LMON_assist_ICCL_BE_init begins");
-   }
+  double be_ts;
+  double be_ts_buf;
+  double c_start_ts;
+  double c_end_ts;
+  c_start_ts = gettimeofdayD();
+  be_ts = 0.0f;
+  {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "LMON_assist_ICCL_BE_init begins");
+  }
 #endif
 
 #if COBO_BASED
   /*
-   * The following code is from Adam Moody's 
+   * The following code is from Adam Moody's
    * PMGR Collective package, implementing
-   * the communication protocol that allows talking 
-   * with the PMGR Collective's clients.  
+   * the communication protocol that allows talking
+   * with the PMGR Collective's clients.
    *
    * And his COBO support
    *
    */
-  int i      = 0;
-  int tosec  = 0;
+  int i = 0;
+  int tosec = 0;
   int ndmons = 0;
   char *tout = NULL;
-  unsigned int hcnt   =0;
+  unsigned int hcnt = 0;
   const char **hostlist = NULL;
   int *portlist = NULL;
 
   struct sockaddr_in sockaddr;
   unsigned int sockaddr_len = sizeof(sockaddr);
 
-  tout = getenv ( "LMON_BE_DAEMON_TIMEOUT" );
-  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
+  tout = getenv("LMON_BE_DAEMON_TIMEOUT");
+  if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
     tosec = atoi(tout);
   else
-	  tosec = DFLT_FE_BE_TOUT;
+    tosec = DFLT_FE_BE_TOUT;
 
-  if (!mydesc->proctab_msg)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "proctab msg has not yet arrived from the launchmon engine! A race condition?");
+  if (!mydesc->proctab_msg) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "proctab msg has not yet arrived from the launchmon engine! A "
+                 "race condition?");
 
-      return LMON_EBUG;
-    }
-  else
-    {
-      if ( parse_raw_RPDTAB_msg (mydesc->proctab_msg, &(mydesc->pMap)) < 0 )
-        {
-          LMON_say_msg (LMON_FE_MSG_PREFIX, false,
-            "failed to parse MPIR_proctable");
+    return LMON_EBUG;
+  } else {
+    if (parse_raw_RPDTAB_msg(mydesc->proctab_msg, &(mydesc->pMap)) < 0) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false, "failed to parse MPIR_proctable");
 
-          return LMON_ESYS;
-        }
-
-      if ( (mydesc->pMap.size()) != 0 )
-        {
-          int j;
-          std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::const_iterator iter;
-          hostlist = (const char **) malloc (mydesc->pMap.size() * sizeof(const char *));
-          if (hostlist == NULL)
-            {
-              LMON_say_msg (LMON_FE_MSG_PREFIX, false,
-                "malloc returned NULL");
-
-              return LMON_ENOMEM;
-            }
-
-          for (iter = mydesc->pMap.begin(); iter != mydesc->pMap.end(); iter++)
-            {
-              // Unless mydesc->pMap destroyed strings that hostlist points
-              // to should be valid
-              hostlist[hcnt] = iter->first.c_str();
-              hcnt++;
-            }
-
-           /* This is only for testing */
-           portlist = (int *) malloc (COBO_PORT_RANGE * sizeof(int));
-	   if (portlist == NULL)
-	     {
-               LMON_say_msg (LMON_FE_MSG_PREFIX, false,
-                 "malloc returned NULL");
-
-               return LMON_ENOMEM;
-	     }
-
-           for (j=0; j < COBO_PORT_RANGE; ++j)
-             portlist[j] = COBO_BEGIN_PORT+j;
-         }
-    }
-
-  mydesc->commDesc[fe_be_conn].nDaemons
-    = mydesc->proctab_msg->sec_or_stringinfo.exec_and_hn.num_host_name;
-  ndmons = mydesc->commDesc[fe_be_conn].nDaemons;
-
-  if ( set_cobosec_mode () < 0)
-    {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "Failed to set COBO secure"
-         " handshake mode for back-end daemons." );
       return LMON_ESYS;
     }
+
+    if ((mydesc->pMap.size()) != 0) {
+      int j;
+      std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::const_iterator
+          iter;
+      hostlist =
+          (const char **)malloc(mydesc->pMap.size() * sizeof(const char *));
+      if (hostlist == NULL) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "malloc returned NULL");
+
+        return LMON_ENOMEM;
+      }
+
+      for (iter = mydesc->pMap.begin(); iter != mydesc->pMap.end(); iter++) {
+        // Unless mydesc->pMap destroyed strings that hostlist points
+        // to should be valid
+        hostlist[hcnt] = iter->first.c_str();
+        hcnt++;
+      }
+
+      /* This is only for testing */
+      portlist = (int *)malloc(COBO_PORT_RANGE * sizeof(int));
+      if (portlist == NULL) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "malloc returned NULL");
+
+        return LMON_ENOMEM;
+      }
+
+      for (j = 0; j < COBO_PORT_RANGE; ++j) portlist[j] = COBO_BEGIN_PORT + j;
+    }
+  }
+
+  mydesc->commDesc[fe_be_conn].nDaemons =
+      mydesc->proctab_msg->sec_or_stringinfo.exec_and_hn.num_host_name;
+  ndmons = mydesc->commDesc[fe_be_conn].nDaemons;
+
+  if (set_cobosec_mode() < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Failed to set COBO secure"
+                 " handshake mode for back-end daemons.");
+    return LMON_ESYS;
+  }
 
   /*
    * Now taking advantage of COBO's new scalable bootstrapping
    * Session id=10 for now.
    */
-  if ( cobo_server_open (10, (char **) hostlist, hcnt, portlist, COBO_PORT_RANGE)
-       != COBO_SUCCESS )
-    {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "cobo_server_open failed.");
+  if (cobo_server_open(10, (char **)hostlist, hcnt, portlist,
+                       COBO_PORT_RANGE) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "cobo_server_open failed.");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if ( cobo_server_get_root_socket (&(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd)) != COBO_SUCCESS)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "cobo_server_get_rootsocket failed.");
+  if (cobo_server_get_root_socket(&(
+          mydesc->commDesc[fe_be_conn].sessionAcceptSockFd)) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "cobo_server_get_rootsocket failed.");
 
-       return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
   free(hostlist);
   free(portlist);
-   
-# if MEASURE_TRACING_COST
-  if ( lmon_read_raw(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd, (void*)&be_ts, sizeof(double)) < 0 )
-    {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "read on a socket failed during MEASURE_TRACING_COST.");
 
-       return LMON_ESYS;
-    }
-# endif
+#if MEASURE_TRACING_COST
+  if (lmon_read_raw(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                    (void *)&be_ts, sizeof(double)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read on a socket failed during MEASURE_TRACING_COST.");
+
+    return LMON_ESYS;
+  }
+#endif
 
 #endif /* COBO_BASED */
 
 #if MEASURE_TRACING_COST
   c_end_ts = gettimeofdayD();
   {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-      "The inclusive LMON overhead of bootstrapping the ICCL layer: %f secs",
-      (c_end_ts - c_start_ts));
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, false,
+        "The inclusive LMON overhead of bootstrapping the ICCL layer: %f secs",
+        (c_end_ts - c_start_ts));
     if (be_ts > (0.0f + 1E-10)) {
-      if (be_ts > c_end_ts) 
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "The BE time stamp is greater than the end of the ICCL layer bootstrapping!"); 
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "Must be out-of-synch clocks across remote nodes. The exclusive LMON overhead cannot be determined");
-        } 
-      else 
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "The exclusive LMON overhead of bootstrapping the ICCL layer: %f secs",
-            (c_end_ts - be_ts));
-        }
+      if (be_ts > c_end_ts) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "The BE time stamp is greater than the end of the ICCL "
+                     "layer bootstrapping!");
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "Must be out-of-synch clocks across remote nodes. The "
+                     "exclusive LMON overhead cannot be determined");
+      } else {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "The exclusive LMON overhead of bootstrapping the ICCL "
+                     "layer: %f secs",
+                     (c_end_ts - be_ts));
+      }
     }
   }
 #endif
@@ -1627,18 +1396,14 @@ LMON_assist_ICCL_BE_init (lmon_session_desc_t *mydesc)
   return LMON_OK;
 }
 
-
-static lmon_rc_e
-LMON_assist_ICCL_MW_init (lmon_session_desc_t *mydesc)
-{
+static lmon_rc_e LMON_assist_ICCL_MW_init(lmon_session_desc_t *mydesc) {
 #if MEASURE_TRACING_COST
   double mw_ts = 0.0f;
   double c_start_ts;
   double c_end_ts;
   c_start_ts = gettimeofdayD();
   {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-      "LMON_assist_ICCL_MW_init begins");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "LMON_assist_ICCL_MW_init begins");
   }
 #endif
 
@@ -1646,116 +1411,107 @@ LMON_assist_ICCL_MW_init (lmon_session_desc_t *mydesc)
 
 #ifdef COBO_BASED
   for (spawner_iter = mydesc->spawner_vector.begin();
-         spawner_iter != mydesc->spawner_vector.end(); spawner_iter++)
-    {
-      // Spawn isn't blocking so that we can overlap the spawning 
-      // daemons across different volumns
-      // Operation will come to the completion when
-      // we throw COBO bootstrap on them as part of fe_mwHandshakeSequence
-      char ssec[128];
-      char secchk[128];
-      snprintf(ssec, 128, "--lmonsharedsec=%s", mydesc->shared_key);
-      snprintf(secchk, 128, "--lmonsecchk=%d", mydesc->randomID);
-      (*spawner_iter)->get_daemon_args().push_back(std::string(ssec));
-      (*spawner_iter)->get_daemon_args().push_back(std::string(secchk));
-      (*spawner_iter)->spawn();
-    }
+       spawner_iter != mydesc->spawner_vector.end(); spawner_iter++) {
+    // Spawn isn't blocking so that we can overlap the spawning
+    // daemons across different volumns
+    // Operation will come to the completion when
+    // we throw COBO bootstrap on them as part of fe_mwHandshakeSequence
+    char ssec[128];
+    char secchk[128];
+    snprintf(ssec, 128, "--lmonsharedsec=%s", mydesc->shared_key);
+    snprintf(secchk, 128, "--lmonsecchk=%d", mydesc->randomID);
+    (*spawner_iter)->get_daemon_args().push_back(std::string(ssec));
+    (*spawner_iter)->get_daemon_args().push_back(std::string(secchk));
+    (*spawner_iter)->spawn();
+  }
 
   std::vector<std::string> combinedHostList;
 
   std::vector<spawner_base_t *>::const_iterator iter;
   for (iter = mydesc->spawner_vector.begin();
-         iter != mydesc->spawner_vector.end(); ++iter)
-    {
-      (*iter)->combineHosts(combinedHostList);
-    }
+       iter != mydesc->spawner_vector.end(); ++iter) {
+    (*iter)->combineHosts(combinedHostList);
+  }
 
   //
   // COBO BOOTSTRAP of MW daemons
   //
   //
   int COBO_MW_BEGIN_PORT = COBO_BEGIN_PORT + COBO_PORT_RANGE;
-  int *portlist = (int *) malloc (COBO_PORT_RANGE * sizeof(int));
-  if (portlist == NULL)
-    {
-      LMON_say_msg (LMON_FE_MSG_PREFIX, false,
-        "malloc returned NULL");
+  int *portlist = (int *)malloc(COBO_PORT_RANGE * sizeof(int));
+  if (portlist == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "malloc returned NULL");
 
-      return LMON_ENOMEM;
-    }
+    return LMON_ENOMEM;
+  }
 
   int i;
-  for (i=0; i < COBO_PORT_RANGE; ++i)
-    portlist[i] = COBO_MW_BEGIN_PORT+i;
+  for (i = 0; i < COBO_PORT_RANGE; ++i) portlist[i] = COBO_MW_BEGIN_PORT + i;
 
   const char **cobohl = NULL;
-  cobohl = (const char **) malloc(sizeof(const char*)*combinedHostList.size());
-  if (cobohl == NULL)
-    {
-      LMON_say_msg (LMON_FE_MSG_PREFIX, false,
-        "malloc returned NULL");
+  cobohl =
+      (const char **)malloc(sizeof(const char *) * combinedHostList.size());
+  if (cobohl == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "malloc returned NULL");
 
-      return LMON_ENOMEM;
-    }
+    return LMON_ENOMEM;
+  }
 
-  int j=0;
+  int j = 0;
   std::vector<std::string>::const_iterator h_it;
-  for (h_it=combinedHostList.begin(); 
-         h_it != combinedHostList.end(); ++h_it)
-    {
-      cobohl[j] = (*h_it).c_str();
-      j++;
-    }
+  for (h_it = combinedHostList.begin(); h_it != combinedHostList.end();
+       ++h_it) {
+    cobohl[j] = (*h_it).c_str();
+    j++;
+  }
 
-   if ( set_cobosec_mode () < 0)
-     {
-        LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-          "Failed to set COBO secure"
-          " handshake mode for middleware deamons." );
-       return LMON_ESYS;
-     }
+  if (set_cobosec_mode() < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Failed to set COBO secure"
+                 " handshake mode for middleware deamons.");
+    return LMON_ESYS;
+  }
 
   //
   // session ID = 11 for now
   //
-  if ( cobo_server_open(11, (char **) cobohl, combinedHostList.size(), portlist, COBO_PORT_RANGE)
-       != COBO_SUCCESS )
-    {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "cobo_server_open failed for launchMwDaemons.");
+  if (cobo_server_open(11, (char **)cobohl, combinedHostList.size(), portlist,
+                       COBO_PORT_RANGE) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "cobo_server_open failed for launchMwDaemons.");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-   if ( cobo_server_get_root_socket(&(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd))
-        != COBO_SUCCESS)
-     {
-        LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-          "cobo_server_get_rootsocket failed for launchMwDaemons");
+  if (cobo_server_get_root_socket(&(
+          mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd)) != COBO_SUCCESS) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "cobo_server_get_rootsocket failed for launchMwDaemons");
 
-       return LMON_ESYS;
-     }
+    return LMON_ESYS;
+  }
 
   free(portlist);
   free(cobohl);
-  // combinedHostList will be freed by the dtor
+// combinedHostList will be freed by the dtor
 
-# if MEASURE_TRACING_COST
-   if ( lmon_read_raw(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd, (void*)&mw_ts, sizeof(double)) < 0 )
-     {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "read on a socket failed during MEASURE_TRACING_COST.");
+#if MEASURE_TRACING_COST
+  if (lmon_read_raw(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                    (void *)&mw_ts, sizeof(double)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read on a socket failed during MEASURE_TRACING_COST.");
 
-       return LMON_ESYS;
-     }
+    return LMON_ESYS;
+  }
 
   c_end_ts = gettimeofdayD();
   {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-     "The LMON overhead of bootstrapping the ICCL layer for MW daemons is: %f secs",
-       (c_end_ts - c_start_ts));
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                 "The LMON overhead of bootstrapping the ICCL layer for MW "
+                 "daemons is: %f secs",
+                 (c_end_ts - c_start_ts));
   }
-# endif
+#endif
 
   return LMON_OK;
 #else
@@ -1764,79 +1520,64 @@ LMON_assist_ICCL_MW_init (lmon_session_desc_t *mydesc)
 #endif
 }
 
-
-static bool
-LMON_fe_is_secure(unsigned char *decryptedID, int k_len, lmon_session_desc_t *mydesc)
-{
+static bool LMON_fe_is_secure(unsigned char *decryptedID, int k_len,
+                              lmon_session_desc_t *mydesc) {
   int32_t int_decryptedID;
   gcry_error_t gcrc;
 
 #if VERBOSE
-  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-    "GCRYPT encrypt, %x:%x:%x:%x",
-    *(int *) decryptedID,
-    *(int *)(decryptedID+4),
-    *(int *)(decryptedID+8),
-    *(int *)(decryptedID+12));
+  LMON_say_msg(LMON_FE_MSG_PREFIX, false, "GCRYPT encrypt, %x:%x:%x:%x",
+               *(int *)decryptedID, *(int *)(decryptedID + 4),
+               *(int *)(decryptedID + 8), *(int *)(decryptedID + 12));
 #endif
 
   //
   // We're currenting using a symmetric cryptography
   //
-  if ( (gcrc = gcry_cipher_decrypt(mydesc->cipher_hndl,
-                                   (unsigned char*) decryptedID,
-                                   k_len,
-                                   NULL,
-                                   0 )) != GPG_ERR_NO_ERROR )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "gcry_cipher_decrypt failed: %s", gcry_strerror (gcrc));
+  if ((gcrc = gcry_cipher_decrypt(mydesc->cipher_hndl,
+                                  (unsigned char *)decryptedID, k_len, NULL,
+                                  0)) != GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "gcry_cipher_decrypt failed: %s",
+                 gcry_strerror(gcrc));
 
-      return false;
-    }
+    return false;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-    "GCRYPT decrypt, %x:%x:%x:%x",
-    *(int *) decryptedID,
-    *(int *)(decryptedID+4),
-    *(int *)(decryptedID+8),
-    *(int *)(decryptedID+12));
+  LMON_say_msg(LMON_FE_MSG_PREFIX, false, "GCRYPT decrypt, %x:%x:%x:%x",
+               *(int *)decryptedID, *(int *)(decryptedID + 4),
+               *(int *)(decryptedID + 8), *(int *)(decryptedID + 12));
 #endif
 
-  memcpy ( (void*) &int_decryptedID, (void*) decryptedID, 4 );
-  if ( mydesc->randomID != int_decryptedID )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "connection cannot be authorized, disconnecting...");
+  memcpy((void *)&int_decryptedID, (void *)decryptedID, 4);
+  if (mydesc->randomID != int_decryptedID) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "connection cannot be authorized, disconnecting...");
 
-      return false;
-    }
+    return false;
+  }
 
   return true;
 }
 
-
 //! lmon_rc_e LMON_fe_beHandshakeSequence
 /*!
     -- assist BE's ICCL layer bootstrap (this can be NOOP most of the cases)
-    -- accept the connection made by the master BE daemon        
+    -- accept the connection made by the master BE daemon
     -- read a msg of lmonp_febe_security_chk
-    -- read "lmonp_befe_hostname" message along with the BE hostname array 
-    -- write "lmonp_febe_proctab" message along with the proctab 
-    -- write "lmon_febe_launch" or "lmon_febe_attach" 
+    -- read "lmonp_befe_hostname" message along with the BE hostname array
+    -- write "lmonp_febe_proctab" message along with the proctab
+    -- write "lmon_febe_launch" or "lmon_febe_attach"
     -- write "lmonp_febe_usrdata" message along with the user data if there
        are data to ship out
     -- read "lmonp_be_ready" message along with BE user data piggybacked
     -- write "lmonp_cont_launch_bp" message to the engine indicating
        the be handshake is done
 */
-static lmon_rc_e 
-LMON_fe_beHandshakeSequence ( 
-	        int sessionHandle,
-                bool is_launch,      /* true for launch, false for attach*/
-		void *febe_data,     /* usrdata in        */
-		void *befe_data )    /* usrdata out       */
+static lmon_rc_e LMON_fe_beHandshakeSequence(
+    int sessionHandle, bool is_launch, /* true for launch, false for attach*/
+    void *febe_data,                   /* usrdata in        */
+    void *befe_data)                   /* usrdata out       */
 {
   struct sockaddr_in clientaddr;
   socklen_t clientaddr_len;
@@ -1856,387 +1597,335 @@ LMON_fe_beHandshakeSequence (
   mydesc = &(sess.sessionDescArray[sessionHandle]);
 
   //
-  // participating in ICCL BE Bootstraping, if necessary 
-  //  
-  // 
-  if ( LMON_assist_ICCL_BE_init (mydesc) != LMON_OK )
-    {
-      
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "back ends bootstrapping throgh LMON_assist_ICCL_BE_init failed ");
-      
-      return LMON_EINVAL;
+  // participating in ICCL BE Bootstraping, if necessary
+  //
+  //
+  if (LMON_assist_ICCL_BE_init(mydesc) != LMON_OK) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "back ends bootstrapping throgh LMON_assist_ICCL_BE_init failed ");
+
+    return LMON_EINVAL;
+  }
+
+  if (mydesc->commDesc[fe_be_conn].sessionAcceptSockFd < 0) {
+    //
+    // ACCEPTING CONNECTION FROM THE MASTER BACKEND DAEMON
+    //   we use the timed version of accept to prevent
+    //   an indefinite hang.
+    //
+    tout = getenv("LMON_BE_DAEMON_TIMEOUT");
+    if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
+      tosec = atoi(tout);
+    else
+      tosec = DFLT_FE_BE_TOUT;
+
+    mydesc->commDesc[fe_be_conn].sessionAcceptSockFd = lmon_timedaccept(
+        mydesc->commDesc[fe_be_conn].sessionListenSockFd,
+        (struct sockaddr *)&clientaddr, &clientaddr_len, tosec);
+
+    if (mydesc->commDesc[fe_be_conn].sessionAcceptSockFd == -2) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "connection to the back end master timed out");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "the back ends have been crashed or never been invoked?");
+
+      return LMON_ETOUT;
+    } else if (mydesc->commDesc[fe_be_conn].sessionAcceptSockFd < 0) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "connection to the back end master failed");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "the back ends have been crashed or never been invoked?");
+
+      return LMON_ESYS;
     }
-
-  if ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd < 0 )
-    {
-      //
-      // ACCEPTING CONNECTION FROM THE MASTER BACKEND DAEMON
-      //   we use the timed version of accept to prevent 
-      //   an indefinite hang. 
-      //
-      tout = getenv ( "LMON_BE_DAEMON_TIMEOUT" );
-      if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
-	tosec = atoi(tout);
-      else
-	tosec = DFLT_FE_BE_TOUT;
-
-
-      mydesc->commDesc[fe_be_conn].sessionAcceptSockFd 
-	= lmon_timedaccept ( mydesc->commDesc[fe_be_conn].sessionListenSockFd,
-			     (struct sockaddr *) &clientaddr,
-			     &clientaddr_len,
-			     tosec);
-
-      if ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd == -2 )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-            "connection to the back end master timed out");
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "the back ends have been crashed or never been invoked?");
-	  
-	  return LMON_ETOUT;
-	}
-      else if ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd < 0 )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "connection to the back end master failed");
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "the back ends have been crashed or never been invoked?");
-	  
-	  return LMON_ESYS;
-	}
-    }
+  }
 
   dec_traverse = decryptedID;
-  for (i=0; i < LMON_KEY_LENGTH/sizeof(int32_t); i++)
-    {
-      //
-      // SECCHK MSG
-      //   -- read and assert lmonp_febe_security_chk type message 
-      //
-      read_lmonp_msgheader( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-			    &msg );
+  for (i = 0; i < LMON_KEY_LENGTH / sizeof(int32_t); i++) {
+    //
+    // SECCHK MSG
+    //   -- read and assert lmonp_febe_security_chk type message
+    //
+    read_lmonp_msgheader(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                         &msg);
 
-      if ( ( msg.msgclass != lmonp_fetobe )
-	   || ( msg.type.fetobe_type != lmonp_febe_security_chk )
-	   || ( msg.lmon_payload_length != 0 )
-	   || ( msg.lmon_payload_length != 0 ) )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "Received an invalid LMONP msg: "
-                         "Front-end back-end protocol mismatch? "
-                         "or back-end disconnected?");
+    if ((msg.msgclass != lmonp_fetobe) ||
+        (msg.type.fetobe_type != lmonp_febe_security_chk) ||
+        (msg.lmon_payload_length != 0) || (msg.lmon_payload_length != 0)) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "Received an invalid LMONP msg: "
+                   "Front-end back-end protocol mismatch? "
+                   "or back-end disconnected?");
 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A proper msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%s)} is expected."
-                         "lmonp_fetobe",
-                         "lmonp_febe_security_chk",
-                         lmon_msg_to_str(field_lmon_payload_length, &msg));
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "  A proper msg of "
+                   "{Class(%s),"
+                   "Type(%s),"
+                   "LMON_payload_size(%s)} is expected."
+                   "lmonp_fetobe",
+                   "lmonp_febe_security_chk",
+                   lmon_msg_to_str(field_lmon_payload_length, &msg));
 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%d)} has been received.",
-                         lmon_msg_to_str(field_class, &msg),
-                         lmon_msg_to_str(field_type, &msg),
-                         lmon_msg_to_str(field_lmon_payload_length, &msg));
-      
-	  return LMON_EBDMSG;      
-	}
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "  A msg of "
+                   "{Class(%s),"
+                   "Type(%s),"
+                   "LMON_payload_size(%d)} has been received.",
+                   lmon_msg_to_str(field_class, &msg),
+                   lmon_msg_to_str(field_type, &msg),
+                   lmon_msg_to_str(field_lmon_payload_length, &msg));
 
-      //
-      // Make sure decrypting security_key2 == randomID
-      //
-      int32_t tmpsec = msg.sec_or_stringinfo.security_key2;
-      memcpy ( (void*) dec_traverse,
-	       (void*) &tmpsec, 
-	       sizeof(int32_t) );
-      dec_traverse += sizeof(int32_t);
+      return LMON_EBDMSG;
     }
 
+    //
+    // Make sure decrypting security_key2 == randomID
+    //
+    int32_t tmpsec = msg.sec_or_stringinfo.security_key2;
+    memcpy((void *)dec_traverse, (void *)&tmpsec, sizeof(int32_t));
+    dec_traverse += sizeof(int32_t);
+  }
+
 #if VERBOSE
-  LMON_say_msg ( LMON_FE_MSG_PREFIX, false, "BE authentication" );
+  LMON_say_msg(LMON_FE_MSG_PREFIX, false, "BE authentication");
 #endif
 
   //
   // is this connection secure?
   //
-  if (!LMON_fe_is_secure(decryptedID, LMON_KEY_LENGTH, mydesc))
-     {
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  if (!LMON_fe_is_secure(decryptedID, LMON_KEY_LENGTH, mydesc)) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "BE connection cannot be authorized... discontinuing the handshake");
 
-       close ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd );
-       //
-       // BE ICCL should detect the connection and start to clear itself up.
-       //
-       return LMON_ESYS;
-     }
+    close(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd);
+    //
+    // BE ICCL should detect the connection and start to clear itself up.
+    //
+    return LMON_ESYS;
+  }
 
-  
   //
   // BE HOSTNAME MSG
   //   -- handshake  message from BE master with BE HOSTNAME array
-  //   
-  if ( read_lmonp_msgheader( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-			     &msg ) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		   "read_lmonp_msgheader failed"
-                   " while attempting to handshake with back end master");
-
-      return LMON_ESYS;
-    }
-
-
-  if ( ( msg.msgclass != lmonp_fetobe )
-       || ( msg.type.fetobe_type != lmonp_befe_hostname )
-       || (msg.lmon_payload_length + msg.usr_payload_length) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	             "Received an invalid LMONP msg: "
-                     "Front-end back-end protocol mismatch? "
-                     "or back-end disconnected?");
-
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A proper msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%s)} is expected."
-                         "lmonp_fetobe",
-                         "lmonp_febe_hostname",
-		         ">=0");
-
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%s),"
-                             "USR_payload_size(%s)} has been received.",
-                         lmon_msg_to_str(field_class, &msg),
-                         lmon_msg_to_str(field_type, &msg),
-                         lmon_msg_to_str(field_lmon_payload_length, &msg),
-                         lmon_msg_to_str(field_usr_payload_length, &msg));
-
-      return LMON_EBDMSG;
-    }
-
-  len = msg.lmon_payload_length + msg.usr_payload_length;  
-
-  mydesc->hntab_msg = (lmonp_t*) malloc(len+sizeof(msg));
-  if ( mydesc->hntab_msg == NULL )
-    return LMON_ENOMEM;
-
-  memcpy(mydesc->hntab_msg, &msg, sizeof(msg));
-  tv = (char*) mydesc->hntab_msg;
-  tv += sizeof(msg);
-  if ( read_lmonp_payloads(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-	                   tv,
-			   len) < 0 )
-  {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		   "read_lmonp_payloads failed"
-                   "while attempting to handshake with back end master");
+  //
+  if (read_lmonp_msgheader(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                           &msg) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_msgheader failed"
+                 " while attempting to handshake with back end master");
 
     return LMON_ESYS;
   }
-  
-  if ( mydesc->proctab_msg == NULL )
-    return LMON_EBUG;
-  
+
+  if ((msg.msgclass != lmonp_fetobe) ||
+      (msg.type.fetobe_type != lmonp_befe_hostname) ||
+      (msg.lmon_payload_length + msg.usr_payload_length) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Received an invalid LMONP msg: "
+                 "Front-end back-end protocol mismatch? "
+                 "or back-end disconnected?");
+
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A proper msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s)} is expected."
+                 "lmonp_fetobe",
+                 "lmonp_febe_hostname", ">=0");
+
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s),"
+                 "USR_payload_size(%s)} has been received.",
+                 lmon_msg_to_str(field_class, &msg),
+                 lmon_msg_to_str(field_type, &msg),
+                 lmon_msg_to_str(field_lmon_payload_length, &msg),
+                 lmon_msg_to_str(field_usr_payload_length, &msg));
+
+    return LMON_EBDMSG;
+  }
+
+  len = msg.lmon_payload_length + msg.usr_payload_length;
+
+  mydesc->hntab_msg = (lmonp_t *)malloc(len + sizeof(msg));
+  if (mydesc->hntab_msg == NULL) return LMON_ENOMEM;
+
+  memcpy(mydesc->hntab_msg, &msg, sizeof(msg));
+  tv = (char *)mydesc->hntab_msg;
+  tv += sizeof(msg);
+  if (read_lmonp_payloads(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd, tv,
+                          len) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_payloads failed"
+                 "while attempting to handshake with back end master");
+
+    return LMON_ESYS;
+  }
+
+  if (mydesc->proctab_msg == NULL) return LMON_EBUG;
+
   //
   // PROCTAB MSG
-  //   -- We simply flip some bits to convert this message to 
+  //   -- We simply flip some bits to convert this message to
   //      "lmonp_febe_proctab" type
   //
   mydesc->proctab_msg->msgclass = lmonp_fetobe;
   mydesc->proctab_msg->type.fetobe_type = lmonp_febe_proctab;
-  if ( write_lmonp_long_msg ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-		      mydesc->proctab_msg,
-		      sizeof ( lmonp_t )
-		      + mydesc->proctab_msg->lmon_payload_length
-		      + mydesc->proctab_msg->usr_payload_length ) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		   "write_lmonp_long_msg failed"
-                   "while attempting to handshake with back end master");
+  if (write_lmonp_long_msg(
+          mydesc->commDesc[fe_be_conn].sessionAcceptSockFd, mydesc->proctab_msg,
+          sizeof(lmonp_t) + mydesc->proctab_msg->lmon_payload_length +
+              mydesc->proctab_msg->usr_payload_length) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "write_lmonp_long_msg failed"
+                 "while attempting to handshake with back end master");
 
-      return LMON_ESYS;
-    }
- 
+    return LMON_ESYS;
+  }
+
   //
   // launch case or attach case?
-  // 
+  //
   lmonp_t use_type_msg;
-  if (is_launch)
-    {
-      lmonp_fe_to_be_msg_e tracemode = lmonp_febe_launch;
-      const char *dontstop;
-      if ((dontstop = getenv("LMON_DONT_STOP_APP")))
-        {
-          if (atoi(dontstop) == 1)
-            {
-              tracemode = lmonp_febe_launch_dontstop;
-            }      
-        }
-      set_msg_header ( &use_type_msg,
-                      lmonp_fetobe,
-                      tracemode,
-                      0, 0, 0, 0, 0, 0, 0 );
+  if (is_launch) {
+    lmonp_fe_to_be_msg_e tracemode = lmonp_febe_launch;
+    const char *dontstop;
+    if ((dontstop = getenv("LMON_DONT_STOP_APP"))) {
+      if (atoi(dontstop) == 1) {
+        tracemode = lmonp_febe_launch_dontstop;
+      }
     }
-  else
-    {
-      lmonp_fe_to_be_msg_e tracemode = lmonp_febe_attach;
-      const char *dontstop;
-      if ((dontstop = getenv("LMON_DONT_STOP_APP")))
-        {
-          if (atoi(dontstop) == 0)
-            {
-              tracemode = lmonp_febe_attach_stop;
-            }
-        }
+    set_msg_header(&use_type_msg, lmonp_fetobe, tracemode, 0, 0, 0, 0, 0, 0, 0);
+  } else {
+    lmonp_fe_to_be_msg_e tracemode = lmonp_febe_attach;
+    const char *dontstop;
+    if ((dontstop = getenv("LMON_DONT_STOP_APP"))) {
+      if (atoi(dontstop) == 0) {
+        tracemode = lmonp_febe_attach_stop;
+      }
+    }
 
-      set_msg_header ( &use_type_msg,
-                      lmonp_fetobe,
-                      tracemode,
-                      0, 0, 0, 0, 0, 0, 0 );
-    }
-    
-  write_lmonp_long_msg ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-                         &use_type_msg,
-                         sizeof ( use_type_msg ));
- 
+    set_msg_header(&use_type_msg, lmonp_fetobe, tracemode, 0, 0, 0, 0, 0, 0, 0);
+  }
+
+  write_lmonp_long_msg(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                       &use_type_msg, sizeof(use_type_msg));
 
   //
   // rm_type
-  // 
+  //
   lmonp_t rm_type_msg;
   rm_catalogue_e rm_entry =
-    mydesc->rm_info.rm_supported_types[mydesc->rm_info.index_to_cur_instance];
-  set_msg_header ( &rm_type_msg,
-		   lmonp_fetobe,
-		   lmonp_febe_rm_type,
-		   (unsigned short) rm_entry,
-		   0, 0, 0, 0, 0, 0 );
+      mydesc->rm_info.rm_supported_types[mydesc->rm_info.index_to_cur_instance];
+  set_msg_header(&rm_type_msg, lmonp_fetobe, lmonp_febe_rm_type,
+                 (unsigned short)rm_entry, 0, 0, 0, 0, 0, 0);
 
-  write_lmonp_long_msg ( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-                         &rm_type_msg,
-                         sizeof ( rm_type_msg ));
-
+  write_lmonp_long_msg(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                       &rm_type_msg, sizeof(rm_type_msg));
 
   //
   // USRDATA MSG
-  //  -- writing the lmonp_febe_usrdata message along with the user data 
+  //  -- writing the lmonp_febe_usrdata message along with the user data
   //     if there are data to ship out
   //
   lmon_rc_e lrc;
-  lrc = LMON_fe_handleFeBeUsrData( sessionHandle, febe_data );
-  if (lrc != LMON_OK && lrc != LMON_ENOPLD)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LMON_fe_handleFeBeUsrData returned an error code");
-      return lrc;
-    }
+  lrc = LMON_fe_handleFeBeUsrData(sessionHandle, febe_data);
+  if (lrc != LMON_OK && lrc != LMON_ENOPLD) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LMON_fe_handleFeBeUsrData returned an error code");
+    return lrc;
+  }
 
   //
-  // CONTINUE LAUNCH MSG 
+  // CONTINUE LAUNCH MSG
   //
   lmonp_t cont_req_msg;
-  if ( read_lmonp_msgheader( mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-			     &cont_req_msg) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		   "read_lmonp_msgheader failed"
-                   " while attempting to receive continue launch message from back end master");
+  if (read_lmonp_msgheader(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+                           &cont_req_msg) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_msgheader failed"
+                 " while attempting to receive continue launch message from "
+                 "back end master");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
+  if ((cont_req_msg.msgclass != lmonp_fetobe) ||
+      (cont_req_msg.type.fetobe_type != lmonp_befe_cont_launch_bp)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Received an invalid LMONP msg: "
+                 "Front-end back-end protocol mismatch? "
+                 "or back-end disconnected?");
 
-  if ( ( cont_req_msg.msgclass != lmonp_fetobe )
-       || ( cont_req_msg.type.fetobe_type != lmonp_befe_cont_launch_bp))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	             "Received an invalid LMONP msg: "
-                     "Front-end back-end protocol mismatch? "
-                     "or back-end disconnected?");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A proper msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s)} is expected."
+                 "lmonp_fetobe",
+                 "lmonp_befe_cont_launch_bp", "==0");
 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A proper msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%s)} is expected."
-                         "lmonp_fetobe",
-                         "lmonp_befe_cont_launch_bp",
-		         "==0");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s),"
+                 "USR_payload_size(%s)} has been received.",
+                 lmon_msg_to_str(field_class, &cont_req_msg),
+                 lmon_msg_to_str(field_type, &cont_req_msg),
+                 lmon_msg_to_str(field_lmon_payload_length, &cont_req_msg),
+                 lmon_msg_to_str(field_usr_payload_length, &cont_req_msg));
 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "  A msg of "
-                            "{Class(%s)," 
-                             "Type(%s),"
-                             "LMON_payload_size(%s),"
-                             "USR_payload_size(%s)} has been received.",
-                         lmon_msg_to_str(field_class, &cont_req_msg),
-                         lmon_msg_to_str(field_type, &cont_req_msg),
-                         lmon_msg_to_str(field_lmon_payload_length, &cont_req_msg),
-                         lmon_msg_to_str(field_usr_payload_length, &cont_req_msg));
-
-      return LMON_EBDMSG;
-    }
+    return LMON_EBDMSG;
+  }
 
   //
-  // Release the continue message to the engine that it is now safe to continue 
+  // Release the continue message to the engine that it is now safe to continue
   // out of launch-bp
   //
-  lmonp_t engineMsg; 
-  init_msg_header (&engineMsg);
+  lmonp_t engineMsg;
+  init_msg_header(&engineMsg);
   engineMsg.msgclass = lmonp_fetofe;
   engineMsg.type.fetofe_type = lmonp_cont_launch_bp;
 
-  write_lmonp_long_msg ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd,
-                         &engineMsg,
-                         sizeof(engineMsg) );
-
+  write_lmonp_long_msg(mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd,
+                       &engineMsg, sizeof(engineMsg));
 
   //
   // READY MSG ( usrdata can be piggybacked )
   //  -- receiving the ready message from BE master
   //
-  lrc = LMON_fe_handleBeFeUsrData( sessionHandle, befe_data );
-  if (lrc != LMON_OK && lrc != LMON_ENOPLD)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LMON_fe_handleBeFeUsrData returned an error code");
-      return lrc;
-    }
+  lrc = LMON_fe_handleBeFeUsrData(sessionHandle, befe_data);
+  if (lrc != LMON_OK && lrc != LMON_ENOPLD) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LMON_fe_handleBeFeUsrData returned an error code");
+    return lrc;
+  }
 
   //
   // Handshake has been successful
-  //  
+  //
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_fe_mwHandshakeSequence
 /*!
     -- accept the connection made by the master MW daemon (ICCL)
          via LMON_assist_ICCL_MW_init
     -- read a msg of lmonp_femw_security_chk (SECURITY)
-    -- read "lmonp_mwfe_hostname" message along with the BE hostname array (HOSTNAME)
-    -- write "lmonp_femw_usrdata" message along with the user data if there (USER COMM.)
+    -- read "lmonp_mwfe_hostname" message along with the BE hostname array
+   (HOSTNAME)
+    -- write "lmonp_femw_usrdata" message along with the user data if there
+   (USER COMM.)
        are data to ship out
     -- read "lmonp_mw_ready" message along with BE user data piggybacked (READY)
 */
-static lmon_rc_e
-LMON_fe_mwHandshakeSequence (
-                int sessionHandle,
-                void *femw_data,     /* usrdata in        */
-                void *mwfe_data )    /* usrdata out       */
+static lmon_rc_e LMON_fe_mwHandshakeSequence(int sessionHandle,
+                                             void *femw_data, /* usrdata in */
+                                             void *mwfe_data) /* usrdata out */
 {
   lmon_rc_e lrc;
   lmon_session_desc_t *mydesc;
@@ -2245,182 +1934,166 @@ LMON_fe_mwHandshakeSequence (
   mydesc = &(sess.sessionDescArray[sessionHandle]);
 
   //
-  // TODO: need a timeout mechanism for COBO-based boostrapping 
+  // TODO: need a timeout mechanism for COBO-based boostrapping
   //       talk to Adam Moody
   //
-  lrc = LMON_assist_ICCL_MW_init (mydesc);
-  if ( lrc != LMON_OK )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LMON_assist_ICCL_MW_init failed ");
+  lrc = LMON_assist_ICCL_MW_init(mydesc);
+  if (lrc != LMON_OK) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "LMON_assist_ICCL_MW_init failed ");
 
-      return lrc;
-    }
+    return lrc;
+  }
 
   unsigned char encrypt_packet_buf[LMON_KEY_LENGTH];
   unsigned char *encrypt_trav = encrypt_packet_buf;
   lmonp_t msg;
-  for (i=0; i < LMON_KEY_LENGTH/sizeof(int32_t); i++)
-    {
-      //
-      // SECCHK MSG
-      //   -- read and assert lmonp_femw_security_chk type message
-      //
-      read_lmonp_msgheader(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-                           &msg );
+  for (i = 0; i < LMON_KEY_LENGTH / sizeof(int32_t); i++) {
+    //
+    // SECCHK MSG
+    //   -- read and assert lmonp_femw_security_chk type message
+    //
+    read_lmonp_msgheader(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                         &msg);
 
-      if ( (msg.msgclass != lmonp_fetomw)
-           || (msg.type.fetomw_type != lmonp_femw_security_chk)
-           || (msg.lmon_payload_length != 0)
-           || (msg.usr_payload_length != 0))
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "Received an invalid LMONP msg: "
-                         "Front-end middleware protocol mismatch? "
-                         "or middleware disconnected?");
+    if ((msg.msgclass != lmonp_fetomw) ||
+        (msg.type.fetomw_type != lmonp_femw_security_chk) ||
+        (msg.lmon_payload_length != 0) || (msg.usr_payload_length != 0)) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "Received an invalid LMONP msg: "
+                   "Front-end middleware protocol mismatch? "
+                   "or middleware disconnected?");
 
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "  A proper msg of "
-                            "{Class(%s),"
-                             "Type(%s),"
-                             "LMON_payload_size(%s)} is expected."
-                         "lmonp_fetomw",
-                         "lmonp_femw_security_chk",
-                         "0");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "  A proper msg of "
+                   "{Class(%s),"
+                   "Type(%s),"
+                   "LMON_payload_size(%s)} is expected."
+                   "lmonp_fetomw",
+                   "lmonp_femw_security_chk", "0");
 
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "  A msg of "
-                            "{Class(%s),"
-                             "Type(%s),"
-                             "LMON_payload_size(%d)} has been received.",
-                         lmon_msg_to_str(field_class, &msg),
-                         lmon_msg_to_str(field_type, &msg),
-                         lmon_msg_to_str(field_lmon_payload_length, &msg));
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "  A msg of "
+                   "{Class(%s),"
+                   "Type(%s),"
+                   "LMON_payload_size(%d)} has been received.",
+                   lmon_msg_to_str(field_class, &msg),
+                   lmon_msg_to_str(field_type, &msg),
+                   lmon_msg_to_str(field_lmon_payload_length, &msg));
 
-           LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-             "discontinuing the handshake...");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "discontinuing the handshake...");
 
-           return LMON_EBDMSG;
-        }
-
-      //
-      // Filling the buf of LMON_KEY_LENGTH bytes with receiving encripted payloads 
-      //
-      int32_t tmpsec = msg.sec_or_stringinfo.security_key2;
-      memcpy((void*) encrypt_trav, (void*) &tmpsec, sizeof(int32_t));
-      encrypt_trav += sizeof(int32_t);
+      return LMON_EBDMSG;
     }
 
+    //
+    // Filling the buf of LMON_KEY_LENGTH bytes with receiving encripted
+    // payloads
+    //
+    int32_t tmpsec = msg.sec_or_stringinfo.security_key2;
+    memcpy((void *)encrypt_trav, (void *)&tmpsec, sizeof(int32_t));
+    encrypt_trav += sizeof(int32_t);
+  }
+
 #if VERBOSE
-  LMON_say_msg ( LMON_FE_MSG_PREFIX, false, "MW authentication" ); 
+  LMON_say_msg(LMON_FE_MSG_PREFIX, false, "MW authentication");
 #endif
 
   //
   // is this connection secure?
   //   -- read a msg of lmonp_femw_security_chk
   //
-  if (!LMON_fe_is_secure(encrypt_packet_buf, LMON_KEY_LENGTH, mydesc))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  if (!LMON_fe_is_secure(encrypt_packet_buf, LMON_KEY_LENGTH, mydesc)) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "BE connection cannot be authorized... discontinuing the handshake");
 
-      close ( mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd );
-      //
-      // MW ICCL should detect the connection and start to clear itself up.
-      //
-      return LMON_ESYS;
-    }
+    close(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd);
+    //
+    // MW ICCL should detect the connection and start to clear itself up.
+    //
+    return LMON_ESYS;
+  }
 
   //
   // MW HOSTNAME MSG
   //   -- handshake  message from MW master with BE HOSTNAME array
   //
-  if ( read_lmonp_msgheader(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-                            &msg ) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "read_lmonp_msgheader failed");
+  if (read_lmonp_msgheader(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
+                           &msg) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "read_lmonp_msgheader failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if ( ( msg.msgclass != lmonp_fetomw )
-       || ( msg.type.fetomw_type != lmonp_mwfe_hostname )
-       || ( (msg.lmon_payload_length + msg.usr_payload_length) < 0 ) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "Received an invalid LMONP msg: "
-                         "Front-end middleware protocol mismatch? "
-                         "or middleware disconnected?");
+  if ((msg.msgclass != lmonp_fetomw) ||
+      (msg.type.fetomw_type != lmonp_mwfe_hostname) ||
+      ((msg.lmon_payload_length + msg.usr_payload_length) < 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Received an invalid LMONP msg: "
+                 "Front-end middleware protocol mismatch? "
+                 "or middleware disconnected?");
 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "  A proper msg of "
-                            "{Class(%s),"
-                             "Type(%s),"
-                             "LMON_payload_size(%s)} is expected."
-                         "lmonp_fetomw",
-                         "lmonp_femw_hostname",
-                         ">0");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A proper msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%s)} is expected."
+                 "lmonp_fetomw",
+                 "lmonp_femw_hostname", ">0");
 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                         "  A msg of "
-                            "{Class(%s),"
-                             "Type(%s),"
-                             "LMON_payload_size(%d)} has been received.",
-                         lmon_msg_to_str(field_class, &msg),
-                         lmon_msg_to_str(field_type, &msg),
-                         lmon_msg_to_str(field_lmon_payload_length, &msg));
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "  A msg of "
+                 "{Class(%s),"
+                 "Type(%s),"
+                 "LMON_payload_size(%d)} has been received.",
+                 lmon_msg_to_str(field_class, &msg),
+                 lmon_msg_to_str(field_type, &msg),
+                 lmon_msg_to_str(field_lmon_payload_length, &msg));
 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "discontinuing the handshake...");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "discontinuing the handshake...");
 
-      return LMON_EBDMSG;
-    }
+    return LMON_EBDMSG;
+  }
 
   unsigned int len = msg.lmon_payload_length + msg.usr_payload_length;
 
-  mydesc->hntab_mw_msg = (lmonp_t*) malloc(len+sizeof(msg));
-  if ( mydesc->hntab_mw_msg == NULL )
-    return LMON_ENOMEM;
+  mydesc->hntab_mw_msg = (lmonp_t *)malloc(len + sizeof(msg));
+  if (mydesc->hntab_mw_msg == NULL) return LMON_ENOMEM;
 
   memcpy(mydesc->hntab_mw_msg, &msg, sizeof(msg));
-  char *tv = (char*) mydesc->hntab_mw_msg;
+  char *tv = (char *)mydesc->hntab_mw_msg;
   tv += sizeof(msg);
-  if ( read_lmonp_payloads(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd,
-                           tv,
-                           len) < 0 )
-  {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                   "read_lmonp_payloads failed"
-                   "while attempting to handshake with middleware master");
+  if (read_lmonp_payloads(mydesc->commDesc[fe_mw_conn].sessionAcceptSockFd, tv,
+                          len) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_payloads failed"
+                 "while attempting to handshake with middleware master");
 
     return LMON_ESYS;
   }
 
   //
   // USRDATA MSG
-  //  -- writing the lmonp_femw_usrdata message along with the user data 
+  //  -- writing the lmonp_femw_usrdata message along with the user data
   //     if there are data to ship out
   //
   lrc = LMON_fe_handleFeMwUsrData(sessionHandle, femw_data);
-  if (lrc != LMON_OK && lrc != LMON_ENOPLD)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LMON_fe_handleFeMwUsrData returned an error code");
-      return lrc;
-    }
+  if (lrc != LMON_OK && lrc != LMON_ENOPLD) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LMON_fe_handleFeMwUsrData returned an error code");
+    return lrc;
+  }
 
   //
   // READY MSG ( usrdata can be piggybacked )
   //  -- receiving the ready message from MW master
   //
   lrc = LMON_fe_handleMwFeUsrData(sessionHandle, mwfe_data);
-  if (lrc != LMON_OK && lrc != LMON_ENOPLD)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LMON_fe_handleMwFeUsrData returned an error code");
-      return lrc;
-    }
+  if (lrc != LMON_OK && lrc != LMON_ENOPLD) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LMON_fe_handleMwFeUsrData returned an error code");
+    return lrc;
+  }
 
   //
   // Handshake has been successful
@@ -2428,39 +2101,28 @@ LMON_fe_mwHandshakeSequence (
   return LMON_OK;
 }
 
-
-
-
-
 //! LMON_set_options
 /*!
-  sets the given options in a way that the main launchmon 
+  sets the given options in a way that the main launchmon
   engine understands
 */
-static lmon_rc_e
-LMON_set_options ( 
-	        lmon_session_desc_t *mydesc, 
-		opts_args_t& opt,
-		int verbose,
-		bool attach,
-		const char *launcher,
-		char *launcher_argv[],
-		int launcherPid,
-		const char *toolDaemon,
-		char *daemon_argopts[])
-{
+static lmon_rc_e LMON_set_options(lmon_session_desc_t *mydesc, opts_args_t &opt,
+                                  int verbose, bool attach,
+                                  const char *launcher, char *launcher_argv[],
+                                  int launcherPid, const char *toolDaemon,
+                                  char *daemon_argopts[]) {
   using namespace std;
 
   int i;
   char portinfo[16];
-  opt_struct_t* optcontext; 
+  opt_struct_t *optcontext;
   enum self_trace_verbosity ver;
 
   optcontext = opt.get_my_opt();
   optcontext->verbose = verbose;
   optcontext->debugtarget = "";
 
-  if (verbose == 0 )
+  if (verbose == 0)
     ver = quiet;
   else if (verbose == 1)
     ver = level1;
@@ -2469,20 +2131,19 @@ LMON_set_options (
   else if (verbose == 3)
     ver = level3;
   else
-    ver = quiet;	
+    ver = quiet;
 
-  self_trace_t::self_trace().launchmon_module_trace.verbosity_level     = ver;
-  self_trace_t::self_trace().tracer_module_trace.verbosity_level        = ver;
-  self_trace_t::self_trace().symtab_module_trace.verbosity_level        = ver;
-  self_trace_t::self_trace().event_module_trace.verbosity_level         = ver;
-  self_trace_t::self_trace().driver_module_trace.verbosity_level        = ver;
-  self_trace_t::self_trace().machine_module_trace.verbosity_level       = ver;
-  self_trace_t::self_trace().opt_module_trace.verbosity_level           = ver;
+  self_trace_t::self_trace().launchmon_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().tracer_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().symtab_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().event_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().driver_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().machine_module_trace.verbosity_level = ver;
+  self_trace_t::self_trace().opt_module_trace.verbosity_level = ver;
 
-  sprintf ( portinfo, 
-	      "%d", 
-	      (unsigned short) 
-	      ntohs (mydesc->commDesc[fe_engine_conn].servAddr.sin_port) );
+  sprintf(portinfo, "%d",
+          (unsigned short)ntohs(
+              mydesc->commDesc[fe_engine_conn].servAddr.sin_port));
 
   optcontext->remote = true;
   optcontext->remote_info = mydesc->commDesc[fe_engine_conn].ipInfo;
@@ -2491,326 +2152,268 @@ LMON_set_options (
 
   char tmprandomID[128];
 
-  sprintf (tmprandomID, 
-	     "%d",
-	     mydesc->randomID);
+  sprintf(tmprandomID, "%d", mydesc->randomID);
 
   optcontext->lmon_sec_info = mydesc->shared_key;
   optcontext->lmon_sec_info += ":";
-  optcontext->lmon_sec_info += tmprandomID;	
+  optcontext->lmon_sec_info += tmprandomID;
   optcontext->attach = attach;
   optcontext->tool_daemon = toolDaemon;
 
-  if (launcher != NULL)
-    {    
-      optcontext->debugtarget = launcher;
-    }
+  if (launcher != NULL) {
+    optcontext->debugtarget = launcher;
+  }
 
-  if (launcherPid > 0)
-    {
-      optcontext->launcher_pid = launcherPid;
-    }
+  if (launcherPid > 0) {
+    optcontext->launcher_pid = launcherPid;
+  }
 
   optcontext->tool_daemon_opts.clear();
 
-  if (launcher_argv != NULL)
-    {
-      optcontext->remaining = launcher_argv;
+  if (launcher_argv != NULL) {
+    optcontext->remaining = launcher_argv;
+  }
+
+  if (daemon_argopts != NULL) {
+    for (i = 0;; ++i) {
+      if (daemon_argopts[i] != NULL) {
+        optcontext->tool_daemon_opts.push_back(string(daemon_argopts[i]));
+      } else
+        break;
     }
-  
-  if ( daemon_argopts != NULL )
-    {	
-      for (i=0; ; ++i)
-	{
-	  if (daemon_argopts[i] != NULL)
-	    {
-              optcontext->tool_daemon_opts.push_back(string(daemon_argopts[i]));
-	    }
-	  else
-	    break;
-	}
-    }
+  }
 
   lmon_daemon_env_t *trav = mydesc->daemonEnvList[0];
 
-  while (trav != NULL)
-    {
-      optcontext->envMap.insert( 
-		make_pair ( string(trav->envName), 
-		            string(trav->envValue)) );
-      trav = trav->next;
-    }
+  while (trav != NULL) {
+    optcontext->envMap.insert(
+        make_pair(string(trav->envName), string(trav->envValue)));
+    trav = trav->next;
+  }
 
   return LMON_OK;
 }
 
-
 //! LMON_openBindAndListen
 /*!
-  opens up a TCP socket, binding it with a random port and listening in 
-  on it. This is per-session server socket. 
+  opens up a TCP socket, binding it with a random port and listening in
+  on it. This is per-session server socket.
 
-  Mar 5 2008: DHA We added "O_NONBLOCK flag to the socket here to 
-  be able to prevent indefinite blocking on socket calls.  
+  Mar 5 2008: DHA We added "O_NONBLOCK flag to the socket here to
+  be able to prevent indefinite blocking on socket calls.
 */
-static lmon_rc_e 
-LMON_openBindAndListen ( int *sfd )
-{
+static lmon_rc_e LMON_openBindAndListen(int *sfd) {
   int rc;
   struct sockaddr_in servaddr;
   struct hostent *hp;
-  struct in_addr **addr; 
-  char hn[MAX_LMON_STRING]; 
+  struct in_addr **addr;
+  char hn[MAX_LMON_STRING];
   char *hngiven;
 
-  if ( (rc = gethostname(hn, MAX_LMON_STRING)) < 0 ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "gethostname call failed");
+  if ((rc = gethostname(hn, MAX_LMON_STRING)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "gethostname call failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP || SUB_ARCH_BGQ
   //
   // BlueGene/L uses NIC whose name is suffixed with -io to communicate
-  // packets to/from IO nodes.  
+  // packets to/from IO nodes.
   //
   // DHA 3/4/3009, reviewed. Looks fine for the DAWN configuration
   // /etc/hosts shows that I/O network is detnoted as FENname-io
-  // following the same convention. 
+  // following the same convention.
   //
   // Changed RM_BGL_MPIRUN to RM_BG_MPIRUN to genericize BlueGene Support
   //
-  strcat (hn, "-io");
+  strcat(hn, "-io");
 #elif SUB_ARCH_ALPS || SUB_ARCH_CRAY
   //
-  // Cray uses its own way to name a node, so overwriting 
+  // Cray uses its own way to name a node, so overwriting
   // hn with the name generated with their method
   //
-  std::ifstream ifs( "/proc/cray_xt/nid" );
+  std::ifstream ifs("/proc/cray_xt/nid");
   uint32_t nid;
   ifs >> nid;
 
   std::ostringstream nidStr;
-  nidStr << "nid" << std::setw( 5 ) << std::setfill( '0' )
-         << nid << std::ends;
-  snprintf(hn, MAX_LMON_STRING, "%s",nidStr.str().c_str());
+  nidStr << "nid" << std::setw(5) << std::setfill('0') << nid << std::ends;
+  snprintf(hn, MAX_LMON_STRING, "%s", nidStr.str().c_str());
 #endif
 
   //
-  // LMON_FE_HOSTNAME_TO_CONN support to handle a condition where 
-  // the hostname returned by gethostname doesn't represent a 
-  // hostname for remote tool daemons to connect to 
+  // LMON_FE_HOSTNAME_TO_CONN support to handle a condition where
+  // the hostname returned by gethostname doesn't represent a
+  // hostname for remote tool daemons to connect to
   //
-  if ( (hngiven = getenv ("LMON_FE_HOSTNAME_TO_CONN")) != NULL)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-		     "front-end hostname that remote daemons use is given");	
-      memset (hn, '\0', MAX_LMON_STRING);
-      snprintf(hn, MAX_LMON_STRING, "%s", hngiven);
-    } 
+  if ((hngiven = getenv("LMON_FE_HOSTNAME_TO_CONN")) != NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                 "front-end hostname that remote daemons use is given");
+    memset(hn, '\0', MAX_LMON_STRING);
+    snprintf(hn, MAX_LMON_STRING, "%s", hngiven);
+  }
 
-  if ( (hp = gethostbyname(hn)) == NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "gethostbyname call failed");
+  if ((hp = gethostbyname(hn)) == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "gethostbyname call failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  addr = (struct in_addr **) hp->h_addr_list;      
-  if ( ((*sfd) = socket ( AF_INET, SOCK_STREAM, 0 )) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "socket call failed");
+  addr = (struct in_addr **)hp->h_addr_list;
+  if (((*sfd) = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "socket call failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  bzero (&servaddr, sizeof(servaddr));
+  bzero(&servaddr, sizeof(servaddr));
   servaddr.sin_family = AF_INET;
-  memcpy (&servaddr.sin_addr, *addr, sizeof(struct in_addr));
+  memcpy(&servaddr.sin_addr, *addr, sizeof(struct in_addr));
   servaddr.sin_port = 0;
 
-  if ( (rc = bind( (*sfd),
-		   (struct sockaddr*) &servaddr, 
-		   sizeof(servaddr)) < 0))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "bind call failed");      
+  if ((rc = bind((*sfd), (struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "bind call failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if ( ( rc = listen( (*sfd), SOMAXCONN) ) < 0 )
-    {      
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "listen call failed");      
+  if ((rc = listen((*sfd), SOMAXCONN)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "listen call failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
-  if ( ( rc = fcntl ( (*sfd), F_SETFL, O_NONBLOCK) ) < 0 )
-    {      
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "setting O_NONBLOCK for a socket failed");      
+  if ((rc = fcntl((*sfd), F_SETFL, O_NONBLOCK)) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "setting O_NONBLOCK for a socket failed");
 
-      return LMON_ESYS;
-    }
+    return LMON_ESYS;
+  }
 
   return LMON_OK;
 }
 
-
-//! LMON_handle_proctab_event 
+//! LMON_handle_proctab_event
 /*!
   fetches the proctable message from the LaunchMON Engine
 */
-static int 
-LMON_handle_proctab_event ( 
-		int readingFd, 
-		lmon_session_desc_t *mydesc, 
-		lmonp_t *msg )
-{
+static int LMON_handle_proctab_event(int readingFd, lmon_session_desc_t *mydesc,
+                                     lmonp_t *msg) {
   int bytesread;
   char *proctab_message;
   char *trav_ptr;
-	
-  proctab_message = (char *) 
-    malloc( sizeof(*msg) 
-	    + msg->lmon_payload_length
-	    + msg->usr_payload_length); 
-  
-  if ( proctab_message == NULL )
-    return LMON_ENOMEM;
 
-  memcpy(proctab_message,msg,sizeof(*msg));
+  proctab_message = (char *)malloc(sizeof(*msg) + msg->lmon_payload_length +
+                                   msg->usr_payload_length);
+
+  if (proctab_message == NULL) return LMON_ENOMEM;
+
+  memcpy(proctab_message, msg, sizeof(*msg));
   trav_ptr = proctab_message;
-  trav_ptr += sizeof(*msg);	  
-	 
-  bytesread 
-    = read_lmonp_payloads(readingFd, 
-			  trav_ptr, 
-			  msg->lmon_payload_length+msg->usr_payload_length);
+  trav_ptr += sizeof(*msg);
 
-	 
-  if ( bytesread != (int) (msg->lmon_payload_length+msg->usr_payload_length))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-	"read_lmonp_payloads returned a bad return code" );
+  bytesread = read_lmonp_payloads(
+      readingFd, trav_ptr, msg->lmon_payload_length + msg->usr_payload_length);
 
-      return -1;
-    }
-       
+  if (bytesread != (int)(msg->lmon_payload_length + msg->usr_payload_length)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_payloads returned a bad return code");
+
+    return -1;
+  }
+
   //
   // registering a raw proctable message
   // one might expect a race condition here for fear that other thread may use
-  // mydesc->proctab_msg before this assignment. But this assignment is 
+  // mydesc->proctab_msg before this assignment. But this assignment is
   // supposed to happen while the main thread is being block on a condition
-  // variable either in LMON_fe_attachAndSpawnDaemons or LMON_fe_launchAndSpawnDaemons
+  // variable either in LMON_fe_attachAndSpawnDaemons or
+  // LMON_fe_launchAndSpawnDaemons
   //
-  mydesc->proctab_msg = (lmonp_t *) proctab_message;
-  
+  mydesc->proctab_msg = (lmonp_t *)proctab_message;
+
   return 0;
 }
 
-
-static int 
-LMON_handle_resourcehandle_event ( 
-		int readingFd, 
-		lmon_session_desc_t *mydesc, 
-		lmonp_t *msg )
-{
+static int LMON_handle_resourcehandle_event(int readingFd,
+                                            lmon_session_desc_t *mydesc,
+                                            lmonp_t *msg) {
   uint32_t rid;
   int bytesread;
 
-  if ( (msg->lmon_payload_length+msg->usr_payload_length) != sizeof(int) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-        "payload size mismatch detected during LMON_handle_resourcehandle_event" );
-      return -1;
-    }
-  
-  bytesread 
-    = read_lmonp_payloads(readingFd, 
-			  &rid, 
-			  msg->lmon_payload_length+msg->usr_payload_length);
+  if ((msg->lmon_payload_length + msg->usr_payload_length) != sizeof(int)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "payload size mismatch detected during "
+                 "LMON_handle_resourcehandle_event");
+    return -1;
+  }
 
-  if ( bytesread != (int) (msg->lmon_payload_length+msg->usr_payload_length))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-        "read_lmonp_payloads returned a bad return code" );
+  bytesread = read_lmonp_payloads(
+      readingFd, &rid, msg->lmon_payload_length + msg->usr_payload_length);
 
-      return -1;
-    }
-  
+  if (bytesread != (int)(msg->lmon_payload_length + msg->usr_payload_length)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_payloads returned a bad return code");
+
+    return -1;
+  }
+
   mydesc->resourceHandle = rid;
 
   return 0;
 }
 
-
-static int
-LMON_handle_rminfo_event (
-		int readingFd, 
-		lmon_session_desc_t *mydesc,
-		lmonp_t *msg )
-{
+static int LMON_handle_rminfo_event(int readingFd, lmon_session_desc_t *mydesc,
+                                    lmonp_t *msg) {
   uint32_t pid_rm_pair[2];
   int bytesread;
 
   /*
-   * lmonp_payload: launcherpid (4bytes) rm_type (4bytes) 
+   * lmonp_payload: launcherpid (4bytes) rm_type (4bytes)
    */
-  if ( (msg->lmon_payload_length+msg->usr_payload_length) != sizeof(pid_rm_pair))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-        "payload size mismatch detected during LMON_handle_rminfo_event" );
-      return -1;
-    }
-  
-  bytesread 
-    = read_lmonp_payloads(readingFd,
-			  pid_rm_pair,
-			  msg->lmon_payload_length+msg->usr_payload_length);
+  if ((msg->lmon_payload_length + msg->usr_payload_length) !=
+      sizeof(pid_rm_pair)) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
+        "payload size mismatch detected during LMON_handle_rminfo_event");
+    return -1;
+  }
 
-  if ( bytesread != (int) (msg->lmon_payload_length+msg->usr_payload_length))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-        "read_lmonp_payloads returned a bad return code" );
+  bytesread =
+      read_lmonp_payloads(readingFd, pid_rm_pair,
+                          msg->lmon_payload_length + msg->usr_payload_length);
 
-      return -1;
-    }
+  if (bytesread != (int)(msg->lmon_payload_length + msg->usr_payload_length)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "read_lmonp_payloads returned a bad return code");
 
-  mydesc->rm_launcher_pid = (pid_t) pid_rm_pair[0];
-  mydesc->rm_info.rm_launcher_pid = (pid_t) pid_rm_pair[0];
+    return -1;
+  }
 
-  rm_catalogue_e rm_type = (rm_catalogue_e) pid_rm_pair[1];
+  mydesc->rm_launcher_pid = (pid_t)pid_rm_pair[0];
+  mydesc->rm_info.rm_launcher_pid = (pid_t)pid_rm_pair[0];
+
+  rm_catalogue_e rm_type = (rm_catalogue_e)pid_rm_pair[1];
   int i;
-  for (i=0; i <  mydesc->rm_info.num_supported_types; ++i)
-    {
-      if (mydesc->rm_info.rm_supported_types[i] == rm_type)
-        {
-          mydesc->rm_info.index_to_cur_instance = i;
-          break;
-        }
-     }
+  for (i = 0; i < mydesc->rm_info.num_supported_types; ++i) {
+    if (mydesc->rm_info.rm_supported_types[i] == rm_type) {
+      mydesc->rm_info.index_to_cur_instance = i;
+      break;
+    }
+  }
 
-  return (i < mydesc->rm_info.num_supported_types)? 0 : -1;
+  return (i < mydesc->rm_info.num_supported_types) ? 0 : -1;
 }
 
-
-static void
-LMON_child_fork_handler ( void )
-{
+static void LMON_child_fork_handler(void) {
   int i;
   lmon_session_desc_t *mydesc;
 
   /*
    *
-   * This fork handler terminates all active threads because 
-   * they may cause unwonted contentions with 
+   * This fork handler terminates all active threads because
+   * they may cause unwonted contentions with
    * the parent process's threads.
    *
    * The recent code which allows LaunchMON to invoke a separate
@@ -2818,367 +2421,335 @@ LMON_child_fork_handler ( void )
    *
    */
 
-  for (i=0; i < MAX_LMON_SESSION; ++i) 
-    {
-      mydesc = &(sess.sessionDescArray[i]);
+  for (i = 0; i < MAX_LMON_SESSION; ++i) {
+    mydesc = &(sess.sessionDescArray[i]);
 
-      /*
-       * I wouldn't worry about data races for this routine. (no locks) 
-       */
-      if ( (mydesc->registered == LMON_TRUE)
-	   && (mydesc->spawned == LMON_TRUE))
-	{
+    /*
+     * I wouldn't worry about data races for this routine. (no locks)
+     */
+    if ((mydesc->registered == LMON_TRUE) && (mydesc->spawned == LMON_TRUE)) {
 #ifdef WATCHDOG_THREAD_DEBUG
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	     "child fork handler, cancelling watchdog threads");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "child fork handler, cancelling watchdog threads");
 #endif
-	  pthread_cancel ( mydesc->watchdogThr.fetofeMonitoringThr );	  
-	}
+      pthread_cancel(mydesc->watchdogThr.fetofeMonitoringThr);
     }
+  }
 }
 
-
-static int
-fe_getStatus ( lmon_session_desc_t* mydesc, int *status )
-{
+static int fe_getStatus(lmon_session_desc_t *mydesc, int *status) {
   int globalmask = 0;
-  int localmask  = 0; 
+  int localmask = 0;
   (*status) = 0;
 
-  if ( mydesc->registered == LMON_TRUE )
-    {
-      localmask = 1;
-      globalmask |= localmask;
-    }
+  if (mydesc->registered == LMON_TRUE) {
+    localmask = 1;
+    globalmask |= localmask;
+  }
 
-  if ( mydesc->spawned == LMON_TRUE )
-    {
-      localmask = 1;
-      localmask = localmask << 1; 
-      globalmask |= localmask;
-    }
+  if (mydesc->spawned == LMON_TRUE) {
+    localmask = 1;
+    localmask = localmask << 1;
+    globalmask |= localmask;
+  }
 
-  if ( mydesc->mw_spawned == LMON_TRUE )
-    {
-      localmask = 1;
-      localmask = localmask << 2; 
-      globalmask |= localmask;
-    }
+  if (mydesc->mw_spawned == LMON_TRUE) {
+    localmask = 1;
+    localmask = localmask << 2;
+    globalmask |= localmask;
+  }
 
-  if ( mydesc->detached == LMON_TRUE )
-    {
-      localmask = 1;
-      localmask = localmask << 3; 
-      globalmask |= localmask;
-    }
+  if (mydesc->detached == LMON_TRUE) {
+    localmask = 1;
+    localmask = localmask << 3;
+    globalmask |= localmask;
+  }
 
-  if ( mydesc->killed == LMON_TRUE )
-    {
-      localmask = 1;
-      localmask = localmask << 4; 
-      globalmask |= localmask;
-    }
+  if (mydesc->killed == LMON_TRUE) {
+    localmask = 1;
+    localmask = localmask << 4;
+    globalmask |= localmask;
+  }
 
   (*status) = globalmask;
 
   return 0;
 }
 
-
 //! LMON_fetofe_watchdog_thread ( void* arg )
 /*!
-  The main watchdog thread routine. designed to watch per-session launchmon 
+  The main watchdog thread routine. designed to watch per-session launchmon
   engine process.
 
 
-  Currently, this function uses fine-grain pthread locks. 
+  Currently, this function uses fine-grain pthread locks.
 */
-static void* 
-LMON_fetofe_watchdog_thread ( void *arg )
-{
+static void *LMON_fetofe_watchdog_thread(void *arg) {
   int rc;
   int readingFd;
   int sessionId;
   int status;
-  int *argconv; 
+  int *argconv;
   lmonp_t msg;
   lmon_session_desc_t *mydesc;
 
-  /* 
+  /*
    ***************** IMPORTANT ***********************
    *
-   * NOTE: Shared data access policy 
+   * NOTE: Shared data access policy
    * Watchdog threads
    * 1. For watchdog threads, only this routine (top-level thread function)
-   *    can acquire/release locks. 
-   * 2. Watchdog threads are responsible for destorying and initializing 
-   *    their session descriptors only when "asynchronous" termination 
+   *    can acquire/release locks.
+   * 2. Watchdog threads are responsible for destorying and initializing
+   *    their session descriptors only when "asynchronous" termination
    *    event occurs.
-   * 
+   *
    * The Main thread
    * 1. For the main thread, only the top-level external API calls
    *    can acquire/release locks and use condition variables.
    * 2. The main thread is responsible for destorying and initializing
-   *    its session descriptors when "synchronous" termination 
-   *    event occurs. 
+   *    its session descriptors when "synchronous" termination
+   *    event occurs.
    *
    ***************** IMPORTANT ***********************
    */
 
-
-  argconv = (int *) arg;
+  argconv = (int *)arg;
   readingFd = argconv[0];
   sessionId = argconv[1];
   mydesc = &(sess.sessionDescArray[sessionId]);
-  
+
 #ifdef WATCHDOG_THREAD_DEBUG
   char message[PATH_MAX];
   sprintf(message, "watchdog thread created: sessionid %d", sessionId);
-  LMON_say_msg ( LMON_FE_MSG_PREFIX, true, message);
+  LMON_say_msg(LMON_FE_MSG_PREFIX, true, message);
 #endif
-  
+
   /*
-   * While the per-session watchdog thread is alive, the session 
+   * While the per-session watchdog thread is alive, the session
    * descriptor cannot be destroyed and re-initialized.
    */
-  for ( ; ; )
-    {									
+  for (;;) {
+    //
+    //
+    // per-session watchdog thread's main event loop ...
+    //
+    //
+    if ((rc = read_lmonp_msgheader(readingFd, &msg)) < 0) {
+      //
+      // If "read a message" fails, we should loop over
       //
       //
-      // per-session watchdog thread's main event loop ...
-      //
-      //
-      if ( ( rc = read_lmonp_msgheader ( readingFd, &msg )) < 0 )
-	{
-	  //
-	  // If "read a message" fails, we should loop over
-	  //
-	  //
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	     "read_lmonp_msg returned a negative return code");
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	     "front end's connection to launchmon engine is disconnected?");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "read_lmonp_msg returned a negative return code");
+      LMON_say_msg(
+          LMON_FE_MSG_PREFIX, true,
+          "front end's connection to launchmon engine is disconnected?");
 
-	  break;	  
-	}
-
-      switch ( msg.type.fetofe_type )
-	{
-	case lmonp_stop_at_launch_bp_spawned:
-	case lmonp_stop_at_first_attach:
-	  //
-	  // The events indicating "app tasks and tool daemons are spawned
-	  //
-	  //
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "launch_bp or first_attach done...");
-#endif
-	  break;
-
-	case lmonp_proctable_avail:
-	  //
-	  // The event indicating the proctable is available.
-	  // 
-	  //
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  if ( LMON_handle_proctab_event(readingFd, mydesc, &msg) != 0 )
-	    {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-                 "LMON_handle_proctab_event failed");
-
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	      goto watchdog_done;
-	    }
-	  mydesc->spawned = LMON_TRUE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "RPDTAB message received...");
-#endif
-	  //
-	  // Let the main thread know, the LaunchMON engine says 
-          // "it is okay to spawn daemons
-	  //
-	  pthread_cond_signal(&(mydesc->watchdogThr.condVar));
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	  break;
-
-	case lmonp_resourcehandle_avail:
-	  //
-	  // The event indicating the resourcehandle is available.
-	  // 
-	  //
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  if ( LMON_handle_resourcehandle_event(readingFd, mydesc, &msg) != 0 )
-	    {	     
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-                 "LMON_handle_resourcehandle_event failed");
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	      goto watchdog_done;
-	    }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "rid available event received...");
-#endif
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	  break;
-
-        case lmonp_rminfo:
-	  //
-	  // The event indicating RMInfo is available.
-	  // 
-	  //
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  if ( LMON_handle_rminfo_event(readingFd, mydesc, &msg) != 0 )
-	    {	     
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-                 "LMON_handle_rminfo_event failed");
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	      goto watchdog_done;
-	    }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "rminfo event received...");
-#endif
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	  break;
-
-	case lmonp_detach_done:
-          //
-	  // Synchronous detach event  
-          //
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  mydesc->detached = LMON_TRUE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "detach cmd done...");
-#endif
-	  pthread_cond_signal(&(mydesc->watchdogThr.condVar));
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-          goto watchdog_done;
-	  break;	
-
-	case lmonp_kill_done:
-          //
-	  // Synchronous termination event
-          //
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  mydesc->killed = LMON_TRUE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "kill cmd done...");
-#endif
-	  pthread_cond_signal(&(mydesc->watchdogThr.condVar));
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-          goto watchdog_done;
-	  break;	
-
-        case lmonp_stop_tracing:
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  mydesc->detached = LMON_TRUE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "the engine stopped tracing the job...");
-#endif
-	  // this can unlock the main thread that's possible waiting on a cond var 
-          pthread_cond_signal(&(mydesc->watchdogThr.condVar));
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-          goto watchdog_done;
-          break;
-
-        case lmonp_bedmon_exited:
-	case lmonp_mwdmon_exited:
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  mydesc->detached = LMON_TRUE;
-	  mydesc->spawned = LMON_FALSE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "the daemons terminated...");
-#endif
-	  // this can unlock the main thread that's possible waiting on a cond var 
-          pthread_cond_signal(&(mydesc->watchdogThr.condVar));
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-          goto watchdog_done;
-          break;
-
-	case lmonp_exited:
-	case lmonp_terminated:
-	case lmonp_stop_at_launch_bp_abort:
-	  // 
-	  // Asynchronous termination event
-	  // The event indicating the job is done, either normally or abnormally
-	  // 
-	  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-	  mydesc->killed = LMON_TRUE;
-          fe_getStatus (mydesc, &status); 
-          if (mydesc->statusCB != NULL)
-            {
-              if (mydesc->statusCB(&status) != 0)
-                {
-	          LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-                    "registered status call back returned non-zero... continue");
-                }
-            }
-#if VERBOSE 
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	     "the job terminated...");
-#endif
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-	  goto watchdog_asynch_termination;
-	  break;
-
-	default:
-	  goto watchdog_done;
-	  break;
-	}
+      break;
     }
 
-  watchdog_asynch_termination:
+    switch (msg.type.fetofe_type) {
+      case lmonp_stop_at_launch_bp_spawned:
+      case lmonp_stop_at_first_attach:
+//
+// The events indicating "app tasks and tool daemons are spawned
+//
+//
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "launch_bp or first_attach done...");
+#endif
+        break;
+
+      case lmonp_proctable_avail:
+        //
+        // The event indicating the proctable is available.
+        //
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        if (LMON_handle_proctab_event(readingFd, mydesc, &msg) != 0) {
+          LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                       "LMON_handle_proctab_event failed");
+
+          pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+          goto watchdog_done;
+        }
+        mydesc->spawned = LMON_TRUE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "RPDTAB message received...");
+#endif
+        //
+        // Let the main thread know, the LaunchMON engine says
+        // "it is okay to spawn daemons
+        //
+        pthread_cond_signal(&(mydesc->watchdogThr.condVar));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        break;
+
+      case lmonp_resourcehandle_avail:
+        //
+        // The event indicating the resourcehandle is available.
+        //
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        if (LMON_handle_resourcehandle_event(readingFd, mydesc, &msg) != 0) {
+          LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                       "LMON_handle_resourcehandle_event failed");
+          pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+          goto watchdog_done;
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "rid available event received...");
+#endif
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        break;
+
+      case lmonp_rminfo:
+        //
+        // The event indicating RMInfo is available.
+        //
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        if (LMON_handle_rminfo_event(readingFd, mydesc, &msg) != 0) {
+          LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                       "LMON_handle_rminfo_event failed");
+          pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+          goto watchdog_done;
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "rminfo event received...");
+#endif
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        break;
+
+      case lmonp_detach_done:
+        //
+        // Synchronous detach event
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        mydesc->detached = LMON_TRUE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "detach cmd done...");
+#endif
+        pthread_cond_signal(&(mydesc->watchdogThr.condVar));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        goto watchdog_done;
+        break;
+
+      case lmonp_kill_done:
+        //
+        // Synchronous termination event
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        mydesc->killed = LMON_TRUE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "kill cmd done...");
+#endif
+        pthread_cond_signal(&(mydesc->watchdogThr.condVar));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        goto watchdog_done;
+        break;
+
+      case lmonp_stop_tracing:
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        mydesc->detached = LMON_TRUE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                     "the engine stopped tracing the job...");
+#endif
+        // this can unlock the main thread that's possible waiting on a cond var
+        pthread_cond_signal(&(mydesc->watchdogThr.condVar));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        goto watchdog_done;
+        break;
+
+      case lmonp_bedmon_exited:
+      case lmonp_mwdmon_exited:
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        mydesc->detached = LMON_TRUE;
+        mydesc->spawned = LMON_FALSE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "the daemons terminated...");
+#endif
+        // this can unlock the main thread that's possible waiting on a cond var
+        pthread_cond_signal(&(mydesc->watchdogThr.condVar));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        goto watchdog_done;
+        break;
+
+      case lmonp_exited:
+      case lmonp_terminated:
+      case lmonp_stop_at_launch_bp_abort:
+        //
+        // Asynchronous termination event
+        // The event indicating the job is done, either normally or abnormally
+        //
+        pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+        mydesc->killed = LMON_TRUE;
+        fe_getStatus(mydesc, &status);
+        if (mydesc->statusCB != NULL) {
+          if (mydesc->statusCB(&status) != 0) {
+            LMON_say_msg(
+                LMON_FE_MSG_PREFIX, false,
+                "registered status call back returned non-zero... continue");
+          }
+        }
+#if VERBOSE
+        LMON_say_msg(LMON_FE_MSG_PREFIX, false, "the job terminated...");
+#endif
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        goto watchdog_asynch_termination;
+        break;
+
+      default:
+        goto watchdog_done;
+        break;
+    }
+  }
+
+watchdog_asynch_termination:
 
 #if 0
     pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
@@ -3187,250 +2758,218 @@ LMON_fetofe_watchdog_thread ( void *arg )
     pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 #endif
 
-  watchdog_done: 
-    pthread_exit(NULL); 
+watchdog_done:
+  pthread_exit(NULL);
 }
 
-static void tokenize(std::string str, std::list<std::string> &result)
-{
-#  define append_to_buffer(C) buffer[buffer_pos++] = C
+static void tokenize(std::string str, std::list<std::string> &result) {
+#define append_to_buffer(C) buffer[buffer_pos++] = C
 
-   size_t len = str.length(), buffer_pos = 0;
-   char *buffer = (char *) malloc(len+1);
-   bool escaped = false, quoted = false;
+  size_t len = str.length(), buffer_pos = 0;
+  char *buffer = (char *)malloc(len + 1);
+  bool escaped = false, quoted = false;
 
-   for (int i = 0; i < len; i++) {
-      char c = str[i];
-      if (escaped) {
-         switch (c) {
-            case 'a': append_to_buffer('\a'); break;
-            case 'b': append_to_buffer('\b'); break;
-            case 'f': append_to_buffer('\f'); break;
-            case 'n': append_to_buffer('\n'); break;
-            case 'r': append_to_buffer('\r'); break;
-            case 't': append_to_buffer('\t'); break;
-            case 'v': append_to_buffer('\v'); break;
-            default: append_to_buffer(c); break;
-         }
-         escaped = false;
+  for (int i = 0; i < len; i++) {
+    char c = str[i];
+    if (escaped) {
+      switch (c) {
+        case 'a':
+          append_to_buffer('\a');
+          break;
+        case 'b':
+          append_to_buffer('\b');
+          break;
+        case 'f':
+          append_to_buffer('\f');
+          break;
+        case 'n':
+          append_to_buffer('\n');
+          break;
+        case 'r':
+          append_to_buffer('\r');
+          break;
+        case 't':
+          append_to_buffer('\t');
+          break;
+        case 'v':
+          append_to_buffer('\v');
+          break;
+        default:
+          append_to_buffer(c);
+          break;
       }
-      else if (c == '\\') {
-         escaped = true;
-      }
-      else if (c == '"') {
-         quoted = !quoted;
-      }
-      else if (quoted) {
-         append_to_buffer(c);
-      }
-      else if (c == ' ') {
-         append_to_buffer('\0');
-         result.push_back(buffer);
-         buffer_pos = 0;
-
-         while (i+1 < len && buffer[i+1] == ' ')
-            i++;
-      }
-      else {
-         append_to_buffer(c);
-      }
-   }
-
-   if (buffer_pos > 0) {
+      escaped = false;
+    } else if (c == '\\') {
+      escaped = true;
+    } else if (c == '"') {
+      quoted = !quoted;
+    } else if (quoted) {
+      append_to_buffer(c);
+    } else if (c == ' ') {
       append_to_buffer('\0');
       result.push_back(buffer);
-   }
+      buffer_pos = 0;
 
-   free(buffer);
+      while (i + 1 < len && buffer[i + 1] == ' ') i++;
+    } else {
+      append_to_buffer(c);
+    }
+  }
+
+  if (buffer_pos > 0) {
+    append_to_buffer('\0');
+    result.push_back(buffer);
+  }
+
+  free(buffer);
 }
 
-static int
-tokenize ( const std::string& str,
-           char **myargv,
-           int myargvMax )
-{
+static int tokenize(const std::string &str, char **myargv, int myargvMax) {
   char *first = (char *)str.c_str();
   char *last = NULL;
-  int i=0;
-  int quote=0; 
+  int i = 0;
+  int quote = 0;
 
-  if (!first)
-    return -1;
+  if (!first) return -1;
 
-  for (i=0;i < myargvMax ; ++i)
-    {
-      while ( *first != '\0' && ((*first == ' ') || (*first) == '"')) 
-        {
-          if ( (*first) == '"' )
-            quote=1;
-          first++;
-        }
+  for (i = 0; i < myargvMax; ++i) {
+    while (*first != '\0' && ((*first == ' ') || (*first) == '"')) {
+      if ((*first) == '"') quote = 1;
+      first++;
+    }
 
-      last = first;
+    last = first;
 
-      if ( quote ) 
-        {
-          while ( *last != '\0' && *last != '"' )
-            last++;
+    if (quote) {
+      while (*last != '\0' && *last != '"') last++;
 
-          if (*last == '\0' )
-            return -1;
-        } 
-      else
-        {
-          while ( *last != '\0' && *last != ' ' )
-            last++; 
-        }
+      if (*last == '\0') return -1;
+    } else {
+      while (*last != '\0' && *last != ' ') last++;
+    }
 
-    if ( first == last )
-      break;
-     
-    myargv[i] = (char *) malloc (last - first + 1);
-    memcpy ( myargv[i], first, last-first );
-    myargv[i][last-first] = '\0';
+    if (first == last) break;
 
-    if ( quote )
-      last++;
+    myargv[i] = (char *)malloc(last - first + 1);
+    memcpy(myargv[i], first, last - first);
+    myargv[i][last - first] = '\0';
+
+    if (quote) last++;
 
     quote = 0;
     first = last;
   }
 
-  return i; 
+  return i;
 }
 
-
-static lmon_rc_e 
-bld_exec_lmon_launch_str ( bool isLocal, 
-			   const char *hostname,
-			   const std::list<std::string> &lmonOptArgs, 
-			   opts_args_t &opt )
-{
+static lmon_rc_e bld_exec_lmon_launch_str(
+    bool isLocal, const char *hostname,
+    const std::list<std::string> &lmonOptArgs, opts_args_t &opt) {
   using namespace std;
 
   std::list<std::string> cmdlist;
   char *rm;
   char *lmonpath;
   char *debugflag;
-  int k=0;
+  int k = 0;
 
-  if ( isLocal ) 
-    {
+  if (isLocal) {
+    map<string, string>::const_iterator envListPos;
+    for (envListPos = opt.get_my_opt()->envMap.begin();
+         envListPos != opt.get_my_opt()->envMap.end(); envListPos++) {
+      setenv(envListPos->first.c_str(), envListPos->second.c_str(), 1);
+    }
 
-      map<string, string>::const_iterator envListPos;		
-      for (envListPos = opt.get_my_opt()->envMap.begin(); 
-	   envListPos !=  opt.get_my_opt()->envMap.end(); envListPos++)
-	{ 
- 	  setenv ( envListPos->first.c_str (), envListPos->second.c_str (), 1 );
-	}
+    if (getenv("LMON_DEBUG_LAUNCHMON_ENGINE")) {
+      tokenize(TVCMD, cmdlist);
+    }
 
-      if ( getenv("LMON_DEBUG_LAUNCHMON_ENGINE") )
-	{
-           tokenize(TVCMD, cmdlist);
-	}
+    if ((lmonpath = getenv("LMON_LAUNCHMON_ENGINE_PATH")) != NULL) {
+      cmdlist.push_back(lmonpath);
+    } else {
+      cmdlist.push_back("launchmon");
+    }
 
-      if ( ( lmonpath = getenv ("LMON_LAUNCHMON_ENGINE_PATH")) != NULL )
-	{
-          cmdlist.push_back(lmonpath);
-	}
-      else
-	{
-	  cmdlist.push_back("launchmon");
-	}
+    if (getenv("LMON_DEBUG_LAUNCHMON_ENGINE")) {
+      cmdlist.push_back("-a");
+    }
+    cmdlist.insert(cmdlist.end(), lmonOptArgs.begin(), lmonOptArgs.end());
 
-      if ( getenv("LMON_DEBUG_LAUNCHMON_ENGINE") )
-	{
-           cmdlist.push_back("-a");
-	}
-      cmdlist.insert(cmdlist.end(), lmonOptArgs.begin(), lmonOptArgs.end());
+    if (k < 0) return LMON_EINVAL;
 
-      if ( k < 0 )
-        return LMON_EINVAL;
+  }  // The tool FEN is already co-located with the RM.
+  else {
+    // LMON_REMOTE_LOGIN (default=ssh)
+    if ((rm = getenv("LMON_REMOTE_LOGIN")) != NULL)
+      tokenize(rm, cmdlist);
+    else
+      tokenize(SSHCMD, cmdlist);
 
-    }  // The tool FEN is already co-located with the RM.
-  else
-    {
-      // LMON_REMOTE_LOGIN (default=ssh)
-      if ( ( rm = getenv ("LMON_REMOTE_LOGIN")) != NULL )	  
-         tokenize(rm, cmdlist);
-      else	  
-         tokenize(SSHCMD, cmdlist);
+    cmdlist.push_back(hostname);
 
-      cmdlist.push_back(hostname);
+    cmdlist.push_back(ENVCMD);
 
-      cmdlist.push_back(ENVCMD);
+    map<string, string>::const_iterator envListPos;
+    for (envListPos = opt.get_my_opt()->envMap.begin();
+         envListPos != opt.get_my_opt()->envMap.end(); envListPos++) {
+      string lstring = envListPos->first + "=" + envListPos->second;
+      cmdlist.push_back(lstring);
+    }
 
-      map<string, string>::const_iterator envListPos;		
-      for (envListPos = opt.get_my_opt()->envMap.begin(); 
-	   envListPos !=  opt.get_my_opt()->envMap.end(); envListPos++)
-	{ 
-	  string lstring = envListPos->first + "=" + envListPos->second;
-          cmdlist.push_back(lstring);
-	}
+    char *pref = getenv("LMON_PREFIX");
+    if (pref) {
+      cmdlist.push_back(string("LMON_PREFIX=") + string(pref));
+    } else if (pref = getenv("LMON_RM_CONFIG_DIR")) {
+      cmdlist.push_back(string("LMON_RM_CONFIG_DIR=") + string(pref));
+      if (pref = getenv("LMON_COLOC_UTIL_DIR"))
+        cmdlist.push_back(string("LMON_COLOC_UTIL_DIR=") + string(pref));
+    }
 
-      char *pref = getenv("LMON_PREFIX");
-      if ( pref )
-        {
-           cmdlist.push_back(string("LMON_PREFIX=") + string(pref));
-        }
-      else if ( pref = getenv("LMON_RM_CONFIG_DIR") )
-       {
-           cmdlist.push_back(string("LMON_RM_CONFIG_DIR=") + string(pref));
-           if ( pref = getenv("LMON_COLOC_UTIL_DIR"))
-               cmdlist.push_back(string("LMON_COLOC_UTIL_DIR=") + string(pref));
-       }
+    if (getenv("LMON_DEBUG_LAUNCHMON_ENGINE")) {
+      tokenize(TVCMD, cmdlist);
+    }
 
-      if ( getenv("LMON_DEBUG_LAUNCHMON_ENGINE") )
-	{
-           tokenize(TVCMD, cmdlist);
-	}
+    if ((lmonpath = getenv("LMON_LAUNCHMON_ENGINE_PATH")) != NULL) {
+      cmdlist.push_back(lmonpath);
 
-      if ( ( lmonpath = getenv ("LMON_LAUNCHMON_ENGINE_PATH")) != NULL )
-	{
-           cmdlist.push_back(lmonpath);
+      //
+      // perform a sanity check here of the given path
+      //
+    } else {
+      cmdlist.push_back("launchmon");
+      //
+      // perform a sanity check if this is in the user's PATH
+      //
+    }
 
-	  //
-	  // perform a sanity check here of the given path
-	  //
-	}
-      else
-	{
-           cmdlist.push_back("launchmon");
-	  //
-	  // perform a sanity check if this is in the user's PATH
-	  //
-	}
+    if (getenv("LMON_DEBUG_LAUNCHMON_ENGINE")) {
+      cmdlist.push_back("-a");
+    }
 
-      if ( getenv("LMON_DEBUG_LAUNCHMON_ENGINE") )
-	{
-           cmdlist.push_back("-a");
-	}
-      
-      cmdlist.insert(cmdlist.end(), lmonOptArgs.begin(), lmonOptArgs.end());      
-    }  // The tool FEN is not co-located with the RM.
+    cmdlist.insert(cmdlist.end(), lmonOptArgs.begin(), lmonOptArgs.end());
+  }  // The tool FEN is not co-located with the RM.
 
-  char **myargv = (char **) malloc(sizeof(char *) * (cmdlist.size() + 1));
+  char **myargv = (char **)malloc(sizeof(char *) * (cmdlist.size() + 1));
   unsigned int j = 0;
   for (list<string>::iterator i = cmdlist.begin(); i != cmdlist.end(); i++) {
-     myargv[j++] = const_cast<char *>(i->c_str());
+    myargv[j++] = const_cast<char *>(i->c_str());
   }
   myargv[j] = NULL;
 
-  if ( execvp ( myargv[0], myargv) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "LaunchMON Engine invocation failed, exiting: %s",
-	strerror(errno));
+  if (execvp(myargv[0], myargv) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "LaunchMON Engine invocation failed, exiting: %s",
+                 strerror(errno));
 
-      //
-      // If execv fails, sink here. 
-      //
-      exit(1);
-    } 
+    //
+    // If execv fails, sink here.
+    //
+    exit(1);
+  }
 
   return LMON_EINVAL;
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -3439,994 +2978,735 @@ bld_exec_lmon_launch_str ( bool isLocal,
 //
 //
 
-
 //! lmon_rc_e LMON_fe_init ( int LMON_VERSION )
 /*!
 
     Please refer to the manpage
 
 */
-extern "C"
-lmon_rc_e
-LMON_fe_init ( int ver )
-{
+extern "C" lmon_rc_e LMON_fe_init(int ver) {
   int i;
 
-  if ( ver != LMON_return_ver() )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "LMON FE API version mismatch");
+  if (ver != LMON_return_ver()) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "LMON FE API version mismatch");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
 #if VERBOSE
-  /* This will enable debug print for security handshake 
-   * The security messages will not go to the errorCB 
+  /* This will enable debug print for security handshake
+   * The security messages will not go to the errorCB
    */
-  handshake_enable_debug_prints (stdout);
+  handshake_enable_debug_prints(stdout);
 #endif
 
-  set_client_name ( LMON_FE_MSG_PREFIX );
+  set_client_name(LMON_FE_MSG_PREFIX);
   std::string os_isa_str = TARGET_OS_ISA_STRING;
   resmanager.init(os_isa_str);
 
-  for (i=0; i < MAX_LMON_SESSION; ++i )
-    {
-      /*
-       * We initialize eventMutex and condition variable separately since this lock
-       * should be persistent throughout the exectuion unlike other
-       * pthread primitives.
-       */
-      pthread_mutex_init (&(sess.sessionDescArray[i].watchdogThr.eventMutex), NULL);
-      pthread_cond_init(&(sess.sessionDescArray[i].watchdogThr.condVar), NULL);
-    }
+  for (i = 0; i < MAX_LMON_SESSION; ++i) {
+    /*
+     * We initialize eventMutex and condition variable separately since this
+     * lock
+     * should be persistent throughout the exectuion unlike other
+     * pthread primitives.
+     */
+    pthread_mutex_init(&(sess.sessionDescArray[i].watchdogThr.eventMutex),
+                       NULL);
+    pthread_cond_init(&(sess.sessionDescArray[i].watchdogThr.condVar), NULL);
+  }
 
-  for (i=0; i < MAX_LMON_SESSION; ++i) 
-    {
-      /*
-       * Being paranoid on data race conditions...
-       */
-      pthread_mutex_lock (&(sess.sessionDescArray[i].watchdogThr.eventMutex));
-      if ( LMON_init_sess(&(sess.sessionDescArray[i])) != 0 )
-	{
-          pthread_mutex_unlock (&(sess.sessionDescArray[i].watchdogThr.eventMutex));
+  for (i = 0; i < MAX_LMON_SESSION; ++i) {
+    /*
+     * Being paranoid on data race conditions...
+     */
+    pthread_mutex_lock(&(sess.sessionDescArray[i].watchdogThr.eventMutex));
+    if (LMON_init_sess(&(sess.sessionDescArray[i])) != 0) {
+      pthread_mutex_unlock(&(sess.sessionDescArray[i].watchdogThr.eventMutex));
 
-	  return LMON_EINIT;
-	}
-      pthread_mutex_unlock (&(sess.sessionDescArray[i].watchdogThr.eventMutex));
+      return LMON_EINIT;
     }
+    pthread_mutex_unlock(&(sess.sessionDescArray[i].watchdogThr.eventMutex));
+  }
 
   sess.sessionPtrIndex = 0;
-  
+
   //
-  // calling pthread_atfork so that forked process won't inherit 
+  // calling pthread_atfork so that forked process won't inherit
   // active watchdog threads. This is possible if the client
-  // is requesting more than one active sessions. 
-  // Apparently, you don't want the 
-  // launchmon engine to have those watchdog threads...  
+  // is requesting more than one active sessions.
+  // Apparently, you don't want the
+  // launchmon engine to have those watchdog threads...
   //
-  if ( ( pthread_atfork ( NULL, NULL, LMON_child_fork_handler ) ) != 0 )
+  if ((pthread_atfork(NULL, NULL, LMON_child_fork_handler)) != 0)
     return LMON_ESYS;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_fe_createsession(int* sessionHandle)
-/*! 
+/*!
 
     Please refer to the manpage
 
 */
-extern "C"
-lmon_rc_e
-LMON_fe_createSession ( int *sessionHandle )
-{ 
+extern "C" lmon_rc_e LMON_fe_createSession(int *sessionHandle) {
   char portinfo[10];
   char rannum[LMON_KEY_LENGTH];
   gcry_error_t gcrc;
   lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
-  lmon_daemon_env_t fe_listensock_info_secchk[4];     
+  lmon_daemon_env_t fe_listensock_info_secchk[4];
   lmon_daemon_env_t fe_listensock_info_secchk_mw[4];
 
   (*sessionHandle) = sess.sessionPtrIndex;
   mydesc = &(sess.sessionDescArray[(*sessionHandle)]);
 
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if ( (mydesc->registered) == LMON_FALSE ) 
-    {
-      int rc;
-      int i;
+  if ((mydesc->registered) == LMON_FALSE) {
+    int rc;
+    int i;
 
-      for ( i = 0; i < 3; i++ )
-	{
-	  //
-	  // opens up a TCP socket, binding it with a random port and listening 
-	  // in on it. This is per-session server socket.
-	  //
-	  // 0: FE-BE
-	  // 1: FE-MW
-	  // 2: FE-Engine
-	  //
-	  if ( LMON_openBindAndListen ( &(mydesc->commDesc[i].sessionListenSockFd) ) 
-	       != LMON_OK )
-	    { 
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "LMON_openBindAndListen Failed");
-
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-	      return  LMON_ESYS;
-	    }
-
-	  socklen_t len = sizeof ( mydesc->commDesc[i].servAddr );
-	  if ( ( rc = getsockname ( mydesc->commDesc[i].sessionListenSockFd,
-				    (struct sockaddr*) &(mydesc->commDesc[i].servAddr), 
-				    &len)) < 0 )
-	    {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "getsockname call failed");
-
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-	      return LMON_ESYS;
-	    }
-
-	  if ( ( inet_ntop(AF_INET, &(mydesc->commDesc[i].servAddr.sin_addr), 
-			   mydesc->commDesc[i].ipInfo, MAX_LMON_STRING)) == NULL )
-	    {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "inet_ntop call failed");
-
-	      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-	      return LMON_ESYS;
-	    }
-	}  // for ( i = 0; i < 3; i++ )
-
+    for (i = 0; i < 3; i++) {
       //
-      // a random seed for the random number generator
+      // opens up a TCP socket, binding it with a random port and listening
+      // in on it. This is per-session server socket.
       //
-      srand (time(NULL));
-
+      // 0: FE-BE
+      // 1: FE-MW
+      // 2: FE-Engine
       //
-      // randomID is a random number and shared_key is a encryption key,
-      // both of which get propagated to daemons via an environment variable: 
-      // RM propagates this to daemons and hence it should be secure.
-      //
-      mydesc->randomID = rand ();
-      bzero ( (void *) mydesc->shared_key, LMON_KEY_LENGTH );
-      sprintf ( mydesc->shared_key, "%d", rand ());
+      if (LMON_openBindAndListen(&(mydesc->commDesc[i].sessionListenSockFd)) !=
+          LMON_OK) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true, "LMON_openBindAndListen Failed");
 
-      //
-      // open a cipher: BLOWFISH Algorithm on 128 bit key
-      //
-      if ( (gcrc = gcry_cipher_open ( &(mydesc->cipher_hndl), 
-				      GCRY_CIPHER_BLOWFISH,
-				      GCRY_CIPHER_MODE_ECB,
-				      0 )) != GPG_ERR_NO_ERROR )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "gcry_cipher_open call failed: %s", 
-            gcry_strerror (gcrc));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        return LMON_ESYS;
+      }
 
-	  return LMON_ESYS;
-	}
+      socklen_t len = sizeof(mydesc->commDesc[i].servAddr);
+      if ((rc = getsockname(mydesc->commDesc[i].sessionListenSockFd,
+                            (struct sockaddr *)&(mydesc->commDesc[i].servAddr),
+                            &len)) < 0) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true, "getsockname call failed");
 
-      //
-      // setting a 128 bit key 
-      //
-      if ( (gcrc = gcry_cipher_setkey ( mydesc->cipher_hndl, 
-					mydesc->shared_key,
-					LMON_KEY_LENGTH )) != GPG_ERR_NO_ERROR )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "gcry_cipher_setkey call failed: %s", gcry_strerror(gcrc));
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-	  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        return LMON_ESYS;
+      }
 
-	  return LMON_ESYS;
-	}
+      if ((inet_ntop(AF_INET, &(mydesc->commDesc[i].servAddr.sin_addr),
+                     mydesc->commDesc[i].ipInfo, MAX_LMON_STRING)) == NULL) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true, "inet_ntop call failed");
+
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+        return LMON_ESYS;
+      }
+    }  // for ( i = 0; i < 3; i++ )
+
+    //
+    // a random seed for the random number generator
+    //
+    srand(time(NULL));
+
+    //
+    // randomID is a random number and shared_key is a encryption key,
+    // both of which get propagated to daemons via an environment variable:
+    // RM propagates this to daemons and hence it should be secure.
+    //
+    mydesc->randomID = rand();
+    bzero((void *)mydesc->shared_key, LMON_KEY_LENGTH);
+    sprintf(mydesc->shared_key, "%d", rand());
+
+    //
+    // open a cipher: BLOWFISH Algorithm on 128 bit key
+    //
+    if ((gcrc = gcry_cipher_open(&(mydesc->cipher_hndl), GCRY_CIPHER_BLOWFISH,
+                                 GCRY_CIPHER_MODE_ECB, 0)) !=
+        GPG_ERR_NO_ERROR) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "gcry_cipher_open call failed: %s",
+                   gcry_strerror(gcrc));
+
+      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+      return LMON_ESYS;
+    }
+
+    //
+    // setting a 128 bit key
+    //
+    if ((gcrc = gcry_cipher_setkey(mydesc->cipher_hndl, mydesc->shared_key,
+                                   LMON_KEY_LENGTH)) != GPG_ERR_NO_ERROR) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "gcry_cipher_setkey call failed: %s", gcry_strerror(gcrc));
+
+      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+      return LMON_ESYS;
+    }
 
 #if VERBOSE
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-         "GCRYPT shared_key: %s", mydesc->shared_key);
-       LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-         "GCRYPT setkey, %x:%x:%x:%x",
-	  *(int*)(mydesc->shared_key),
-	  *(int*)(mydesc->shared_key+4),
-	  *(int*)(mydesc->shared_key+8),
-	  *(int*)(mydesc->shared_key+12));
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "GCRYPT shared_key: %s",
+                 mydesc->shared_key);
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false, "GCRYPT setkey, %x:%x:%x:%x",
+                 *(int *)(mydesc->shared_key), *(int *)(mydesc->shared_key + 4),
+                 *(int *)(mydesc->shared_key + 8),
+                 *(int *)(mydesc->shared_key + 12));
 #endif
- 
-      //
-      // turn on a flag saying "session occupied"
-      //
-      mydesc->registered = LMON_TRUE;
 
-      // 
-      // envVar to communicate neccessary info to the BE master
-      // and the MW master      
-      // LMON_FE_ADDR_ENVNAME="LMON_FE_WHERETOCONNECT_ADDR"
-      // LMON_FE_PORT_ENVNAME="LMON_FE_WHERETOCONNECT_PORT"
-      // LMON_SHRD_SEC_ENVNAME="LMON_SHARED_SECRET"
-      // LMON_SEC_CHK_ENVNAME="LMON_SEC_CHK" 
-      //
+    //
+    // turn on a flag saying "session occupied"
+    //
+    mydesc->registered = LMON_TRUE;
 
-      //
-      // Front-end's IP information
-      //
-      fe_listensock_info_secchk[0].envName 
-	= strdup (LMON_FE_ADDR_ENVNAME);
-      fe_listensock_info_secchk[0].envValue 
-	= strdup (mydesc->commDesc[fe_be_conn].ipInfo);
-      fe_listensock_info_secchk[0].next = NULL;
+    //
+    // envVar to communicate neccessary info to the BE master
+    // and the MW master
+    // LMON_FE_ADDR_ENVNAME="LMON_FE_WHERETOCONNECT_ADDR"
+    // LMON_FE_PORT_ENVNAME="LMON_FE_WHERETOCONNECT_PORT"
+    // LMON_SHRD_SEC_ENVNAME="LMON_SHARED_SECRET"
+    // LMON_SEC_CHK_ENVNAME="LMON_SEC_CHK"
+    //
 
-      //
-      // Front-end's Port information
-      //
-      fe_listensock_info_secchk[1].envName 
-	= strdup(LMON_FE_PORT_ENVNAME);
-      sprintf ( portinfo, 
-		"%d", 
-		(unsigned short) 
-		ntohs (mydesc->commDesc[fe_be_conn].servAddr.sin_port) );
-      fe_listensock_info_secchk[1].envValue 
-	= strdup (portinfo);
-      fe_listensock_info_secchk[1].next 
-	= NULL;
+    //
+    // Front-end's IP information
+    //
+    fe_listensock_info_secchk[0].envName = strdup(LMON_FE_ADDR_ENVNAME);
+    fe_listensock_info_secchk[0].envValue =
+        strdup(mydesc->commDesc[fe_be_conn].ipInfo);
+    fe_listensock_info_secchk[0].next = NULL;
 
-      //
-      // Front-end's random session ID for secure connection
-      //
-      fe_listensock_info_secchk[2].envName 
-	= strdup (LMON_SEC_CHK_ENVNAME);
-      sprintf ( rannum, "%d", mydesc->randomID );
-      fe_listensock_info_secchk[2].envValue = strdup (rannum);
-      fe_listensock_info_secchk[2].next = NULL;
+    //
+    // Front-end's Port information
+    //
+    fe_listensock_info_secchk[1].envName = strdup(LMON_FE_PORT_ENVNAME);
+    sprintf(
+        portinfo, "%d",
+        (unsigned short)ntohs(mydesc->commDesc[fe_be_conn].servAddr.sin_port));
+    fe_listensock_info_secchk[1].envValue = strdup(portinfo);
+    fe_listensock_info_secchk[1].next = NULL;
 
-      //
-      // Shared Key for secure connection
-      //
-      fe_listensock_info_secchk[3].envName 
-	= strdup (LMON_SHRD_SEC_ENVNAME);
-      fe_listensock_info_secchk[3].envValue 
-	= strdup (mydesc->shared_key);
-      fe_listensock_info_secchk[3].next = NULL;
+    //
+    // Front-end's random session ID for secure connection
+    //
+    fe_listensock_info_secchk[2].envName = strdup(LMON_SEC_CHK_ENVNAME);
+    sprintf(rannum, "%d", mydesc->randomID);
+    fe_listensock_info_secchk[2].envValue = strdup(rannum);
+    fe_listensock_info_secchk[2].next = NULL;
 
-      //
-      // registering above info to the environment variable list
-      //
-      LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[0]),
-                               fe_listensock_info_secchk,
-                               4 );
+    //
+    // Shared Key for secure connection
+    //
+    fe_listensock_info_secchk[3].envName = strdup(LMON_SHRD_SEC_ENVNAME);
+    fe_listensock_info_secchk[3].envValue = strdup(mydesc->shared_key);
+    fe_listensock_info_secchk[3].next = NULL;
 
-      //
-      // release memory
-      //
-      for (i=0; i < 4; ++i)
-        {
-          free(fe_listensock_info_secchk[i].envName);
-          free(fe_listensock_info_secchk[i].envValue);
-        }
+    //
+    // registering above info to the environment variable list
+    //
+    LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[0]),
+                           fe_listensock_info_secchk, 4);
 
-      if ( getenv("LMON_DEBUG_BES"))
-        {
-	  //
-	  // backend daemon debugging support
-	  //
-	  lmon_daemon_env_t de[2];
-	  de[0].envName = strdup("LMON_DEBUG_BES");
-	  de[0].envValue = strdup("yes");
-	  de[0].next = NULL;
-	  de[1].envName = strdup("DISPLAY");
-	  de[1].envValue = strdup(getenv("DISPLAY"));
-	  de[1].next = NULL;
-	  LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[0]), de, 2 );
-          //
-          // release memory
-          //
-          free(de[0].envName);
-          free(de[0].envValue);
-          free(de[1].envName);
-          free(de[1].envValue);
-        }
-
-      fe_listensock_info_secchk_mw[0].envName 
-	= strdup (LMON_FE_ADDR_ENVNAME);
-      fe_listensock_info_secchk_mw[0].envValue 
-	= strdup (mydesc->commDesc[fe_mw_conn].ipInfo);
-      fe_listensock_info_secchk_mw[0].next = NULL;
-
-
-      fe_listensock_info_secchk_mw[1].envName 
-	= strdup (LMON_FE_PORT_ENVNAME);
-      sprintf ( portinfo, 
-		"%d", 
-		(unsigned short) 
-		ntohs (mydesc->commDesc[fe_mw_conn].servAddr.sin_port) );
-      fe_listensock_info_secchk_mw[1].envValue 
-	= strdup (portinfo);
-      fe_listensock_info_secchk_mw[1].next = NULL; 
-
-
-      fe_listensock_info_secchk_mw[2].envName 
-	= strdup (LMON_SEC_CHK_ENVNAME);
-      fe_listensock_info_secchk_mw[2].envValue 
-	= strdup (rannum);
-      fe_listensock_info_secchk_mw[2].next = NULL; 
-
-      fe_listensock_info_secchk_mw[3].envName 
-	= strdup (LMON_SHRD_SEC_ENVNAME);
-      fe_listensock_info_secchk_mw[3].envValue 
-	= strdup (mydesc->shared_key);
-      fe_listensock_info_secchk_mw[3].next = NULL;
-
-      //
-      // registering above information into the MW environment variable list
-      //
-      LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[1]),
-                               fe_listensock_info_secchk_mw,
-                               4 );
-
-      //
-      // release memory
-      //
-      for (i=0; i < 4; ++i)
-        {
-          free(fe_listensock_info_secchk_mw[i].envName);
-          free(fe_listensock_info_secchk_mw[i].envValue);
-        }
-
-      if ( getenv("LMON_DEBUG_MWS"))
-        {
-	  //
-	  // middleware deamon debugging support
-	  //
-	  lmon_daemon_env_t de[1];
-	  de[0].envName = strdup("LMON_DEBUG_MWS");
-	  de[0].envValue = strdup("yes");
-	  de[0].next = NULL;
-	  de[1].envName = strdup("DISPLAY");
-	  de[1].envValue = strdup(getenv("DISPLAY"));
-	  de[1].next = NULL;
-	  LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[1]), de, 2 );
-          //
-          // release memory
-          //
-          free(de[0].envName);
-          free(de[0].envValue);
-          free(de[1].envName);
-          free(de[1].envValue);
-        }
-
-      sess.sessionPtrIndex++;     // increment sessionPtrIndex to point to the next
-                                  // available session resource element
-
-      if ( ( sess.sessionPtrIndex / MAX_LMON_SESSION) == 1 )
-	{
-	  //
-	  // we're wrapped around!
-	  //
-	  sess.sessionPtrIndex %= MAX_LMON_SESSION;
-	  if ( sess.sessionDescArray[sess.sessionPtrIndex].registered 
-	       == LMON_TRUE)
-	    {
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	      	"the current backend session was granted, but the next session can be a problem");
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "the session descriptor to which the incremented sessionPtrIndex points has already been registered");
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "Too many active sessions going on?");
-	      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                "the next call must wait until one of the active session descriptors is freed");
-
-	      lrc = LMON_EINVAL;
-	    }
-	}
-      else
-	{
-	  lrc = LMON_OK;
-	}
+    //
+    // release memory
+    //
+    for (i = 0; i < 4; ++i) {
+      free(fe_listensock_info_secchk[i].envName);
+      free(fe_listensock_info_secchk[i].envValue);
     }
-  else
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "the session descriptor has already been registered");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "Too many active sessions going on?");
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "a new session request cannot be granted until one of the active sessions is freed");
 
-      lrc = LMON_EINVAL;
-    } 
+    if (getenv("LMON_DEBUG_BES")) {
+      //
+      // backend daemon debugging support
+      //
+      lmon_daemon_env_t de[2];
+      de[0].envName = strdup("LMON_DEBUG_BES");
+      de[0].envValue = strdup("yes");
+      de[0].next = NULL;
+      de[1].envName = strdup("DISPLAY");
+      de[1].envValue = strdup(getenv("DISPLAY"));
+      de[1].next = NULL;
+      LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[0]), de, 2);
+      //
+      // release memory
+      //
+      free(de[0].envName);
+      free(de[0].envValue);
+      free(de[1].envName);
+      free(de[1].envValue);
+    }
+
+    fe_listensock_info_secchk_mw[0].envName = strdup(LMON_FE_ADDR_ENVNAME);
+    fe_listensock_info_secchk_mw[0].envValue =
+        strdup(mydesc->commDesc[fe_mw_conn].ipInfo);
+    fe_listensock_info_secchk_mw[0].next = NULL;
+
+    fe_listensock_info_secchk_mw[1].envName = strdup(LMON_FE_PORT_ENVNAME);
+    sprintf(
+        portinfo, "%d",
+        (unsigned short)ntohs(mydesc->commDesc[fe_mw_conn].servAddr.sin_port));
+    fe_listensock_info_secchk_mw[1].envValue = strdup(portinfo);
+    fe_listensock_info_secchk_mw[1].next = NULL;
+
+    fe_listensock_info_secchk_mw[2].envName = strdup(LMON_SEC_CHK_ENVNAME);
+    fe_listensock_info_secchk_mw[2].envValue = strdup(rannum);
+    fe_listensock_info_secchk_mw[2].next = NULL;
+
+    fe_listensock_info_secchk_mw[3].envName = strdup(LMON_SHRD_SEC_ENVNAME);
+    fe_listensock_info_secchk_mw[3].envValue = strdup(mydesc->shared_key);
+    fe_listensock_info_secchk_mw[3].next = NULL;
+
+    //
+    // registering above information into the MW environment variable list
+    //
+    LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[1]),
+                           fe_listensock_info_secchk_mw, 4);
+
+    //
+    // release memory
+    //
+    for (i = 0; i < 4; ++i) {
+      free(fe_listensock_info_secchk_mw[i].envName);
+      free(fe_listensock_info_secchk_mw[i].envValue);
+    }
+
+    if (getenv("LMON_DEBUG_MWS")) {
+      //
+      // middleware deamon debugging support
+      //
+      lmon_daemon_env_t de[1];
+      de[0].envName = strdup("LMON_DEBUG_MWS");
+      de[0].envValue = strdup("yes");
+      de[0].next = NULL;
+      de[1].envName = strdup("DISPLAY");
+      de[1].envValue = strdup(getenv("DISPLAY"));
+      de[1].next = NULL;
+      LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[1]), de, 2);
+      //
+      // release memory
+      //
+      free(de[0].envName);
+      free(de[0].envValue);
+      free(de[1].envName);
+      free(de[1].envValue);
+    }
+
+    sess.sessionPtrIndex++;  // increment sessionPtrIndex to point to the next
+                             // available session resource element
+
+    if ((sess.sessionPtrIndex / MAX_LMON_SESSION) == 1) {
+      //
+      // we're wrapped around!
+      //
+      sess.sessionPtrIndex %= MAX_LMON_SESSION;
+      if (sess.sessionDescArray[sess.sessionPtrIndex].registered == LMON_TRUE) {
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "the current backend session was granted, but the next "
+                     "session can be a problem");
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "the session descriptor to which the incremented "
+                     "sessionPtrIndex points has already been registered");
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "Too many active sessions going on?");
+        LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                     "the next call must wait until one of the active session "
+                     "descriptors is freed");
+
+        lrc = LMON_EINVAL;
+      }
+    } else {
+      lrc = LMON_OK;
+    }
+  } else {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "the session descriptor has already been registered");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "Too many active sessions going on?");
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "a new session request cannot be granted until one of the "
+                 "active sessions is freed");
+
+    lrc = LMON_EINVAL;
+  }
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return lrc;
 }
 
-
-//! lmon_rc_e LMON_fe_regPackForFeToBe 
+//! lmon_rc_e LMON_fe_regPackForFeToBe
 /*!
 
     Please refer to the manpage
- 
+
 */
-extern "C"
-lmon_rc_e 
-LMON_fe_regPackForFeToBe (
-	        int sessionHandle, 
-		int (*packFebe) (void *udata,
-                  void *msgbuf,int msgbufmax,int *msgbuflen))
-{
-  lmon_session_desc_t* mydesc;
+extern "C" lmon_rc_e LMON_fe_regPackForFeToBe(
+    int sessionHandle,
+    int (*packFebe)(void *udata, void *msgbuf, int msgbufmax, int *msgbuflen)) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc = LMON_OK;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( packFebe == NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "packFebe is null!");
-      return LMON_EBDARG;
-    }
-  
+  if (packFebe == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "packFebe is null!");
+    return LMON_EBDARG;
+  }
+
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
 
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex)); 
-      return LMON_EBDARG;
-    }
-  
-  if ( mydesc->spawned == LMON_FALSE ) 
-    {
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-      if ( mydesc->pack != NULL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	    "pack was already registered. replacing it with the new func...");
-	}
+  if (mydesc->spawned == LMON_FALSE) {
+    if (mydesc->pack != NULL) {
+      LMON_say_msg(
+          LMON_FE_MSG_PREFIX, false,
+          "pack was already registered. replacing it with the new func...");
+    }
 
-      mydesc->pack = packFebe;
-    }
-  else
-    {
-	  rc = LMON_EINVAL;
-    }
-  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex)); 
+    mydesc->pack = packFebe;
+  } else {
+    rc = LMON_EINVAL;
+  }
+  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_regUnpackForBeToFe
 /*!
 
-    Please refer to the manpage  
+    Please refer to the manpage
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_regUnpackForBeToFe ( 
-		int sessionHandle, 
-		int (*unpackBefe) ( void * udatabuf,
-                  int udatabuflen, void *udata ))
-{
-  lmon_session_desc_t* mydesc;
-  lmon_rc_e rc = LMON_OK; 
+extern "C" lmon_rc_e LMON_fe_regUnpackForBeToFe(
+    int sessionHandle,
+    int (*unpackBefe)(void *udatabuf, int udatabuflen, void *udata)) {
+  lmon_session_desc_t *mydesc;
+  lmon_rc_e rc = LMON_OK;
 
-  if ( (sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;
-    }
-  
-  if ( unpackBefe == NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "unpackBebe is null!");
+    return LMON_EBDARG;
+  }
 
-      return LMON_EBDARG;
-    }
+  if (unpackBefe == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "unpackBebe is null!");
+
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
+
+  if (mydesc->spawned == LMON_FALSE) {
+    if (mydesc->unpack != NULL) {
+      LMON_say_msg(
+          LMON_FE_MSG_PREFIX, false,
+          "unpack was already registered. replacing it with the new func...");
     }
-  
-  if ( mydesc->spawned == LMON_FALSE ) 
-    {
-      if ( mydesc->unpack != NULL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	    "unpack was already registered. replacing it with the new func...");
-	}
-      mydesc->unpack= unpackBefe;
-    }
-  else
-    {
-      rc = LMON_EINVAL;
-    }
+    mydesc->unpack = unpackBefe;
+  } else {
+    rc = LMON_EINVAL;
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_regPackForFeToMw
 /*!
 
-    Please refer to the manpage  
+    Please refer to the manpage
 
 */
-lmon_rc_e 
-LMON_fe_regPackForFeToMw (
-                int sessionHandle,
-                int (*packFemw) (void *udata,
-                  void *msgbuf,int msgbufmax,int *msgbuflen))
-{
+lmon_rc_e LMON_fe_regPackForFeToMw(int sessionHandle,
+                                   int (*packFemw)(void *udata, void *msgbuf,
+                                                   int msgbufmax,
+                                                   int *msgbuflen)) {
   lmon_session_desc_t *mydesc;
   lmon_rc_e rc = LMON_OK;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    { 
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( packFemw == NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-         "packFemw is null!");
+  if (packFemw == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "packFemw is null!");
 
-      return LMON_EBDARG;
-    }
-  
+    return LMON_EBDARG;
+  }
+
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
-  
-  if ( mydesc->spawned == LMON_FALSE ) 
-    {
-      if ( mydesc->mw_pack != NULL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	    "middleware pack was already registered. replacing it with the new func...");
-	}
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-      mydesc->mw_pack = packFemw;
+  if (mydesc->spawned == LMON_FALSE) {
+    if (mydesc->mw_pack != NULL) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "middleware pack was already registered. replacing it with "
+                   "the new func...");
     }
-  else
-    {
-	  rc = LMON_EINVAL;
-    }
+
+    mydesc->mw_pack = packFemw;
+  } else {
+    rc = LMON_EINVAL;
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return rc;
 }
 
- 
 //! lmon_rc_e LMON_fe_regUnpackForMwToFe
 /*!
 
-    Please refer to the manpage  
+    Please refer to the manpage
 
-*/  
-lmon_rc_e 
-LMON_fe_regUnpackForMwToFe (
-                int sessionHandle,
-                int (*unpackMwfe)
-                ( void* udatabuf,int udatabuflen, void* udata ))
-{
-  lmon_session_desc_t* mydesc;
-  lmon_rc_e rc = LMON_OK; 
+*/
+lmon_rc_e LMON_fe_regUnpackForMwToFe(int sessionHandle,
+                                     int (*unpackMwfe)(void *udatabuf,
+                                                       int udatabuflen,
+                                                       void *udata)) {
+  lmon_session_desc_t *mydesc;
+  lmon_rc_e rc = LMON_OK;
 
-  if ( (sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION) )   
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid");
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;
-    }
-  
-  if ( unpackMwfe == NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "unpackMwbe is null!");
+    return LMON_EBDARG;
+  }
 
-      return LMON_EBDARG;
-    }
+  if (unpackMwfe == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "unpackMwbe is null!");
+
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
+
+  if (mydesc->spawned == LMON_FALSE) {
+    if (mydesc->mw_unpack != NULL) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "middleware unpack was already registered. replacing it "
+                   "with the new func...");
     }
-  
-  if ( mydesc->spawned == LMON_FALSE ) 
-    {
-      if ( mydesc->mw_unpack != NULL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-	    "middleware unpack was already registered. replacing it with the new func...");
-	}
-      mydesc->mw_unpack= unpackMwfe;
-    }
-  else
-    {
-      rc = LMON_EINVAL;
-    }
+    mydesc->mw_unpack = unpackMwfe;
+  } else {
+    rc = LMON_EINVAL;
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return rc;
-
-} 
-
+}
 
 //! lmon_rc_e LMON_fe_putToBeDaemonEnv
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_putToBeDaemonEnv (
-		int sessionHandle, 
-		lmon_daemon_env_t* dmonEnv, 
-		int numElem )
-{
-  lmon_session_desc_t* mydesc; 
+extern "C" lmon_rc_e LMON_fe_putToBeDaemonEnv(int sessionHandle,
+                                              lmon_daemon_env_t *dmonEnv,
+                                              int numElem) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;
-    }
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
 
   rc = LMON_OK;
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->spawned == LMON_FALSE ) 
-    { 
-      rc = LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[0]),
-				    dmonEnv,
-				    numElem);
-    }
-  else
-    {
-      rc = LMON_EINVAL;
-    }
+  if (mydesc->spawned == LMON_FALSE) {
+    rc = LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[0]), dmonEnv, numElem);
+  } else {
+    rc = LMON_EINVAL;
+  }
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_putToMwDaemonEnv
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-lmon_rc_e 
-LMON_fe_putToMwDaemonEnv (
-                int sessionHandle, 
-                lmon_daemon_env_t* dmonEnv, 
-                int numElem )
-{
-  lmon_session_desc_t* mydesc;
+lmon_rc_e LMON_fe_putToMwDaemonEnv(int sessionHandle,
+                                   lmon_daemon_env_t *dmonEnv, int numElem) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-  
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+
   rc = LMON_OK;
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
 
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
-  
-  if ( mydesc->spawned == LMON_FALSE ) 
-    { 
-      rc = LMON_fe_putToDaemonEnv ( &(mydesc->daemonEnvList[1]),
-				    dmonEnv,
-				    numElem);
-    }
-  else
-    {
-      rc = LMON_EINVAL;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
+
+  if (mydesc->spawned == LMON_FALSE) {
+    rc = LMON_fe_putToDaemonEnv(&(mydesc->daemonEnvList[1]), dmonEnv, numElem);
+  } else {
+    rc = LMON_EINVAL;
+  }
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_sendUsrData
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-lmon_rc_e LMON_fe_sendUsrDataBe ( int sessionHandle, void* febe_data )
-{
-  lmon_session_desc_t* mydesc;
+lmon_rc_e LMON_fe_sendUsrDataBe(int sessionHandle, void *febe_data) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  rc = LMON_fe_handleFeBeUsrData ( sessionHandle, febe_data );
+  rc = LMON_fe_handleFeBeUsrData(sessionHandle, febe_data);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_recvUsrDataBE
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-lmon_rc_e LMON_fe_recvUsrDataBe ( int sessionHandle, void* befe_data )
-{
-  lmon_session_desc_t* mydesc;
+lmon_rc_e LMON_fe_recvUsrDataBe(int sessionHandle, void *befe_data) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  rc = LMON_fe_handleBeFeUsrData ( sessionHandle, befe_data );
+  rc = LMON_fe_handleBeFeUsrData(sessionHandle, befe_data);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_sendUsrData
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-lmon_rc_e 
-LMON_fe_sendUsrDataMw ( int sessionHandle, void* femw_data )
-{
-  lmon_session_desc_t* mydesc;
+lmon_rc_e LMON_fe_sendUsrDataMw(int sessionHandle, void *femw_data) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  rc = LMON_fe_handleFeMwUsrData ( sessionHandle, femw_data );
+  rc = LMON_fe_handleFeMwUsrData(sessionHandle, femw_data);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   return rc;
 }
-
 
 //! lmon_rc_e LMON_fe_recvUsrDataBE
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-lmon_rc_e 
-LMON_fe_recvUsrDataMw ( int sessionHandle, void* mwfe_data )
-{
-  lmon_session_desc_t* mydesc;
+lmon_rc_e LMON_fe_recvUsrDataMw(int sessionHandle, void *mwfe_data) {
+  lmon_session_desc_t *mydesc;
   lmon_rc_e rc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  rc = LMON_fe_handleMwFeUsrData ( sessionHandle, mwfe_data );
+  rc = LMON_fe_handleMwFeUsrData(sessionHandle, mwfe_data);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   return rc;
 }
-
-
 
 //! lmon_rc_e LMON_fe_detach
 /*!
 
-    Please refer to the manpage    
+    Please refer to the manpage
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_detach ( int sessionHandle )
-{
-  lmonp_t msg;
-  lmon_session_desc_t* mydesc;
-  int numbytes;
-  int rc;
-  struct timespec ts;
-  char* tout = NULL;
-  lmon_rc_e lrc = LMON_OK;
-
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid" );
-
-      return LMON_EBDARG;
-    }
-
-  mydesc = &sess.sessionDescArray[sessionHandle];   
-  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if ( (mydesc->registered == LMON_FALSE)
-       || (mydesc->detached == LMON_TRUE)
-       || (mydesc->killed == LMON_TRUE) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-        "the given session is invalid, the job/daemons already killed/detached?");
-
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
-  
-  init_msg_header (&msg);
-  msg.msgclass = lmonp_fetofe;
-  msg.type.fetofe_type = lmonp_detach;
-
-  numbytes = write_lmonp_long_msg ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd,
-				    &msg,
-				    sizeof(msg) );
-
-  if ( numbytes != sizeof(msg))
-    return LMON_EINVAL;
-  
-  tout = getenv ( "LMON_FE_DMONCTL_TIMEOUT" );
-  clock_gettime ( CLOCK_REALTIME, &ts );
-
-  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
-    ts.tv_sec += atoi(tout);
-  else
-    ts.tv_sec += DFLT_FE_ENGINE_TOUT;
-
-  while ( mydesc->detached != LMON_TRUE )
-    {
-      /*
-       * This must be signaled by "lmonp_detach_done" event
-       */
-      rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
-  	              &(mydesc->watchdogThr.eventMutex),
-                      &ts );
-
-      if ( mydesc->detached != LMON_TRUE)
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "the main thread woke up out of LMON_fe_detach, but the required condition is not met" );
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "probably the engine had retired" );
-        }
-
-      if ( rc == ETIMEDOUT )
-        {
-          lrc = LMON_ETOUT;
-          break;
-        }
-      else if ( rc != 0 )
-        {
-          lrc = LMON_EINVAL;
-          break;
-        }
-    }
-
-  /*
-   * at this point all locks must have been released
-   *
-   */
-  //LMON_destroy_sess (mydesc);
-  //LMON_init_sess (mydesc);
-  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-  return lrc;
-}
-
-
-//! lmon_rc_e LMON_fe_kill
-/*!
-
-    Please refer to the manpage    
-
-*/
-lmon_rc_e 
-LMON_fe_kill ( int sessionHandle )
-{
+extern "C" lmon_rc_e LMON_fe_detach(int sessionHandle) {
   lmonp_t msg;
   lmon_session_desc_t *mydesc;
   int numbytes;
@@ -4435,490 +3715,487 @@ LMON_fe_kill ( int sessionHandle )
   char *tout = NULL;
   lmon_rc_e lrc = LMON_OK;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "the given session is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &sess.sessionDescArray[sessionHandle];   
+  mydesc = &sess.sessionDescArray[sessionHandle];
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if ( (mydesc->registered == LMON_FALSE)
-       || (mydesc->detached == LMON_TRUE)
-       || (mydesc->killed == LMON_TRUE) ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "the given session is invalid, the job/daemons already killed/detached?");
+  if ((mydesc->registered == LMON_FALSE) || (mydesc->detached == LMON_TRUE) ||
+      (mydesc->killed == LMON_TRUE)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                 "the given session is invalid, the job/daemons already "
+                 "killed/detached?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  init_msg_header (&msg);
+  init_msg_header(&msg);
   msg.msgclass = lmonp_fetofe;
-  msg.type.fetofe_type = lmonp_kill;
+  msg.type.fetofe_type = lmonp_detach;
 
-  numbytes = write_lmonp_long_msg ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, 
-				    &msg,
-				    sizeof(msg) );
-  if ( numbytes != sizeof(msg))
-    return LMON_EINVAL;
- 
-  tout = getenv ( "LMON_FE_DMONCTL_TIMEOUT" );
-  clock_gettime ( CLOCK_REALTIME, &ts );
+  numbytes = write_lmonp_long_msg(
+      mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, &msg, sizeof(msg));
 
-  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
+  if (numbytes != sizeof(msg)) return LMON_EINVAL;
+
+  tout = getenv("LMON_FE_DMONCTL_TIMEOUT");
+  clock_gettime(CLOCK_REALTIME, &ts);
+
+  if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
     ts.tv_sec += atoi(tout);
   else
     ts.tv_sec += DFLT_FE_ENGINE_TOUT;
 
-  while ( mydesc->killed != LMON_TRUE )
-    {
-      /*
-       * This must be signaled by "lmonp_kill_done" event
-       */
-      rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
-	              &(mydesc->watchdogThr.eventMutex),
-	              &ts );
+  while (mydesc->detached != LMON_TRUE) {
+    /*
+     * This must be signaled by "lmonp_detach_done" event
+     */
+    rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
+                                &(mydesc->watchdogThr.eventMutex), &ts);
 
-      if ( mydesc->killed != LMON_TRUE)
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "the main thread woke up out of LMON_fe_kill, but the required condition is not met" );
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "probably the engine had retired before getting the kill message" );
-        }
-
-      if ( rc == ETIMEDOUT )
-        {
-          lrc = LMON_ETOUT;
-          break;
-        }	 
-      else if ( rc != 0 )
-        {
-          lrc = LMON_EINVAL;
-          break;
-        }
+    if (mydesc->detached != LMON_TRUE) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "the main thread woke up out of LMON_fe_detach, but the "
+                   "required condition is not met");
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "probably the engine had retired");
     }
+
+    if (rc == ETIMEDOUT) {
+      lrc = LMON_ETOUT;
+      break;
+    } else if (rc != 0) {
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
 
   /*
    * at this point all locks must have been released
    *
    */
-  LMON_destroy_sess(mydesc);
-  LMON_init_sess (mydesc);
-  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-  return lrc; 
-}
-
-
-//! lmon_rc_e LMON_fe_shutdownDaemons
-/*!
-
-    Please refer to the manpage    
-
-*/
-lmon_rc_e 
-LMON_fe_shutdownDaemons ( int sessionHandle )
-{
-  lmonp_t msg;
-  lmon_session_desc_t* mydesc;
-  int numbytes;
-  int rc;
-  struct timespec ts;
-  char* tout = NULL;
-  lmon_rc_e lrc = LMON_OK;
-
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "session is invalid" );
-      return LMON_EBDARG;    
-    }
-
-  mydesc = &sess.sessionDescArray[sessionHandle];   
-  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
-
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
-
-  init_msg_header (&msg);
-  msg.msgclass = lmonp_fetofe;
-  msg.type.fetofe_type = lmonp_shutdownbe;
-
-  numbytes = write_lmonp_long_msg ( mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, 
-				    &msg,
-				    sizeof(msg) );
-
-  if ( numbytes != sizeof(msg))
-    return LMON_EINVAL; 
-
-  tout = getenv ( "LMON_FE_DMONCTL_TIMEOUT" );
-  clock_gettime ( CLOCK_REALTIME, &ts );
-
-  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
-    ts.tv_sec += atoi(tout);
-  else
-    ts.tv_sec += DFLT_FE_ENGINE_TOUT;
-
-  while ( mydesc->detached != LMON_TRUE )
-    {
-      /*
-       * This must be signaled by "lmonp_detach_done" event
-       */
-      rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
-  	              &(mydesc->watchdogThr.eventMutex),
-		      &ts );
-      if ( mydesc->detached != LMON_TRUE)
-        {
-          LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-            "the main thread woke up, but the associated boolean predicate is still false" );
-        }
-
-      if ( rc == ETIMEDOUT )
-        {
-          lrc = LMON_ETOUT;
-          break;
-        }
-      else if ( rc != 0 )
-        {
-          lrc = LMON_EINVAL;
-          break;
-        }
-    }
-
-  /*
-   * at this point all locks must have been released
-   *
-   */
-  LMON_destroy_sess(mydesc);
-  LMON_init_sess (mydesc);
+  // LMON_destroy_sess (mydesc);
+  // LMON_init_sess (mydesc);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return lrc;
 }
 
+//! lmon_rc_e LMON_fe_kill
+/*!
+
+    Please refer to the manpage
+
+*/
+lmon_rc_e LMON_fe_kill(int sessionHandle) {
+  lmonp_t msg;
+  lmon_session_desc_t *mydesc;
+  int numbytes;
+  int rc;
+  struct timespec ts;
+  char *tout = NULL;
+  lmon_rc_e lrc = LMON_OK;
+
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "the given session is invalid");
+
+    return LMON_EBDARG;
+  }
+
+  mydesc = &sess.sessionDescArray[sessionHandle];
+  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+  if ((mydesc->registered == LMON_FALSE) || (mydesc->detached == LMON_TRUE) ||
+      (mydesc->killed == LMON_TRUE)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "the given session is invalid, the job/daemons already "
+                 "killed/detached?");
+
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
+
+  init_msg_header(&msg);
+  msg.msgclass = lmonp_fetofe;
+  msg.type.fetofe_type = lmonp_kill;
+
+  numbytes = write_lmonp_long_msg(
+      mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, &msg, sizeof(msg));
+  if (numbytes != sizeof(msg)) return LMON_EINVAL;
+
+  tout = getenv("LMON_FE_DMONCTL_TIMEOUT");
+  clock_gettime(CLOCK_REALTIME, &ts);
+
+  if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
+    ts.tv_sec += atoi(tout);
+  else
+    ts.tv_sec += DFLT_FE_ENGINE_TOUT;
+
+  while (mydesc->killed != LMON_TRUE) {
+    /*
+     * This must be signaled by "lmonp_kill_done" event
+     */
+    rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
+                                &(mydesc->watchdogThr.eventMutex), &ts);
+
+    if (mydesc->killed != LMON_TRUE) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "the main thread woke up out of LMON_fe_kill, but the "
+                   "required condition is not met");
+      LMON_say_msg(
+          LMON_FE_MSG_PREFIX, false,
+          "probably the engine had retired before getting the kill message");
+    }
+
+    if (rc == ETIMEDOUT) {
+      lrc = LMON_ETOUT;
+      break;
+    } else if (rc != 0) {
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
+
+  /*
+   * at this point all locks must have been released
+   *
+   */
+  LMON_destroy_sess(mydesc);
+  LMON_init_sess(mydesc);
+  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+  return lrc;
+}
+
+//! lmon_rc_e LMON_fe_shutdownDaemons
+/*!
+
+    Please refer to the manpage
+
+*/
+lmon_rc_e LMON_fe_shutdownDaemons(int sessionHandle) {
+  lmonp_t msg;
+  lmon_session_desc_t *mydesc;
+  int numbytes;
+  int rc;
+  struct timespec ts;
+  char *tout = NULL;
+  lmon_rc_e lrc = LMON_OK;
+
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+
+  mydesc = &sess.sessionDescArray[sessionHandle];
+  pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
+
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
+
+  init_msg_header(&msg);
+  msg.msgclass = lmonp_fetofe;
+  msg.type.fetofe_type = lmonp_shutdownbe;
+
+  numbytes = write_lmonp_long_msg(
+      mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd, &msg, sizeof(msg));
+
+  if (numbytes != sizeof(msg)) return LMON_EINVAL;
+
+  tout = getenv("LMON_FE_DMONCTL_TIMEOUT");
+  clock_gettime(CLOCK_REALTIME, &ts);
+
+  if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
+    ts.tv_sec += atoi(tout);
+  else
+    ts.tv_sec += DFLT_FE_ENGINE_TOUT;
+
+  while (mydesc->detached != LMON_TRUE) {
+    /*
+     * This must be signaled by "lmonp_detach_done" event
+     */
+    rc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
+                                &(mydesc->watchdogThr.eventMutex), &ts);
+    if (mydesc->detached != LMON_TRUE) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "the main thread woke up, but the associated boolean "
+                   "predicate is still false");
+    }
+
+    if (rc == ETIMEDOUT) {
+      lrc = LMON_ETOUT;
+      break;
+    } else if (rc != 0) {
+      lrc = LMON_EINVAL;
+      break;
+    }
+  }
+
+  /*
+   * at this point all locks must have been released
+   *
+   */
+  LMON_destroy_sess(mydesc);
+  LMON_init_sess(mydesc);
+  pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+  return lrc;
+}
 
 //! lmon_rc_e LMON_fe_getProctableSize
 /*!
-  
-    Please refer to the manpage    
+
+    Please refer to the manpage
 
 */
-extern "C"
-lmon_rc_e
-LMON_fe_getProctableSize (
-                int sessionHandle,
-                unsigned int* size )
-{
-  lmon_session_desc_t* mydesc;
+extern "C" lmon_rc_e LMON_fe_getProctableSize(int sessionHandle,
+                                              unsigned int *size) {
+  lmon_session_desc_t *mydesc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION)) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->spawned == LMON_FALSE )
-  {
-    LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-      "has this session already finished?");
+  if (mydesc->spawned == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "has this session already finished?");
 
     pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
     return LMON_EDUNAV;
   }
 
-  if ( !( mydesc->proctab_msg ) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "per-session proctab_msg is null!  ");
+  if (!(mydesc->proctab_msg)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "per-session proctab_msg is null!  ");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
-  if (mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-    {
-     (*size)
-        = (unsigned int) ( mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks );
-    }
-  else
-    {
-     (*size)
-        = (unsigned int) ( mydesc->proctab_msg->long_num_tasks );
-    }
+  if (mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+    (*size) = (unsigned int)(mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks);
+  } else {
+    (*size) = (unsigned int)(mydesc->proctab_msg->long_num_tasks);
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_fe_getProctable
 /*!
-  
-    Please refer to the manpage    
+
+    Please refer to the manpage
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_getProctable (
-		int sessionHandle, 
-		MPIR_PROCDESC_EXT* proctable, 
-		unsigned int* size, 
-		unsigned int maxlen )
-{
+extern "C" lmon_rc_e LMON_fe_getProctable(int sessionHandle,
+                                          MPIR_PROCDESC_EXT *proctable,
+                                          unsigned int *size,
+                                          unsigned int maxlen) {
   unsigned int i;
-  char* traverse;
-  char* strtab_offset;
+  char *traverse;
+  char *strtab_offset;
 
-  lmon_session_desc_t* mydesc;
+  lmon_session_desc_t *mydesc;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) 
-       || (maxlen < 0) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION) ||
+      (maxlen < 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->spawned == LMON_FALSE )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                   "has this session already finished?");
+  if (mydesc->spawned == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "has this session already finished?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
+  if (!(mydesc->proctab_msg)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "per-session proctab_msg is null!  ");
 
-  if ( !( mydesc->proctab_msg ) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-	"per-session proctab_msg is null!  ");
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
-  
-  if ( !( proctable ) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true, 
-		     "proctable is null ! " );
+  if (!(proctable)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "proctable is null ! ");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
-  traverse = get_lmonpayload_begin ( ( mydesc->proctab_msg ) );
-  if (!traverse)
-    {
-      return LMON_EDUNAV;
-    }
-  if (mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-    {
-     (*size)
-        = (unsigned int) ( mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks);
-    }
-  else
-    {
-     (*size)
-        = (unsigned int) ( mydesc->proctab_msg->long_num_tasks);
-    }
+  traverse = get_lmonpayload_begin((mydesc->proctab_msg));
+  if (!traverse) {
+    return LMON_EDUNAV;
+  }
+  if (mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+    (*size) = (unsigned int)(mydesc->proctab_msg->sec_or_jobsizeinfo.num_tasks);
+  } else {
+    (*size) = (unsigned int)(mydesc->proctab_msg->long_num_tasks);
+  }
 
-  strtab_offset = get_strtab_begin ( mydesc->proctab_msg );
+  strtab_offset = get_strtab_begin(mydesc->proctab_msg);
 
-  for ( i = 0; (i < ( *size )) && i < maxlen; i++ )
-    {
-      //
-      // fetch a host_name
-      // possible error check what  ( strtab_offset + ( *((unsigned int*)traverse)) ) contains
-      proctable[i].pd.host_name 
-	= strdup ( strtab_offset + ( *((unsigned int*)traverse)) );
-      traverse += sizeof (unsigned int);
+  for (i = 0; (i < (*size)) && i < maxlen; i++) {
+    //
+    // fetch a host_name
+    // possible error check what  ( strtab_offset + ( *((unsigned
+    // int*)traverse)) ) contains
+    proctable[i].pd.host_name =
+        strdup(strtab_offset + (*((unsigned int *)traverse)));
+    traverse += sizeof(unsigned int);
 
-      //
-      // fetch a exectuable_name
-      //
-      proctable[i].pd.executable_name 
-	= strdup ( strtab_offset + (  *((unsigned int*)traverse)) );
-      traverse += sizeof (unsigned int);
+    //
+    // fetch a exectuable_name
+    //
+    proctable[i].pd.executable_name =
+        strdup(strtab_offset + (*((unsigned int *)traverse)));
+    traverse += sizeof(unsigned int);
 
-      //
-      // fetch a pid      
-      //
-      memcpy ( &(proctable[i].pd.pid), 
-	      (void*) traverse,
-	      sizeof(int) );
-      traverse += sizeof (int);
+    //
+    // fetch a pid
+    //
+    memcpy(&(proctable[i].pd.pid), (void *)traverse, sizeof(int));
+    traverse += sizeof(int);
 
-      //
-      // fetch a mpirank
-      //
-      memcpy ( &(proctable[i].mpirank),
-	       (void*) traverse,
-	       sizeof(int) );
-      traverse += sizeof (int);
+    //
+    // fetch a mpirank
+    //
+    memcpy(&(proctable[i].mpirank), (void *)traverse, sizeof(int));
+    traverse += sizeof(int);
 
-      memcpy ( &(proctable[i].cnodeid),
-	       (void*) traverse,
-	       sizeof(int) );
-      traverse += sizeof (int);
-    }
+    memcpy(&(proctable[i].cnodeid), (void *)traverse, sizeof(int));
+    traverse += sizeof(int);
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-  if (( i == maxlen ) && maxlen < (*size) )
-    return LMON_ETRUNC;
+  if ((i == maxlen) && maxlen < (*size)) return LMON_ETRUNC;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_fe_regErrorCB
 /*!
-  registers a callback function that gets 
-  invoked whenever an error message should 
-  go out.   
+  registers a callback function that gets
+  invoked whenever an error message should
+  go out.
 */
-extern "C"
-lmon_rc_e
-LMON_fe_regErrorCB (int (*func) (const char *format, va_list ap))
-{
-  if ( func == NULL)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "an argument is invalid" );
+extern "C" lmon_rc_e LMON_fe_regErrorCB(int (*func)(const char *format,
+                                                    va_list ap)) {
+  if (func == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( errorCB !=  NULL )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-        "previously registered error callback func will be invalidated" );
-    }
+  if (errorCB != NULL) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, false,
+        "previously registered error callback func will be invalidated");
+  }
 
   errorCB = func;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_fe_regStatusCB
 /*!
-  registers a callback function that gets 
-  invoked whenever there is a status change.  
+  registers a callback function that gets
+  invoked whenever there is a status change.
 */
-extern "C"
-lmon_rc_e
-LMON_fe_regStatusCB (int sessionHandle, int (*func) (int *status))
-{
+extern "C" lmon_rc_e LMON_fe_regStatusCB(int sessionHandle,
+                                         int (*func)(int *status)) {
   lmon_session_desc_t *mydesc;
 
-  if ( (sessionHandle < 0)
-       || (sessionHandle > MAX_LMON_SESSION))
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
 
-  if ( func == NULL)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "an argument is invalid" );
+  if (func == NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
 
-  if ( mydesc->statusCB !=  NULL ) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-        "previously registered status cb func is invalidated" );
-    }
+  if (mydesc->statusCB != NULL) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                 "previously registered status cb func is invalidated");
+  }
 
   mydesc->statusCB = func;
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-  return LMON_OK; 
+  return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_fe_getStatus
 /*!
-  returns the status of the session through the status 
-  argument. It encodes the status using the lowest 
-  five bits as follows. The problem with this routine is 
+  returns the status of the session through the status
+  argument. It encodes the status using the lowest
+  five bits as follows. The problem with this routine is
   that it can't preciously catch some events. The callback
   version is highly recommended.
 
   lowest bit: session is registered (0) or not (1)
     next bit: back-end daemons are spawned or not
     next bit: middleware daemons are spawned or not
-    next bit: engine has detached from the job or not 
-    next bit: the job has been killed or not 
+    next bit: engine has detached from the job or not
+    next bit: the job has been killed or not
 */
-extern "C"
-lmon_rc_e
-LMON_fe_getStatus ( int sessionHandle, int *status )
-{
+extern "C" lmon_rc_e LMON_fe_getStatus(int sessionHandle, int *status) {
   lmon_session_desc_t *mydesc;
 
-    if ( (sessionHandle < 0)
-       || (sessionHandle > MAX_LMON_SESSION)
-       || (status == NULL) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION) ||
+      (status == NULL)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
 
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  fe_getStatus ( mydesc, status);
+  fe_getStatus(mydesc, status);
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return LMON_OK;
@@ -4926,118 +4203,96 @@ LMON_fe_getStatus ( int sessionHandle, int *status )
 
 //! lmon_rc_e LMON_fe_getResourceHandle
 /*!
-  Returns the resource handle via handle only after LMON_fe_attachAndSpawnDaemons 
-  or LMON_fe_launchAndSpawnDaemons call has been called successfully. 
-  For SLURM-based system, the handle is exported through a symbol "totalview_jobid" 
+  Returns the resource handle via handle only after
+  LMON_fe_attachAndSpawnDaemons
+  or LMON_fe_launchAndSpawnDaemons call has been called successfully.
+  For SLURM-based system, the handle is exported through a symbol
+  "totalview_jobid"
   whose type is const char* from the srun process.
 */
-extern "C"
-lmon_rc_e 
-LMON_fe_getResourceHandle ( 
-		int sessionHandle, 
-		char *handle, 
-		int *size, 
-		int maxstring )
-{
+extern "C" lmon_rc_e LMON_fe_getResourceHandle(int sessionHandle, char *handle,
+                                               int *size, int maxstring) {
   lmon_session_desc_t *mydesc;
-  char resbuf[PATH_MAX];   
+  char resbuf[PATH_MAX];
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) 
-       || (maxstring < 0) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION) ||
+      (maxstring < 0)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &(sess.sessionDescArray[(sessionHandle)]); 
+  mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->spawned == LMON_FALSE )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                   "has this session already finished?");
+  if (mydesc->spawned == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "has this session already finished?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
-  if (mydesc->resourceHandle == LMON_INIT )
-    {
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+  if (mydesc->resourceHandle == LMON_INIT) {
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
-  if ( sprintf(resbuf, "%d", mydesc->resourceHandle) < 0 )
-    {
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_ESYS;
-    }
+  if (sprintf(resbuf, "%d", mydesc->resourceHandle) < 0) {
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_ESYS;
+  }
 
-  strncpy ( handle, resbuf, maxstring );
-  int len = strlen (resbuf) + 1; 
-  (*size) = (len > maxstring )? maxstring : len; 
+  strncpy(handle, resbuf, maxstring);
+  int len = strlen(resbuf) + 1;
+  (*size) = (len > maxstring) ? maxstring : len;
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_fe_getRMInfo ( int sessionHandle, lmon_rm_info_t *info)
 /*!
     Please refer to the manpage
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_getRMInfo (int sessionHandle, lmon_rm_info_t *info)
-{
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "the sessionHandle argument is invalid" );
+extern "C" lmon_rc_e LMON_fe_getRMInfo(int sessionHandle,
+                                       lmon_rm_info_t *info) {
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "the sessionHandle argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( !info )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "the info argument is null" );
+  if (!info) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "the info argument is null");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   lmon_session_desc_t *mydesc = &(sess.sessionDescArray[sessionHandle]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(
+        LMON_FE_MSG_PREFIX, true,
         "the session is invalid, the job killed or uninitialized session?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EINVAL;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EINVAL;
+  }
 
-  if (mydesc->rm_info.num_supported_types > 0)
-    {
-      int memsz = sizeof(rm_catalogue_e) * mydesc->rm_info.num_supported_types;
-      info->rm_supported_types
-        = (rm_catalogue_e *) malloc(memsz);
-      memcpy(info->rm_supported_types,
-             mydesc->rm_info.rm_supported_types,
-             memsz);
-    }
+  if (mydesc->rm_info.num_supported_types > 0) {
+    int memsz = sizeof(rm_catalogue_e) * mydesc->rm_info.num_supported_types;
+    info->rm_supported_types = (rm_catalogue_e *)malloc(memsz);
+    memcpy(info->rm_supported_types, mydesc->rm_info.rm_supported_types, memsz);
+  }
 
   info->index_to_cur_instance = mydesc->rm_info.index_to_cur_instance;
   info->num_supported_types = mydesc->rm_info.num_supported_types;
@@ -5045,9 +4300,8 @@ LMON_fe_getRMInfo (int sessionHandle, lmon_rm_info_t *info)
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-  return (info->rm_launcher_pid != -1)? LMON_OK : LMON_EDUNAV;
+  return (info->rm_launcher_pid != -1) ? LMON_OK : LMON_EDUNAV;
 }
-
 
 //! lmon_rc_e LMON_fe_launchAndSpawnDaemons
 /*!
@@ -5055,492 +4309,399 @@ LMON_fe_getRMInfo (int sessionHandle, lmon_rm_info_t *info)
     Please refer to the manpage.
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_launchAndSpawnDaemons ( 
-		int sessionHandle, 
-		const char *hostname,
-		const char *launcher, 
-		char *l_argv[], 
-		const char *toolDaemon, 
-		char *d_argv[], 
-		void *febe_data, 
-		void *befe_data )
-{   
+extern "C" lmon_rc_e LMON_fe_launchAndSpawnDaemons(
+    int sessionHandle, const char *hostname, const char *launcher,
+    char *l_argv[], const char *toolDaemon, char *d_argv[], void *febe_data,
+    void *befe_data) {
   using namespace std;
 
   int verbosity_level;
   char *vb;
   lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
-  string ip_port_pair;    
+  string ip_port_pair;
   pid_t remote_login_pid;
   opts_args_t opt;
 
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "an argument is invalid" );
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;    
-    }
+    return LMON_EBDARG;
+  }
 
-  mydesc = &(sess.sessionDescArray[sessionHandle]);     
+  mydesc = &(sess.sessionDescArray[sessionHandle]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-		     "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   verbosity_level = 0;
-  
-  if ( (vb = getenv (LMON_VERBOSE_ENVNAME)) != NULL )
-    {	
-      /*
-       * The value specified via the "LMON_VERBOSITY" envVar 
-       * sets an appropriate verbose level
-       */
-      verbosity_level = atoi(vb);
+
+  if ((vb = getenv(LMON_VERBOSE_ENVNAME)) != NULL) {
+    /*
+     * The value specified via the "LMON_VERBOSITY" envVar
+     * sets an appropriate verbose level
+     */
+    verbosity_level = atoi(vb);
+  }
+
+  if ((verbosity_level > 3) || (verbosity_level) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                 "verbosity level must be between 0 and 3");
+    verbosity_level = 0;
+  }
+
+  if ((lrc = LMON_set_options(mydesc, opt, verbosity_level, false, launcher,
+                              l_argv, 0, toolDaemon, d_argv)) != LMON_OK) {
+    return LMON_EBDARG;
+  }
+
+  if ((remote_login_pid = fork()) != 0) {
+    //
+    // A separate process got spawned, which will either directly
+    // execute the launchmon engine or perform a login to the given
+    // host to invoke the launchmon engine.
+    //
+    // To facilitate communications among all components, the FEN API
+    // runtime will spawn a watchdog thread (POSIX Thread) that handles
+    // asynchronous communications with the engine.
+    //
+    //
+    int thrarg[2];
+    pthread_t *mythrHandle = &(mydesc->watchdogThr.fetofeMonitoringThr);
+
+    if ((lrc = LMON_fe_acceptEngine(sessionHandle)) != LMON_OK) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                   "internal LMON_fe_acceptEgine call failed");
+
+      return lrc;
     }
 
-  if ( (verbosity_level > 3) || (verbosity_level) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-           "verbosity level must be between 0 and 3" );
-      verbosity_level = 0;
+    //
+    // This is the front-end LaunchMON Engine pair
+    //
+    thrarg[0] = mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd;
+    thrarg[1] = sessionHandle;
+
+    //
+    // LMON_fetofe_watchdog_thread is the thread-entry function
+    //
+    // It will begin polling the FE-Engine message queue
+    //
+    if ((pthread_create(mythrHandle, NULL, LMON_fetofe_watchdog_thread,
+                        (void *)thrarg)) != 0) {
+      return LMON_ESYS;
     }
 
-  if ( (lrc = LMON_set_options( mydesc,
-				opt,
-				verbosity_level,
-				false,
-				launcher,
-				l_argv,
-				0,
-				toolDaemon,
-				d_argv))
-       != LMON_OK )
-    {
-      return LMON_EBDARG;
-   }
+    //
+    // This API call gets blocked until the watchdog thread get notified of
+    // spawned event.
+    //
+    pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+    if (mydesc->spawned != LMON_TRUE) {
+      struct timespec ts;
+      char *tout = getenv("LMON_FE_ENGINE_TIMEOUT");
+      clock_gettime(CLOCK_REALTIME, &ts);
+      int prc;
 
-  if ( ( remote_login_pid = fork() ) != 0 )
-    {
-      //
-      // A separate process got spawned, which will either directly
-      // execute the launchmon engine or perform a login to the given
-      // host to invoke the launchmon engine. 
-      //
-      // To facilitate communications among all components, the FEN API
-      // runtime will spawn a watchdog thread (POSIX Thread) that handles
-      // asynchronous communications with the engine.
-      //
-      //
-      int thrarg[2];
-      pthread_t* mythrHandle = &(mydesc->watchdogThr.fetofeMonitoringThr);
+      if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
+        ts.tv_sec += atoi(tout);
+      else
+        ts.tv_sec += DFLT_FE_ENGINE_TOUT;
 
-      if ( (lrc = LMON_fe_acceptEngine ( sessionHandle )) != LMON_OK )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, false, 
-	    "internal LMON_fe_acceptEgine call failed" );
-
-	  return lrc;
-	}
-
-      //
-      // This is the front-end LaunchMON Engine pair
-      //
-      thrarg[0] = mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd;
-      thrarg[1] = sessionHandle;
-
-      //
-      // LMON_fetofe_watchdog_thread is the thread-entry function
-      //
-      // It will begin polling the FE-Engine message queue
-      //
-      if ( ( pthread_create( mythrHandle,
-			     NULL,
-			     LMON_fetofe_watchdog_thread,
-			     (void*) thrarg ) ) != 0 )
-	{
-	  return LMON_ESYS;
-	}
- 
-      //
-      // This API call gets blocked until the watchdog thread get notified of 
-      // spawned event.
-      //
-      pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-      if ( mydesc->spawned != LMON_TRUE )
-	{
-	  struct timespec ts; 
-	  char* tout = getenv ( "LMON_FE_ENGINE_TIMEOUT" );
-	  clock_gettime ( CLOCK_REALTIME, &ts ); 
-          int prc;
- 
-	  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
-	    ts.tv_sec += atoi(tout);
-	  else
-	    ts.tv_sec += DFLT_FE_ENGINE_TOUT;
-	  
-          if ( ( prc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
+      if ((prc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
                                         &(mydesc->watchdogThr.eventMutex),
-                                        &ts )) != 0 )
-            {
-              if ( prc == ETIMEDOUT )
-                {
-		  lrc = LMON_ETOUT;
-                  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-                    "FE-ENGINE connection timed out: %d",
-                    tout ? atoi(tout) : DFLT_FE_ENGINE_TOUT );
-                }
-              else
-                {
-		  lrc = LMON_EBUG;
-                  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-                    "FE-ENGINE connection failed with an error within pthread_cond_timedwait: err %d",
-                    prc);
-                }
+                                        &ts)) != 0) {
+        if (prc == ETIMEDOUT) {
+          lrc = LMON_ETOUT;
+          LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                       "FE-ENGINE connection timed out: %d",
+                       tout ? atoi(tout) : DFLT_FE_ENGINE_TOUT);
+        } else {
+          lrc = LMON_EBUG;
+          LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                       "FE-ENGINE connection failed with an error within "
+                       "pthread_cond_timedwait: err %d",
+                       prc);
+        }
 
-              pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-              return lrc;
-            }
-	}
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-      //	    
-      // Once you are here, the watchdog thread should have already 
-      // updated the mydesc->spawned flag
-      //
-      if ( ( lrc = LMON_fe_beHandshakeSequence (sessionHandle,
-						true,  /* this is launch case */
-						febe_data, 
-						befe_data )) != LMON_OK )
-	{
-	  return lrc;
-	}
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        return lrc;
+      }
     }
-  else
-    {
-	
-      //
-      // This process bootstraps the LaunchMON ENGINE with ssh or rsh
-      // or directly exec's the launchMON ENGINE.
-      //	
-      bool isLocal;
-      int i;
-      list<string> lmonOptArgs;
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-      isLocal = (hostname == NULL) ? true : false;
+    //
+    // Once you are here, the watchdog thread should have already
+    // updated the mydesc->spawned flag
+    //
+    if ((lrc = LMON_fe_beHandshakeSequence(sessionHandle,
+                                           true, /* this is launch case */
+                                           febe_data, befe_data)) != LMON_OK) {
+      return lrc;
+    }
+  } else {
+    //
+    // This process bootstraps the LaunchMON ENGINE with ssh or rsh
+    // or directly exec's the launchMON ENGINE.
+    //
+    bool isLocal;
+    int i;
+    list<string> lmonOptArgs;
 
-      if ( (isLocal == false) 
-	   && getenv("LMON_DEBUG_FE_ENGINE_RSH") )	  
-	LMON_TotalView_debug ();
-	
-      lmonOptArgs.push_back("--remote");
-      lmonOptArgs.push_back(opt.get_my_opt()->remote_info);
-      lmonOptArgs.push_back("--lmonsec");
-      lmonOptArgs.push_back(opt.get_my_opt()->lmon_sec_info);
-      lmonOptArgs.push_back("--daemonpath");
-      lmonOptArgs.push_back(opt.get_my_opt()->tool_daemon);
-      
-      const list<string> &tool_daemon_opts = opt.get_my_opt()->tool_daemon_opts;
-      if ( !tool_daemon_opts.empty())
-        {
-          lmonOptArgs.push_back("--daemonopts");
+    isLocal = (hostname == NULL) ? true : false;
 
-          stringstream ss;
-          ss << tool_daemon_opts.size();
-          lmonOptArgs.push_back(ss.str());
+    if ((isLocal == false) && getenv("LMON_DEBUG_FE_ENGINE_RSH"))
+      LMON_TotalView_debug();
 
-          lmonOptArgs.insert(lmonOptArgs.end(), tool_daemon_opts.begin(), tool_daemon_opts.end());
-	}
-      lmonOptArgs.push_back(opt.get_my_opt()->debugtarget);
-      lmonOptArgs.push_back("-a");
-      
-      for ( i = 1; opt.get_my_opt()->remaining[i] != NULL; i++)
-	{
-           lmonOptArgs.push_back(opt.get_my_opt()->remaining[i]);
-	}
+    lmonOptArgs.push_back("--remote");
+    lmonOptArgs.push_back(opt.get_my_opt()->remote_info);
+    lmonOptArgs.push_back("--lmonsec");
+    lmonOptArgs.push_back(opt.get_my_opt()->lmon_sec_info);
+    lmonOptArgs.push_back("--daemonpath");
+    lmonOptArgs.push_back(opt.get_my_opt()->tool_daemon);
 
-      if ( bld_exec_lmon_launch_str ( isLocal, 
-				      hostname,
-				      lmonOptArgs, 
-				      opt )  == LMON_EINVAL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "The program didn't sink with an exec call in bld_exec_lmon_launch_str");
-	  exit(1);
-	}	  		
-    }   
- 
+    const list<string> &tool_daemon_opts = opt.get_my_opt()->tool_daemon_opts;
+    if (!tool_daemon_opts.empty()) {
+      lmonOptArgs.push_back("--daemonopts");
+
+      stringstream ss;
+      ss << tool_daemon_opts.size();
+      lmonOptArgs.push_back(ss.str());
+
+      lmonOptArgs.insert(lmonOptArgs.end(), tool_daemon_opts.begin(),
+                         tool_daemon_opts.end());
+    }
+    lmonOptArgs.push_back(opt.get_my_opt()->debugtarget);
+    lmonOptArgs.push_back("-a");
+
+    for (i = 1; opt.get_my_opt()->remaining[i] != NULL; i++) {
+      lmonOptArgs.push_back(opt.get_my_opt()->remaining[i]);
+    }
+
+    if (bld_exec_lmon_launch_str(isLocal, hostname, lmonOptArgs, opt) ==
+        LMON_EINVAL) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "The program didn't sink with an exec call in "
+                   "bld_exec_lmon_launch_str");
+      exit(1);
+    }
+  }
+
   return lrc;
 }
-  
 
 //! lmon_rc_e LMON_fe_attachAndSpawnDaemons
 /*!
-  
+
     Please refer to the manpage.
 
 
 */
-extern "C" 
-lmon_rc_e 
-LMON_fe_attachAndSpawnDaemons ( 
-		int sessionHandle, 
-		const char* hostname,
-		pid_t launcherPid, 
-		const char* toolDaemon, 
-		char* d_argv[], 
-		void* febe_data, 
-		void* befe_data )
-{
+extern "C" lmon_rc_e LMON_fe_attachAndSpawnDaemons(
+    int sessionHandle, const char *hostname, pid_t launcherPid,
+    const char *toolDaemon, char *d_argv[], void *febe_data, void *befe_data) {
   using namespace std;
 
   int verbosity_level;
-  char* vb;
-  lmon_session_desc_t* mydesc;
+  char *vb;
+  lmon_session_desc_t *mydesc;
   lmon_rc_e lrc = LMON_EINVAL;
-  string ip_port_pair;    
+  string ip_port_pair;
   pid_t remote_login_pid;
   opts_args_t opt;
-  
-  if ( (sessionHandle < 0) 
-       || (sessionHandle > MAX_LMON_SESSION) )    
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"session is invalid" );
-      return LMON_EBDARG;
-    }
-  
-  mydesc = &sess.sessionDescArray[sessionHandle];       
+
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
+
+  mydesc = &sess.sessionDescArray[sessionHandle];
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"the session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "the session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-  
+
   verbosity_level = 0;
-  if ( (vb = getenv (LMON_VERBOSE_ENVNAME)) != NULL )
-    {	
-      /*
-       * The value specified via the "LMON_VERBOSITY" envVar 
-       * sets an appropriate verbose level
-       */
-      verbosity_level = atoi(vb);
+  if ((vb = getenv(LMON_VERBOSE_ENVNAME)) != NULL) {
+    /*
+     * The value specified via the "LMON_VERBOSITY" envVar
+     * sets an appropriate verbose level
+     */
+    verbosity_level = atoi(vb);
+  }
+
+  if ((verbosity_level > 3) || (verbosity_level) < 0) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "verbosity level must be between 0 to 3");
+    verbosity_level = 0;
+  }
+
+  if ((lrc = LMON_set_options(mydesc, opt, verbosity_level, true, NULL, NULL,
+                              launcherPid, toolDaemon, d_argv)) != LMON_OK) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "LMON_set_option failed");
+    return LMON_EBDARG;
+  }
+
+  if ((remote_login_pid = fork()) != 0) {
+    //
+    // A separate process got spawned, which will perform
+    // the meat of the launchmon operations on the parallel
+    // launcher of interest
+    //
+    // As an API level, we will spawn a watchdog to deal with comm
+    // with this launchmon process
+    //
+    int thrarg[2];
+    pthread_t *mythrHandle = &(mydesc->watchdogThr.fetofeMonitoringThr);
+
+    if ((lrc = LMON_fe_acceptEngine(sessionHandle)) != LMON_OK) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "LMON_fe_acceptEngine failed");
+
+      return lrc;
     }
-  
-  if ( (verbosity_level > 3) || (verbosity_level) < 0 )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	"verbosity level must be between 0 to 3");
-      verbosity_level = 0;
+
+    thrarg[0] = mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd;
+    thrarg[1] = sessionHandle;
+
+    //
+    // LMON_fetofe_watchdog_thread is the thread-entry function
+    //
+    if ((pthread_create(mythrHandle, NULL, LMON_fetofe_watchdog_thread,
+                        (void *)thrarg)) != 0) {
+      return LMON_ESYS;
     }
-  
-  if ( ( lrc = LMON_set_options( mydesc,
-				 opt,
-				 verbosity_level,
-				 true,
-				 NULL,
-				 NULL,
-				 launcherPid,
-				 toolDaemon,
-				 d_argv))
-       != LMON_OK )
-      {
-	LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	  "LMON_set_option failed");
-        return LMON_EBDARG;
-      }
-  
-  if ( ( remote_login_pid = fork() ) != 0 )
-    {
-      //
-      // A separate process got spawned, which will perform
-      // the meat of the launchmon operations on the parallel
-      // launcher of interest
-      //
-      // As an API level, we will spawn a watchdog to deal with comm
-      // with this launchmon process
-      //
-      int thrarg[2];
-      pthread_t* mythrHandle
-	= &(mydesc->watchdogThr.fetofeMonitoringThr);
 
-      if ( (lrc = LMON_fe_acceptEngine ( sessionHandle )) != LMON_OK )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-			 "LMON_fe_acceptEngine failed");
-	  
-	  return lrc;
-	}
+    //
+    // This API call gets blocked until the watchdog thread get notified of
+    // spawned event.
+    //
+    pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
+    if (mydesc->spawned != LMON_TRUE) {
+      struct timespec ts;
+      char *tout = getenv("LMON_FE_ENGINE_TIMEOUT");
+      clock_gettime(CLOCK_REALTIME, &ts);
+      int prc;
 
-      thrarg[0] = mydesc->commDesc[fe_engine_conn].sessionAcceptSockFd;
-      thrarg[1] = sessionHandle;
+      if (tout && ((atoi(tout) > 0) && (atoi(tout) <= MAX_TIMEOUT)))
+        ts.tv_sec += atoi(tout);
+      else
+        ts.tv_sec += DFLT_FE_ENGINE_TOUT;
 
-      //
-      // LMON_fetofe_watchdog_thread is the thread-entry function
-      //
-      if ( ( pthread_create( mythrHandle,
-			     NULL,
-			     LMON_fetofe_watchdog_thread,
-			     (void*) thrarg ) ) != 0 )
-	{
-	  return LMON_ESYS;
-	}
-
-      //
-      // This API call gets blocked until the watchdog thread get notified of 
-      // spawned event.	
-      //
-      pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-      if ( mydesc->spawned != LMON_TRUE )
-	{
-	  struct timespec ts; 
-	  char* tout = getenv ( "LMON_FE_ENGINE_TIMEOUT" );
-	  clock_gettime ( CLOCK_REALTIME, &ts ); 
-          int prc;
-	  
-	  if ( tout && ( (atoi(tout) > 0 ) && ( atoi(tout) <= MAX_TIMEOUT )))
-	    ts.tv_sec += atoi(tout);
-	  else
-	    ts.tv_sec += DFLT_FE_ENGINE_TOUT;	     
-	  
-          if ( ( prc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
+      if ((prc = pthread_cond_timedwait(&(mydesc->watchdogThr.condVar),
                                         &(mydesc->watchdogThr.eventMutex),
-                                        &ts )) != 0 )
-            {
-              if ( prc == ETIMEDOUT )
-                {
-	 	  lrc = LMON_ETOUT;
-                  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-                    "FE-ENGINE connection timed out: %d",
-                    tout ? atoi(tout) : DFLT_FE_ENGINE_TOUT );
-                }
-              else
-                {
-		  lrc = LMON_EBUG;
-                  LMON_say_msg ( LMON_FE_MSG_PREFIX, false,
-                    "FE-ENGINE connection failed with an error within pthread_cond_timedwait: err %d",
-                    prc);
-                }
-
-              pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-              return lrc;
-            }
-	}
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-
-      //
-      // Once you are here, the watchdog thread updated the mydesc->spawned flag
-      //
-      if ( mydesc->spawned != LMON_TRUE )
-        {
-	  return LMON_EBUG;
+                                        &ts)) != 0) {
+        if (prc == ETIMEDOUT) {
+          lrc = LMON_ETOUT;
+          LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                       "FE-ENGINE connection timed out: %d",
+                       tout ? atoi(tout) : DFLT_FE_ENGINE_TOUT);
+        } else {
+          lrc = LMON_EBUG;
+          LMON_say_msg(LMON_FE_MSG_PREFIX, false,
+                       "FE-ENGINE connection failed with an error within "
+                       "pthread_cond_timedwait: err %d",
+                       prc);
         }
 
-      if ( (lrc = LMON_fe_beHandshakeSequence (sessionHandle,
-					       false, /* this is attach case */ 
-					       febe_data, 
-					       befe_data ) ) != LMON_OK )
-	{
-	    return lrc;
-	}
-    }
-  else
-    {
-      //
-      // This process bootstraps the LaunchMON ENGINE with ssh or rsh
-      // or directly exec's the launchMON ENGINE.
-      //	
-      bool isLocal;
-      char pidstr[10];
-      list<string> lmonOptArgs;
-
-      isLocal = (hostname == NULL) ? true : false;
-      if ( (isLocal == false) 
-	   && getenv("LMON_DEBUG_FE_ENGINE_RSH") )	  
-	LMON_TotalView_debug ();
-
-      lmonOptArgs.push_back("--remote");
-      lmonOptArgs.push_back(opt.get_my_opt()->remote_info);
-      lmonOptArgs.push_back("--lmonsec");
-      lmonOptArgs.push_back(opt.get_my_opt()->lmon_sec_info);
-      lmonOptArgs.push_back("--daemonpath");
-      lmonOptArgs.push_back(opt.get_my_opt()->tool_daemon);
-
-      const list<string> &tool_daemon_opts = opt.get_my_opt()->tool_daemon_opts;
-      if ( !tool_daemon_opts.empty() )
-        {
-          lmonOptArgs.push_back("--daemonopts");
-
-          stringstream ss;
-          ss << tool_daemon_opts.size();
-          lmonOptArgs.push_back(ss.str());
-
-          lmonOptArgs.insert(lmonOptArgs.end(), tool_daemon_opts.begin(), tool_daemon_opts.end());
-	}
-
-      lmonOptArgs.push_back("--pid");
-      sprintf ( pidstr, "%d", opt.get_my_opt()->launcher_pid ); 
-      lmonOptArgs.push_back(pidstr); 
-
-      if ( bld_exec_lmon_launch_str ( isLocal, 
-				      hostname,
-				      lmonOptArgs, 
-				      opt )  == LMON_EINVAL )
-	{
-	  LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-	    "The program didn't sink with an exec call in bld_exec_lmon_launch_str");
-	  exit(1);
-	}	
+        pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+        return lrc;
       }
+    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+
+    //
+    // Once you are here, the watchdog thread updated the mydesc->spawned flag
+    //
+    if (mydesc->spawned != LMON_TRUE) {
+      return LMON_EBUG;
+    }
+
+    if ((lrc = LMON_fe_beHandshakeSequence(sessionHandle,
+                                           false, /* this is attach case */
+                                           febe_data, befe_data)) != LMON_OK) {
+      return lrc;
+    }
+  } else {
+    //
+    // This process bootstraps the LaunchMON ENGINE with ssh or rsh
+    // or directly exec's the launchMON ENGINE.
+    //
+    bool isLocal;
+    char pidstr[10];
+    list<string> lmonOptArgs;
+
+    isLocal = (hostname == NULL) ? true : false;
+    if ((isLocal == false) && getenv("LMON_DEBUG_FE_ENGINE_RSH"))
+      LMON_TotalView_debug();
+
+    lmonOptArgs.push_back("--remote");
+    lmonOptArgs.push_back(opt.get_my_opt()->remote_info);
+    lmonOptArgs.push_back("--lmonsec");
+    lmonOptArgs.push_back(opt.get_my_opt()->lmon_sec_info);
+    lmonOptArgs.push_back("--daemonpath");
+    lmonOptArgs.push_back(opt.get_my_opt()->tool_daemon);
+
+    const list<string> &tool_daemon_opts = opt.get_my_opt()->tool_daemon_opts;
+    if (!tool_daemon_opts.empty()) {
+      lmonOptArgs.push_back("--daemonopts");
+
+      stringstream ss;
+      ss << tool_daemon_opts.size();
+      lmonOptArgs.push_back(ss.str());
+
+      lmonOptArgs.insert(lmonOptArgs.end(), tool_daemon_opts.begin(),
+                         tool_daemon_opts.end());
+    }
+
+    lmonOptArgs.push_back("--pid");
+    sprintf(pidstr, "%d", opt.get_my_opt()->launcher_pid);
+    lmonOptArgs.push_back(pidstr);
+
+    if (bld_exec_lmon_launch_str(isLocal, hostname, lmonOptArgs, opt) ==
+        LMON_EINVAL) {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                   "The program didn't sink with an exec call in "
+                   "bld_exec_lmon_launch_str");
+      exit(1);
+    }
+  }
 
   return lrc;
 }
 
-
-//! TODO: launchMwDaemons currently supports limited cases--i.e., one daemon per node
+//! TODO: launchMwDaemons currently supports limited cases--i.e., one daemon per
+//! node
 /*! Upon receiving an non-supported case, this call returns LMON_NOTIMPL
 
 */
-extern "C"
-lmon_rc_e LMON_fe_launchMwDaemons(
-                int sessionHandle,
-                dist_request_t req[],
-                int nreq,
-                void *femw_data,
-                void *mwfe_data)
-{
+extern "C" lmon_rc_e LMON_fe_launchMwDaemons(int sessionHandle,
+                                             dist_request_t req[], int nreq,
+                                             void *femw_data, void *mwfe_data) {
   lmon_rc_e lrc;
-  lmon_session_desc_t* mydesc;
+  lmon_session_desc_t *mydesc;
 
-  if ( (sessionHandle < 0)
-       || (sessionHandle > MAX_LMON_SESSION) )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid" );
-      return LMON_EBDARG;
-    }
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "session is invalid");
+    return LMON_EBDARG;
+  }
 
-  if (nreq <=0 || nreq > LMON_N_MW_TYPES)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "invalid nreq. Does nreq exceed the number of different MW volume kinds?" );
-      return LMON_EBDARG;
-    }
+  if (nreq <= 0 || nreq > LMON_N_MW_TYPES) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "invalid nreq. Does nreq exceed the number of different MW "
+                 "volume kinds?");
+    return LMON_EBDARG;
+  }
 
   mydesc = &sess.sessionDescArray[sessionHandle];
 
@@ -5549,117 +4710,88 @@ lmon_rc_e LMON_fe_launchMwDaemons(
   //
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
 
-
   //
   // spawner setup and call the spawn method of the spawners
   //
   int i;
-  for (i=0; i < nreq; ++i) {
+  for (i = 0; i < nreq; ++i) {
     //
-    // process each distribution requests and 
+    // process each distribution requests and
     // push a right kind of spawner into the ordered spawner vector
     //
     lmon_mw_mode_t curmode = req[i].md;
     std::vector<std::string> argvect;
 
-    int j=0;
-    while (req[i].d_argv && req[i].d_argv[j])
-      {
-        argvect.push_back(std::string(req[i].d_argv[j]));
-        j++;
-      }
+    int j = 0;
+    while (req[i].d_argv && req[i].d_argv[j]) {
+      argvect.push_back(std::string(req[i].d_argv[j]));
+      j++;
+    }
 
-    if (IS_MW_COLOC(curmode))
-      {
-        if ((req[i].ndaemon == -1) && (req[i].block == -1)
-             && (req[i].cyclic == -1))
-          {
-            std::vector<std::string> hostvect;
-            std::map<std::string,std::vector<MPIR_PROCDESC_EXT *>,lexGraphCmp>
-               ::const_iterator miter;
-            for (miter = mydesc->pMap.begin();
-                   miter != mydesc->pMap.end(); miter++)
-              {
-                hostvect.push_back(miter->first);
-              }
-            spawner_base_t *colocSpawner
-              = new spawner_coloc_t(mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
-                                std::string(req[i].mw_daemon_path),
-                                argvect,
-                                hostvect);
+    if (IS_MW_COLOC(curmode)) {
+      if ((req[i].ndaemon == -1) && (req[i].block == -1) &&
+          (req[i].cyclic == -1)) {
+        std::vector<std::string> hostvect;
+        std::map<std::string, std::vector<MPIR_PROCDESC_EXT *>,
+                 lexGraphCmp>::const_iterator miter;
+        for (miter = mydesc->pMap.begin(); miter != mydesc->pMap.end();
+             miter++) {
+          hostvect.push_back(miter->first);
+        }
+        spawner_base_t *colocSpawner = new spawner_coloc_t(
+            mydesc->commDesc[fe_be_conn].sessionAcceptSockFd,
+            std::string(req[i].mw_daemon_path), argvect, hostvect);
 
-            mydesc->spawner_vector.push_back(colocSpawner);
-          }
-        else
-          {
-            lrc = LMON_NOTIMPL;
-            goto op_went_bad;
-          }
-      }
-    else if (IS_MW_EXISTINGALLOC(curmode))
-      {
-        // TODO: not implemented yet 
+        mydesc->spawner_vector.push_back(colocSpawner);
+      } else {
         lrc = LMON_NOTIMPL;
         goto op_went_bad;
       }
-    else if (IS_MW_NEWALLOC(curmode))
-      {
-        // TODO: not implemented yet
+    } else if (IS_MW_EXISTINGALLOC(curmode)) {
+      // TODO: not implemented yet
+      lrc = LMON_NOTIMPL;
+      goto op_went_bad;
+    } else if (IS_MW_NEWALLOC(curmode)) {
+      // TODO: not implemented yet
+      lrc = LMON_NOTIMPL;
+      goto op_went_bad;
+    } else if (IS_MW_HOSTLIST(curmode)) {
+      if ((req[i].ndaemon == -1) && (req[i].block == -1) &&
+          (req[i].cyclic == -1)) {
+        if (req[i].optkind == hostlists) {
+          std::vector<std::string> hostvect;
+          char **htrav = req[i].option.hl;
+          int k = 0;
+          while (htrav && htrav[k]) {
+            hostvect.push_back(std::string(htrav[k]));
+            k++;
+          }
+
+          spawner_base_t *rshSpawner = new spawner_rsh_t(
+              std::string(req[i].mw_daemon_path), argvect, hostvect);
+
+          mydesc->spawner_vector.push_back(rshSpawner);
+        } else {
+          LMON_say_msg(LMON_FE_MSG_PREFIX, true, "Bad optkind: req[%d]", i);
+          lrc = LMON_EBDARG;
+          goto op_went_bad;
+        }
+      } else {
         lrc = LMON_NOTIMPL;
         goto op_went_bad;
       }
-    else if (IS_MW_HOSTLIST(curmode))
-      {
-        if ((req[i].ndaemon == -1) && (req[i].block == -1)
-             && (req[i].cyclic == -1))
-          {
-            if (req[i].optkind == hostlists)
-              {
-                std::vector<std::string> hostvect;
-                char **htrav =  req[i].option.hl;
-                int k=0;
-                while (htrav && htrav[k])
-                  {
-                     hostvect.push_back(std::string(htrav[k]));
-                     k++;
-                  }
-
-                spawner_base_t *rshSpawner
-                  = new spawner_rsh_t( std::string(req[i].mw_daemon_path),
-                                   argvect,
-                                   hostvect);
-
-                mydesc->spawner_vector.push_back(rshSpawner);
-              }
-            else
-              {
-                LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-                  "Bad optkind: req[%d]", i);
-                lrc = LMON_EBDARG;
-                goto op_went_bad;
-              }
-          }
-        else
-          {
-            lrc = LMON_NOTIMPL;
-            goto op_went_bad;
-          }
-      }
-    else
-      {
-        LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-          "Bad request: req[%d]", i);
-        lrc = LMON_EBDARG;
-        goto op_went_bad;
-      }
-  }
-
-  lrc = LMON_fe_mwHandshakeSequence (sessionHandle, femw_data, femw_data);
-  if (lrc != LMON_OK)
-    {
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    } else {
+      LMON_say_msg(LMON_FE_MSG_PREFIX, true, "Bad request: req[%d]", i);
+      lrc = LMON_EBDARG;
       goto op_went_bad;
     }
+  }
+
+  lrc = LMON_fe_mwHandshakeSequence(sessionHandle, femw_data, femw_data);
+  if (lrc != LMON_OK) {
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    goto op_went_bad;
+  }
 
   mydesc->mw_spawned = LMON_TRUE;
 
@@ -5671,126 +4803,106 @@ op_went_bad:
   return lrc;
 }
 
+extern "C" lmon_rc_e LMON_fe_getMwHostlist(int sessionHandle, char **hostlist,
+                                           unsigned int *size,
+                                           unsigned int maxlen) {
+  lmon_session_desc_t *mydesc;
 
-extern "C" lmon_rc_e 
-LMON_fe_getMwHostlist(
-                int sessionHandle,
-                char **hostlist,
-                unsigned int *size,
-                unsigned int maxlen)
-{
-  lmon_session_desc_t* mydesc;
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-  if ( (sessionHandle < 0)
-       || (sessionHandle > MAX_LMON_SESSION)) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
-
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->mw_spawned != LMON_TRUE )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "middleware daemons have not been sapwned!");
+  if (mydesc->mw_spawned != LMON_TRUE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "middleware daemons have not been sapwned!");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
   std::vector<std::string> chosts;
   std::vector<std::string>::const_iterator hiter;
   (*size) = 0;
   std::vector<spawner_base_t *>::const_iterator iter;
   for (iter = mydesc->spawner_vector.begin();
-         iter != mydesc->spawner_vector.end(); ++iter)
-    {
-      (*iter)->combineHosts(chosts);
-    }
+       iter != mydesc->spawner_vector.end(); ++iter) {
+    (*iter)->combineHosts(chosts);
+  }
 
   (*size) = chosts.size();
-  unsigned int i=0;
+  unsigned int i = 0;
 
   //
-  // This builds hostlist in ascending LMON MW rank order 
+  // This builds hostlist in ascending LMON MW rank order
   //
-  for (hiter = chosts.begin();
-         ((hiter != chosts.end()) && i <= maxlen); hiter++)
-    {
-      //
-      // Freeing is upto the caller
-      //
-      hostlist[i] = strdup((*hiter).c_str());
-      i++;
-    }
+  for (hiter = chosts.begin(); ((hiter != chosts.end()) && i <= maxlen);
+       hiter++) {
+    //
+    // Freeing is upto the caller
+    //
+    hostlist[i] = strdup((*hiter).c_str());
+    i++;
+  }
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
 
-  if (( i == maxlen ) && maxlen < (*size) )
-    return LMON_ETRUNC;
+  if ((i == maxlen) && maxlen < (*size)) return LMON_ETRUNC;
 
   return LMON_OK;
-
 }
 
+extern "C" lmon_rc_e LMON_fe_getMwHostlistSize(int sessionHandle,
+                                               unsigned int *size) {
+  lmon_session_desc_t *mydesc;
 
-extern "C" lmon_rc_e
-LMON_fe_getMwHostlistSize(
-                int sessionHandle,
-                unsigned int *size)
-{
-  lmon_session_desc_t* mydesc;
+  if ((sessionHandle < 0) || (sessionHandle > MAX_LMON_SESSION)) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true, "an argument is invalid");
 
-  if ( (sessionHandle < 0)
-       || (sessionHandle > MAX_LMON_SESSION)) 
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-         "an argument is invalid" );
-
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
   mydesc = &(sess.sessionDescArray[(sessionHandle)]);
   pthread_mutex_lock(&(mydesc->watchdogThr.eventMutex));
-  if (mydesc->registered == LMON_FALSE)
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "session is invalid, the job killed?");
+  if (mydesc->registered == LMON_FALSE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "session is invalid, the job killed?");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EBDARG;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EBDARG;
+  }
 
-  if ( mydesc->mw_spawned != LMON_TRUE )
-    {
-      LMON_say_msg ( LMON_FE_MSG_PREFIX, true,
-        "middleware daemons have not been sapwned!");
+  if (mydesc->mw_spawned != LMON_TRUE) {
+    LMON_say_msg(LMON_FE_MSG_PREFIX, true,
+                 "middleware daemons have not been sapwned!");
 
-      pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
-      return LMON_EDUNAV;
-    }
+    pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
+    return LMON_EDUNAV;
+  }
 
   (*size) = 0;
 
   std::vector<spawner_base_t *>::const_iterator iter;
   for (iter = mydesc->spawner_vector.begin();
-         iter != mydesc->spawner_vector.end(); ++iter)
-    {
-      (*size) += (*iter)->get_hosts_vector().size();
-    }
+       iter != mydesc->spawner_vector.end(); ++iter) {
+    (*size) += (*iter)->get_hosts_vector().size();
+  }
 
   pthread_mutex_unlock(&(mydesc->watchdogThr.eventMutex));
   return LMON_OK;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_lmonp_msg.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_lmonp_msg.cxx
@@ -1,39 +1,40 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_lmonp_msg.cxx,v 1.6.2.4 2008/03/06 00:13:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May 30 2012 DHA: (ID: 3530680) Added utility functions that return
  *                         information about various LMON message fields.
  *        Nov 08 2010 DHA: Added memset to set_msg_header to remove
  *                         write-into-uninitialized buf conditions
- *        Dec 23 2009 DHA: Added explict config.h inclusion 
+ *        Dec 23 2009 DHA: Added explict config.h inclusion
  *        Mar 13 2009 DHA: Added large nTasks supporf
- *        Mar 05 2008 DHA: Added timedaccept support 
- *        Mar 05 2008 DHA: Rewrote lmon_write_raw and lmon_read_raw to enhance 
+ *        Mar 05 2008 DHA: Added timedaccept support
+ *        Mar 05 2008 DHA: Rewrote lmon_write_raw and lmon_read_raw to enhance
  *                         readibility.
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Dec 19 2006 DHA: Created file.
@@ -49,25 +50,24 @@
 #error This source file requires a LINUX OS
 #endif
 
-#include <unistd.h>
-#include <cstdio>
-#include <stdint.h>
-#include <cassert>
-#include <cstdlib>
-#include <string.h>
-#include <string>
-#include <iostream>
-#include <vector>
-#include <map>
 #include <errno.h>
+#include <stdint.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <unistd.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
 
 #include <lmon_api/lmon_lmonp_msg.h>
 #include <lmon_api/lmon_proctab.h>
 
 #define LMONP_MSG_OP "[LMONP MSG]"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -80,63 +80,51 @@ static std::string iamusedby("Not Set");
 // The following name arrays must be updated whenever the LMONP
 // protocol is updated
 //
-static const char *lmonp_fe_to_fe_str[] =
-  {
-    "lmonp_conn_ack_no_error",
-    "lmonp_conn_ack_parse_error",
-    "lmonp_stop_at_launch_bp_spawned",
-    "lmonp_rminfo",
-    "lmonp_stop_at_launch_bp_abort",
-    "lmonp_proctable_avail",
-    "lmonp_resourcehandle_avail",
-    "lmonp_stop_at_first_exec",
-    "lmonp_stop_at_first_attach",
-    "lmonp_stop_at_loader_bp",
-    "lmonp_stop_at_thread_creation",
-    "lmonp_stop_at_thread_death",
-    "lmonp_stop_at_fork_bp",
-    "lmonp_stop_not_interested",
-    "lmonp_terminated",
-    "lmonp_exited",
-    "lmonp_detach_done",
-    "lmonp_kill_done",
-    "lmonp_stop_tracing",
-    "lmonp_bedmon_exited",
-    "lmonp_mwdmon_exited",
-    "lmonp_detach",
-    "lmonp_kill",
-    "lmonp_shutdownbe",
-    "lmonp_cont_launch_bp",
-    "lmonp_invalid"
-  };
+static const char *lmonp_fe_to_fe_str[] = {"lmonp_conn_ack_no_error",
+                                           "lmonp_conn_ack_parse_error",
+                                           "lmonp_stop_at_launch_bp_spawned",
+                                           "lmonp_rminfo",
+                                           "lmonp_stop_at_launch_bp_abort",
+                                           "lmonp_proctable_avail",
+                                           "lmonp_resourcehandle_avail",
+                                           "lmonp_stop_at_first_exec",
+                                           "lmonp_stop_at_first_attach",
+                                           "lmonp_stop_at_loader_bp",
+                                           "lmonp_stop_at_thread_creation",
+                                           "lmonp_stop_at_thread_death",
+                                           "lmonp_stop_at_fork_bp",
+                                           "lmonp_stop_not_interested",
+                                           "lmonp_terminated",
+                                           "lmonp_exited",
+                                           "lmonp_detach_done",
+                                           "lmonp_kill_done",
+                                           "lmonp_stop_tracing",
+                                           "lmonp_bedmon_exited",
+                                           "lmonp_mwdmon_exited",
+                                           "lmonp_detach",
+                                           "lmonp_kill",
+                                           "lmonp_shutdownbe",
+                                           "lmonp_cont_launch_bp",
+                                           "lmonp_invalid"};
 
-static const char *lmonp_fe_to_be_str[] =
-  {
-    "lmonp_febe_security_chk",
-    "lmonp_febe_proctab",
-    "lmonp_febe_usrdata",
-    "lmonp_febe_launch",
-    "lmonp_febe_launch_dontstop",
-    "lmonp_febe_attach",
-    "lmonp_febe_attach_stop",
-    "lmonp_febe_assist_mw_coloc",
-    "lmonp_febe_rm_type",
-    "lmonp_befe_hostname",
-    "lmonp_befe_usrdata",
-    "lmonp_befe_cont_launch_bp",
-    "lmonp_befe_ready"
-  };
+static const char *lmonp_fe_to_be_str[] = {"lmonp_febe_security_chk",
+                                           "lmonp_febe_proctab",
+                                           "lmonp_febe_usrdata",
+                                           "lmonp_febe_launch",
+                                           "lmonp_febe_launch_dontstop",
+                                           "lmonp_febe_attach",
+                                           "lmonp_febe_attach_stop",
+                                           "lmonp_febe_assist_mw_coloc",
+                                           "lmonp_febe_rm_type",
+                                           "lmonp_befe_hostname",
+                                           "lmonp_befe_usrdata",
+                                           "lmonp_befe_cont_launch_bp",
+                                           "lmonp_befe_ready"};
 
-static const char *lmonp_fe_to_wm_str[] =
-  {
-    "lmonp_femw_security_chk",
-    "lmonp_femw_proctab",
-    "lmonp_femw_usrdata",
-    "lmonp_mwfe_hostname",
-    "lmonp_mwfe_usrdata",
-    "lmonp_mwfe_ready",
-  };
-
+static const char *lmonp_fe_to_wm_str[] = {
+    "lmonp_femw_security_chk", "lmonp_femw_proctab", "lmonp_femw_usrdata",
+    "lmonp_mwfe_hostname",     "lmonp_mwfe_usrdata", "lmonp_mwfe_ready",
+};
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -144,329 +132,265 @@ static const char *lmonp_fe_to_wm_str[] =
 //
 //
 
-//! ssize_t lmon_write_raw 
+//! ssize_t lmon_write_raw
 /*!
-    a wrapper for the write call. 
+    a wrapper for the write call.
 */
-ssize_t 
-lmon_write_raw ( int fd, void *buf, size_t count )
-{
+ssize_t lmon_write_raw(int fd, void *buf, size_t count) {
   ssize_t writeN;
   ssize_t global_writeN = 0;
-  char* write_completely = (char*) buf;
+  char *write_completely = (char *)buf;
   int errflag = 0;
 
-  if (!buf)
-    return -1;
+  if (!buf) return -1;
 
-  for ( ; ; )
-    {
+  for (;;) {
+    writeN = write(fd, (void *)write_completely, count - global_writeN);
 
-      writeN = write ( fd,
-                       (void*)write_completely,
-                       count-global_writeN );
-
-      if (  writeN < 0 )
-        {
-          if ( ( errno == EINTR ) || (errno == EAGAIN)) 
-            {
-              continue;
-            } 
-          else 
-            {
-              // if an error other than EINTR or EAGAIN
-              // occurs, we should probably want to return; 
-              errflag = 1;
-              break;
-            }
-        } 
-
-      global_writeN += writeN;
-      if ( global_writeN == (ssize_t)count )
-        {
-          // if we reached to our goal (count) 
-          // we want to return;
-          break;
-        }
-      else if ( global_writeN > (ssize_t)count ) 
-        {
-          // This should never happen 
-          //
-          errflag = 1;
-          break;
-        }
-   
-      //
-      // otherwise, we want to advance the temporary butter pointer
-      // in order to keep writing to the file descriptor.  
-      //
-      write_completely += writeN;
+    if (writeN < 0) {
+      if ((errno == EINTR) || (errno == EAGAIN)) {
+        continue;
+      } else {
+        // if an error other than EINTR or EAGAIN
+        // occurs, we should probably want to return;
+        errflag = 1;
+        break;
+      }
     }
 
-  return ( (errflag==0) ? global_writeN : -1 );
+    global_writeN += writeN;
+    if (global_writeN == (ssize_t)count) {
+      // if we reached to our goal (count)
+      // we want to return;
+      break;
+    } else if (global_writeN > (ssize_t)count) {
+      // This should never happen
+      //
+      errflag = 1;
+      break;
+    }
 
+    //
+    // otherwise, we want to advance the temporary butter pointer
+    // in order to keep writing to the file descriptor.
+    //
+    write_completely += writeN;
+  }
+
+  return ((errflag == 0) ? global_writeN : -1);
 }
-
 
 //! ssize_t lmon_read_raw ( int fd, void *buf, size_t count )
 /*!
-    a wrapper for the read call. 
+    a wrapper for the read call.
 */
-ssize_t 
-lmon_read_raw ( int fd, void *buf, size_t count )
-{
+ssize_t lmon_read_raw(int fd, void *buf, size_t count) {
   ssize_t readN;
   ssize_t global_readN = 0;
-  char* read_completely = (char*) buf; 
+  char *read_completely = (char *)buf;
   int errflag = 0;
 
-  if (!buf)
-    return -1;
+  if (!buf) return -1;
 
-  for ( ; ; )
-    {
-      readN = read ( fd,
-                     (void*) read_completely, 
-                     count-global_readN );
+  for (;;) {
+    readN = read(fd, (void *)read_completely, count - global_readN);
 
-      if ( readN == 0 )
-        {
-          errflag = 1; /* in the context of sockets API, this means connection lost */
-          break;
-        }
-      else if (  readN < 0 )
-        {
-          if ( ( errno == EINTR ) || (errno == EAGAIN)) 
-            {
-              continue;
-            } 
-          else 
-            {
-              // if an error other than EINTR or EAGAIN
-              // occurs, we should probably want to return; 
-              errflag = 1;
-              break;
-            }
-        } 
+    if (readN == 0) {
+      errflag =
+          1; /* in the context of sockets API, this means connection lost */
+      break;
+    } else if (readN < 0) {
+      if ((errno == EINTR) || (errno == EAGAIN)) {
+        continue;
+      } else {
+        // if an error other than EINTR or EAGAIN
+        // occurs, we should probably want to return;
+        errflag = 1;
+        break;
+      }
+    }
 
-      global_readN += readN;
-      if ( global_readN == (ssize_t)count )
-        {
-          // if we reached to our goal (count) 
-          // we want to return;
-          break;
-        }
-      else if ( global_readN > (ssize_t)count ) 
-        {
-          // This should never happen 
-          //
-          errflag = 1;
-          break;
-        }
- 
-      read_completely += readN;
-    } 
+    global_readN += readN;
+    if (global_readN == (ssize_t)count) {
+      // if we reached to our goal (count)
+      // we want to return;
+      break;
+    } else if (global_readN > (ssize_t)count) {
+      // This should never happen
+      //
+      errflag = 1;
+      break;
+    }
 
-  return ( (errflag==0) ? global_readN : -1 );
+    read_completely += readN;
+  }
+
+  return ((errflag == 0) ? global_readN : -1);
 }
 
 //! int lmon_accept(int s, struct sockaddr *addr, socklen_t *addrlen);
 /*!
-    a wrapper for the accept call. 
+    a wrapper for the accept call.
 */
-int 
-lmon_accept ( int s, struct sockaddr *addr, socklen_t *addrlen )
-{
+int lmon_accept(int s, struct sockaddr *addr, socklen_t *addrlen) {
   int connfd = -1;
 
-  for ( ; ; )
-    {
-      connfd  = accept ( s, addr, addrlen );
+  for (;;) {
+    connfd = accept(s, addr, addrlen);
 
-      //
-      // If s is not marked with O_NONBLOCK and no connection 
-      // arrive, above accept will block. Make sure to mark
-      // the socket with O_NONBLOCK. 
-      //
+    //
+    // If s is not marked with O_NONBLOCK and no connection
+    // arrive, above accept will block. Make sure to mark
+    // the socket with O_NONBLOCK.
+    //
 
-      if (connfd < 0 )
-        {
-          if ( (errno == EAGAIN)
-               || (errno == EWOULDBLOCK)
-               || (errno == EINTR)) 
-            {
-              //
-              // if accept returned because of those errors 
-              // we want to call that again.
-              //
-              continue; 
-            }
-        }
-
-      break;
+    if (connfd < 0) {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINTR)) {
+        //
+        // if accept returned because of those errors
+        // we want to call that again.
+        //
+        continue;
+      }
     }
+
+    break;
+  }
 
   return connfd;
 }
-
 
 //! int lmon_timed_accept
 /*!
     -1: other errors
     -2: timed out
-                                                                                                        
+
 */
-int
-lmon_timedaccept ( int s, struct sockaddr *addr,
-                   socklen_t *addrlen, int toutsec )
-{
+int lmon_timedaccept(int s, struct sockaddr *addr, socklen_t *addrlen,
+                     int toutsec) {
   struct timeval to;
   fd_set readset;
   int nready = 0;
 
-  if (toutsec < 0 )
-    return -1;
+  if (toutsec < 0) return -1;
 
-  FD_ZERO (&readset);
-  FD_SET (s, &readset);
+  FD_ZERO(&readset);
+  FD_SET(s, &readset);
 
   to.tv_sec = toutsec;
   to.tv_usec = 0;
 
-  nready = select (s+1, &readset, NULL, NULL, &to);
+  nready = select(s + 1, &readset, NULL, NULL, &to);
 
-  if ( nready < 0 )
-    {
-      return -1;
-    }
-  else if ( nready == 0 )
-    {
-      //
-      // timed out...
-      //
-      return -2;
-    }
+  if (nready < 0) {
+    return -1;
+  } else if (nready == 0) {
+    //
+    // timed out...
+    //
+    return -2;
+  }
 
- return ( lmon_accept (s, addr, addrlen) );
+  return (lmon_accept(s, addr, addrlen));
 }
-
 
 //! const char *lmon_msg_to_str
 /*!
     returns a string corresponding to a field in an LMONP msg.
 */
-const char *lmon_msg_to_str ( lmon_msg_field_selector_e s, 
-                       lmonp_t *msg ) 
-{
+const char *lmon_msg_to_str(lmon_msg_field_selector_e s, lmonp_t *msg) {
   const char *ret_str = NULL;
 
-  if (!msg)
-    return ret_str; 
+  if (!msg) return ret_str;
 
-  switch (s) 
-    {
+  switch (s) {
     case field_class:
-      switch (msg->msgclass) 
-        {
-          case lmonp_fetofe:
-            ret_str = "lmonp_fetofe";   
-            break; 
+      switch (msg->msgclass) {
+        case lmonp_fetofe:
+          ret_str = "lmonp_fetofe";
+          break;
 
-          case lmonp_fetobe:
-            ret_str = "lmonp_fetobe";   
-            break;
+        case lmonp_fetobe:
+          ret_str = "lmonp_fetobe";
+          break;
 
-          case lmonp_fetomw:
-            ret_str = "lmonp_fetomw";   
-            break;
+        case lmonp_fetomw:
+          ret_str = "lmonp_fetomw";
+          break;
 
-          default:
-            break;
-        }
+        default:
+          break;
+      }
       break;
 
     case field_type:
-      if (msg->msgclass == lmonp_fetofe)
-        {
-          ret_str = lmonp_fe_to_fe_str[msg->type.fetofe_type];
-        }
-      else if (msg->msgclass == lmonp_fetobe)
-        {
-          ret_str = lmonp_fe_to_be_str[msg->type.fetobe_type];
-        }
-      else if (msg->msgclass == lmonp_fetomw)
-        {
-          ret_str = lmonp_fe_to_be_str[msg->type.fetomw_type];
-        }
+      if (msg->msgclass == lmonp_fetofe) {
+        ret_str = lmonp_fe_to_fe_str[msg->type.fetofe_type];
+      } else if (msg->msgclass == lmonp_fetobe) {
+        ret_str = lmonp_fe_to_be_str[msg->type.fetobe_type];
+      } else if (msg->msgclass == lmonp_fetomw) {
+        ret_str = lmonp_fe_to_be_str[msg->type.fetomw_type];
+      }
       break;
 
-  case field_security1: {
-    char *tmp_str = (char *) malloc (16);
-    snprintf(tmp_str, 16, "%d", msg->sec_or_jobsizeinfo.security_key1);
-    ret_str = (const char *) tmp_str;
-    break;
-  }
+    case field_security1: {
+      char *tmp_str = (char *)malloc(16);
+      snprintf(tmp_str, 16, "%d", msg->sec_or_jobsizeinfo.security_key1);
+      ret_str = (const char *)tmp_str;
+      break;
+    }
 
-  case field_security2: {
-    char *tmp_str = (char *) malloc (16);
-    snprintf(tmp_str, 16, "%d", msg->sec_or_stringinfo.security_key2);
-    ret_str = (const char *) tmp_str;
-    break;
-  }
+    case field_security2: {
+      char *tmp_str = (char *)malloc(16);
+      snprintf(tmp_str, 16, "%d", msg->sec_or_stringinfo.security_key2);
+      ret_str = (const char *)tmp_str;
+      break;
+    }
 
-  case field_long_num_tasks: {
-    char *tmp_str = (char *) malloc (16);
-    snprintf(tmp_str, 16, "%d", msg->long_num_tasks);
-    ret_str = (const char *) tmp_str;
-    break;
-  }
-  case field_lmon_payload_length: {
-    char *tmp_str = (char *) malloc (16);
-    snprintf(tmp_str, 16, "%d", msg->lmon_payload_length);
-    ret_str = (const char *) tmp_str;
-    break;
-  }
+    case field_long_num_tasks: {
+      char *tmp_str = (char *)malloc(16);
+      snprintf(tmp_str, 16, "%d", msg->long_num_tasks);
+      ret_str = (const char *)tmp_str;
+      break;
+    }
+    case field_lmon_payload_length: {
+      char *tmp_str = (char *)malloc(16);
+      snprintf(tmp_str, 16, "%d", msg->lmon_payload_length);
+      ret_str = (const char *)tmp_str;
+      break;
+    }
 
-  case field_usr_payload_length: {
-    char *tmp_str = (char *) malloc (16);
-    snprintf(tmp_str, 16, "%d", msg->usr_payload_length);
-    ret_str = (const char *) tmp_str;
-    break;
-  }
+    case field_usr_payload_length: {
+      char *tmp_str = (char *)malloc(16);
+      snprintf(tmp_str, 16, "%d", msg->usr_payload_length);
+      ret_str = (const char *)tmp_str;
+      break;
+    }
 
-  default:
-    break;
+    default:
+      break;
   }
 
   return ret_str;
 }
 
-
 //! void set_client_name ( const char* cn );
 /*!
-    Which spatial component is using this lmonp message? 
+    Which spatial component is using this lmonp message?
 */
-void 
-set_client_name(const char* cn)
-{
-  iamusedby = cn;
-}
-
+void set_client_name(const char *cn) { iamusedby = cn; }
 
 //! print_msg_header ( my_lmon_kind_e rw, lmonp_t* msg );
 /*!
     print_msg_header: debug routine, printing message type and comm parties
 */
-int 
-print_msg_header ( my_lmon_kind_e k, lmonp_t* msg )
-{
+int print_msg_header(my_lmon_kind_e k, lmonp_t *msg) {
   using namespace std;
 
   string kind;
   bool sanitychk = true;
 
-  switch (k)
-    {
+  switch (k) {
     case lmon_fe_driver:
       kind = "[lmon_fe_driver]: ";
       break;
@@ -477,7 +401,7 @@ print_msg_header ( my_lmon_kind_e k, lmonp_t* msg )
 
     case lmon_fe:
       kind = "[lmon_fe]:";
-      break;  
+      break;
 
     case lmon_be:
       kind = "[lmon_be]:";
@@ -490,128 +414,100 @@ print_msg_header ( my_lmon_kind_e k, lmonp_t* msg )
     default:
       sanitychk = false;
       break;
-    }
+  }
 
-  if (!sanitychk)
-    {
-      //
-      // This kind is not known
-      //
-      return -1;   
-    }
-  
-  if ( iamusedby != string("Not Set"))
-    {
-       cout << "[" << iamusedby << "]"<< kind 
-            << "msg->msgclass: " << msg->msgclass 
-	    << endl;
-       cout << "[" << iamusedby << "]"<< kind 
-            << "msg->type.fetofe_type: " << msg->type.fetofe_type 
-	    << endl;
-       cout << "[" << iamusedby << "]"<< kind 
-            << "msg->lmon_payload_length: " << msg->lmon_payload_length 
-	    << endl;
-       cout << "[" << iamusedby << "]"<< kind 
-            << "msg->usr_payload_length: " << msg->usr_payload_length 
-	    << endl;
-    }
-  else
-   { 
-       cout << kind << "msg->msgclass: " << msg->msgclass 
-	    << endl;
-       cout << kind << "msg->type.fetofe_type: " << msg->type.fetofe_type 
-	    << endl;
-       cout << kind << "msg->lmon_payload_length: " << msg->lmon_payload_length 
-	    << endl;
-       cout << kind << "msg->usr_payload_length: " << msg->usr_payload_length 
-	    << endl;  
-   }
+  if (!sanitychk) {
+    //
+    // This kind is not known
+    //
+    return -1;
+  }
+
+  if (iamusedby != string("Not Set")) {
+    cout << "[" << iamusedby << "]" << kind
+         << "msg->msgclass: " << msg->msgclass << endl;
+    cout << "[" << iamusedby << "]" << kind
+         << "msg->type.fetofe_type: " << msg->type.fetofe_type << endl;
+    cout << "[" << iamusedby << "]" << kind
+         << "msg->lmon_payload_length: " << msg->lmon_payload_length << endl;
+    cout << "[" << iamusedby << "]" << kind
+         << "msg->usr_payload_length: " << msg->usr_payload_length << endl;
+  } else {
+    cout << kind << "msg->msgclass: " << msg->msgclass << endl;
+    cout << kind << "msg->type.fetofe_type: " << msg->type.fetofe_type << endl;
+    cout << kind << "msg->lmon_payload_length: " << msg->lmon_payload_length
+         << endl;
+    cout << kind << "msg->usr_payload_length: " << msg->usr_payload_length
+         << endl;
+  }
 
   return 0;
 }
 
-
 //! init_msg_header ( lmonp_t* msg );
-/*! 
+/*!
   init_msg_header: zero outthe header portion of lmonp message
   0 on success, -1 on error
 */
-int 
-init_msg_header ( lmonp_t* msg )
-{
-  if ( memset(msg,0,sizeof(*msg)) == NULL )
-    {
-      return -1;
-    }
+int init_msg_header(lmonp_t *msg) {
+  if (memset(msg, 0, sizeof(*msg)) == NULL) {
+    return -1;
+  }
   return 0;
 }
 
-
 //! write_lmonp_long_msg ( int fd, lmonp_t* msg, int msglength )
-/*! 
-  The functions looks at the header of msg before shipping the 
+/*!
+  The functions looks at the header of msg before shipping the
   entire msg via fd
 */
-int 
-write_lmonp_long_msg ( int fd, lmonp_t* msg, int msglength )
-{
+int write_lmonp_long_msg(int fd, lmonp_t *msg, int msglength) {
   using namespace std;
 
   int write_byte;
-  int msgsize = sizeof ( (*msg) )
-                + msg->lmon_payload_length 
-                + msg->usr_payload_length;
+  int msgsize =
+      sizeof((*msg)) + msg->lmon_payload_length + msg->usr_payload_length;
 
-  if (msgsize != msglength)
-    {
-      cerr << LMONP_MSG_OP
-           << "message size mismatch"
-           << endl;
+  if (msgsize != msglength) {
+    cerr << LMONP_MSG_OP << "message size mismatch" << endl;
 
-      return -1; 
-    }
+    return -1;
+  }
 
-  write_byte = lmon_write_raw ( fd, msg, msgsize );
+  write_byte = lmon_write_raw(fd, msg, msgsize);
 
   return write_byte;
 }
 
-
 //! int read_lmonp_msgheader ( int fd, lmonp_t* msg )
-/*! 
+/*!
   The functions reads only the header portion of an
   lmonp message via fd.
 */
-int 
-read_lmonp_msgheader ( int fd, lmonp_t* msg )
-{
+int read_lmonp_msgheader(int fd, lmonp_t *msg) {
   int read_byte;
-  
-  read_byte = lmon_read_raw ( fd, msg, sizeof(*msg));
+
+  read_byte = lmon_read_raw(fd, msg, sizeof(*msg));
 
   return read_byte;
 }
 
-
 //! int read_lmonp_payloads ( int fd, void* buf, int length )
-/*! 
+/*!
   The functions reads the payloads portion of an
   lmonp message via fd.
 */
-int 
-read_lmonp_payloads ( int fd, void* buf, int length )
-{
+int read_lmonp_payloads(int fd, void *buf, int length) {
   int read_byte;
 
-  read_byte = lmon_read_raw ( fd, buf, length );
+  read_byte = lmon_read_raw(fd, buf, length);
 
   return read_byte;
 }
 
-
 //! int set_msg_header (lmonp_t* msg, ...
-/*! 
-  a helper function setting the lmonp header 
+/*!
+  a helper function setting the lmonp header
 
 typedef struct _lmonp_t {
   lmonp_msg_class_e msgclass            : 3;
@@ -628,7 +524,7 @@ typedef struct _lmonp_t {
   } sec_or_jobsizeinfo;
 
   union u2{
-    unsigned int security_key2          : 32; 
+    unsigned int security_key2          : 32;
     struct unique_str {
       unsigned short num_exec_name      : 16;
       unsigned short num_host_name      : 16;
@@ -643,53 +539,43 @@ typedef struct _lmonp_t {
 
 
 */
-extern "C" 
-int 
-set_msg_header (lmonp_t *msg,
-		lmonp_msg_class_e mc,
-		int type,
-		unsigned short seckey_or_numtasks,
-		unsigned int security_key2,
-		unsigned short num_exec_name,
-		unsigned short num_host_name,
-		unsigned int lntask,
-		unsigned int lmonlen,
-		unsigned int usrlen )
-{
-  if (!msg)
-    return -1;
+extern "C" int set_msg_header(lmonp_t *msg, lmonp_msg_class_e mc, int type,
+                              unsigned short seckey_or_numtasks,
+                              unsigned int security_key2,
+                              unsigned short num_exec_name,
+                              unsigned short num_host_name, unsigned int lntask,
+                              unsigned int lmonlen, unsigned int usrlen) {
+  if (!msg) return -1;
 
   memset(msg, '\0', sizeof(*msg));
 
   msg->msgclass = mc;
 
-  switch (mc)
-    {
+  switch (mc) {
     case lmonp_fetofe:
-      msg->type.fetofe_type = (lmonp_fe_to_fe_msg_e) type;
+      msg->type.fetofe_type = (lmonp_fe_to_fe_msg_e)type;
       break;
 
     case lmonp_fetobe:
-      msg->type.fetobe_type = (lmonp_fe_to_be_msg_e) type;
+      msg->type.fetobe_type = (lmonp_fe_to_be_msg_e)type;
       break;
 
     case lmonp_fetomw:
-      msg->type.fetomw_type = (lmonp_fe_to_mw_msg_e) type;
+      msg->type.fetomw_type = (lmonp_fe_to_mw_msg_e)type;
       break;
 
     default:
       return -1;
-    }
+  }
 
   msg->sec_or_jobsizeinfo.security_key1 = seckey_or_numtasks;
 
   if (security_key2)
     msg->sec_or_stringinfo.security_key2 = security_key2;
-  else
-    {
-      msg->sec_or_stringinfo.exec_and_hn.num_exec_name = num_exec_name;
-      msg->sec_or_stringinfo.exec_and_hn.num_host_name = num_host_name;
-    }
+  else {
+    msg->sec_or_stringinfo.exec_and_hn.num_exec_name = num_exec_name;
+    msg->sec_or_stringinfo.exec_and_hn.num_host_name = num_host_name;
+  }
 
   msg->long_num_tasks = lntask;
   msg->lmon_payload_length = lmonlen;
@@ -698,135 +584,95 @@ set_msg_header (lmonp_t *msg,
   return 0;
 }
 
+char *get_lmonpayload_begin(lmonp_t *msg) {
+  char *ret = (char *)msg;
+  if (!msg) return NULL;
 
-char *
-get_lmonpayload_begin ( lmonp_t *msg )
-{
-  char* ret = (char *) msg;
-  if (!msg)
-    return NULL;
+  if (msg->lmon_payload_length <= 0) return NULL;
 
-  if ( msg->lmon_payload_length <= 0 )
-    return NULL;
-
-  ret += sizeof (*msg);
-
-  return ret; 
-}
-
-
-char *
-get_usrpayload_begin ( lmonp_t *msg )
-{
-  char *ret = (char *) msg;
-  if ( !msg )
-    return NULL;
-
-  if ( msg->usr_payload_length <= 0 ) 
-    return NULL;
-
-  ret = ret + sizeof (*msg) + msg->lmon_payload_length;
+  ret += sizeof(*msg);
 
   return ret;
 }
 
+char *get_usrpayload_begin(lmonp_t *msg) {
+  char *ret = (char *)msg;
+  if (!msg) return NULL;
 
-char *
-get_strtab_begin ( lmonp_t *msg )
-{
+  if (msg->usr_payload_length <= 0) return NULL;
+
+  ret = ret + sizeof(*msg) + msg->lmon_payload_length;
+
+  return ret;
+}
+
+char *get_strtab_begin(lmonp_t *msg) {
   char *ret = NULL;
-  switch (msg->msgclass)
-    {
-    case lmonp_fetofe:
-      {
-        if ( msg->type.fetofe_type == lmonp_proctable_avail )
-        ret = get_lmonpayload_begin ( msg );
-        if (ret)
-          {
-            if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-              {
-                ret += msg->sec_or_jobsizeinfo.num_tasks
-                       * sizeof(uint32_t) * N_Fields_MPIR_PROCDESC_EXT;
-              }
-            else
-              {
-                ret += msg->long_num_tasks
-                       * sizeof(uint32_t) * N_Fields_MPIR_PROCDESC_EXT;
-              }
-            }
-         break;
+  switch (msg->msgclass) {
+    case lmonp_fetofe: {
+      if (msg->type.fetofe_type == lmonp_proctable_avail)
+        ret = get_lmonpayload_begin(msg);
+      if (ret) {
+        if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+          ret += msg->sec_or_jobsizeinfo.num_tasks * sizeof(uint32_t) *
+                 N_Fields_MPIR_PROCDESC_EXT;
+        } else {
+          ret += msg->long_num_tasks * sizeof(uint32_t) *
+                 N_Fields_MPIR_PROCDESC_EXT;
+        }
       }
-    case lmonp_fetobe:
-      {
-        if ( msg->type.fetobe_type == lmonp_febe_proctab )
-          {
-            ret = get_lmonpayload_begin ( msg );
-            if (ret)
-             {
-               if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-                 {
-                   ret += msg->sec_or_jobsizeinfo.num_tasks
-                          * sizeof(uint32_t) * N_Fields_MPIR_PROCDESC_EXT;
-                 }
-               else
-                 {
-                   ret += msg->long_num_tasks*sizeof(uint32_t)
-                          * N_Fields_MPIR_PROCDESC_EXT;
-                 }
-              }
-           }
-         else if ( msg->type.fetobe_type == lmonp_befe_hostname )
-           {
-             ret = get_lmonpayload_begin ( msg );
-             if (ret)
-               {
-                 if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-                   {
-                     ret += msg->sec_or_jobsizeinfo.num_tasks*sizeof(uint32_t);
-                   }
-                 else
-                   {
-                     ret += msg->long_num_tasks*sizeof(uint32_t);
-                   }
-                }
-            }
-          break;
+      break;
+    }
+    case lmonp_fetobe: {
+      if (msg->type.fetobe_type == lmonp_febe_proctab) {
+        ret = get_lmonpayload_begin(msg);
+        if (ret) {
+          if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+            ret += msg->sec_or_jobsizeinfo.num_tasks * sizeof(uint32_t) *
+                   N_Fields_MPIR_PROCDESC_EXT;
+          } else {
+            ret += msg->long_num_tasks * sizeof(uint32_t) *
+                   N_Fields_MPIR_PROCDESC_EXT;
+          }
+        }
+      } else if (msg->type.fetobe_type == lmonp_befe_hostname) {
+        ret = get_lmonpayload_begin(msg);
+        if (ret) {
+          if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+            ret += msg->sec_or_jobsizeinfo.num_tasks * sizeof(uint32_t);
+          } else {
+            ret += msg->long_num_tasks * sizeof(uint32_t);
+          }
+        }
       }
-    case lmonp_fetomw:
-      {
-        if ( msg->type.fetomw_type == lmonp_mwfe_hostname )
-          {
-            ret = get_lmonpayload_begin ( msg );
-            if (ret)
-              {
-                if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-                  {
-                    ret += (msg->sec_or_jobsizeinfo.num_tasks*sizeof(uint32_t));
-                  }
-                else
-                  {
-                    ret += (msg->long_num_tasks*sizeof(uint32_t));
-                  }
-              }
-           }
-         break;
+      break;
+    }
+    case lmonp_fetomw: {
+      if (msg->type.fetomw_type == lmonp_mwfe_hostname) {
+        ret = get_lmonpayload_begin(msg);
+        if (ret) {
+          if (msg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE) {
+            ret += (msg->sec_or_jobsizeinfo.num_tasks * sizeof(uint32_t));
+          } else {
+            ret += (msg->long_num_tasks * sizeof(uint32_t));
+          }
+        }
       }
-
-    default:
       break;
     }
 
+    default:
+      break;
+  }
+
   return ret;
 }
-
 
 //
 // 0 on success
 // <0 on failure
 //
-int
-parse_raw_RPDTAB_msg (lmonp_t *proctabMsg, void *pMap)
-{
+int parse_raw_RPDTAB_msg(lmonp_t *proctabMsg, void *pMap) {
   using namespace std;
 
   char *mpirent;
@@ -837,60 +683,56 @@ parse_raw_RPDTAB_msg (lmonp_t *proctabMsg, void *pMap)
   //
   // This implementation assumes that pMap is C++ STD Map type
   //
-  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > *pTab
-    = (std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > *)pMap;
+  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > *pTab =
+      (std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > *)pMap;
 
-  if ( (*pTab).size() != 0 || proctabMsg == NULL)
-    return -1;
+  if ((*pTab).size() != 0 || proctabMsg == NULL) return -1;
 
-  mpirent = get_lmonpayload_begin ( proctabMsg );
-  if ( !mpirent )
-    return -2;
+  mpirent = get_lmonpayload_begin(proctabMsg);
+  if (!mpirent) return -2;
 
-  strtab  = get_strtab_begin ( proctabMsg );
-  if ( !strtab )
-    return -3;
+  strtab = get_strtab_begin(proctabMsg);
+  if (!strtab) return -3;
 
-    if (proctabMsg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
-        ntasks = proctabMsg->sec_or_jobsizeinfo.num_tasks;
-    else
-        ntasks = proctabMsg->long_num_tasks;
+  if (proctabMsg->sec_or_jobsizeinfo.num_tasks < LMON_NTASKS_THRE)
+    ntasks = proctabMsg->sec_or_jobsizeinfo.num_tasks;
+  else
+    ntasks = proctabMsg->long_num_tasks;
 
-  for ( i=0; i < ntasks; i++ )
-    {
-      unsigned int *hn_ix_ptr = (unsigned int *) mpirent;
-      unsigned int *exec_ix_ptr = (unsigned int *) (mpirent + sizeof (int));
-      int *pid_ptr = (int *) (mpirent + 2*sizeof(int));
-      int *rank_ptr = (int *) (mpirent + 3*sizeof(int));
-      int *cn_ptr = (int *) (mpirent + 4*sizeof(int));
-      mpirent += 5*sizeof (int);
+  for (i = 0; i < ntasks; i++) {
+    unsigned int *hn_ix_ptr = (unsigned int *)mpirent;
+    unsigned int *exec_ix_ptr = (unsigned int *)(mpirent + sizeof(int));
+    int *pid_ptr = (int *)(mpirent + 2 * sizeof(int));
+    int *rank_ptr = (int *)(mpirent + 3 * sizeof(int));
+    int *cn_ptr = (int *)(mpirent + 4 * sizeof(int));
+    mpirent += 5 * sizeof(int);
 
-      string hntmpstr( strtab + (*hn_ix_ptr) );
-      char *exeptr = ( strtab + (*exec_ix_ptr) );
+    string hntmpstr(strtab + (*hn_ix_ptr));
+    char *exeptr = (strtab + (*exec_ix_ptr));
 
-      MPIR_PROCDESC_EXT *anentry = (MPIR_PROCDESC_EXT *)
-	malloc (sizeof (MPIR_PROCDESC_EXT) );
+    MPIR_PROCDESC_EXT *anentry =
+        (MPIR_PROCDESC_EXT *)malloc(sizeof(MPIR_PROCDESC_EXT));
 
-      if ( anentry == NULL )
-        return -4;
+    if (anentry == NULL) return -4;
 
-      anentry->pd.executable_name = strdup ( exeptr );
-      anentry->pd.host_name = strdup ( hntmpstr.c_str () );
-      anentry->pd.pid = ( *pid_ptr );
-      anentry->mpirank = ( *rank_ptr );
-      anentry->cnodeid = ( *cn_ptr );
-	
-      if ( (*pTab).find (hntmpstr) == (*pTab).end() )
-	{
-	  vector<MPIR_PROCDESC_EXT *> avec;
-	  avec.push_back (anentry);
-	  (*pTab)[hntmpstr] = avec;
-	}
-      else
-	{
-	  (*pTab)[hntmpstr].push_back (anentry);
-	}
+    anentry->pd.executable_name = strdup(exeptr);
+    anentry->pd.host_name = strdup(hntmpstr.c_str());
+    anentry->pd.pid = (*pid_ptr);
+    anentry->mpirank = (*rank_ptr);
+    anentry->cnodeid = (*cn_ptr);
+
+    if ((*pTab).find(hntmpstr) == (*pTab).end()) {
+      vector<MPIR_PROCDESC_EXT *> avec;
+      avec.push_back(anentry);
+      (*pTab)[hntmpstr] = avec;
+    } else {
+      (*pTab)[hntmpstr].push_back(anentry);
     }
+  }
 
   return 0;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_mw.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_mw.cxx
@@ -1,32 +1,34 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
- *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support branch.
+ *        May 31 2012 DHA: Copied the file from the 0.8-middleware-support
+ *                         branch.
  *        Aug 02 2010 DHA: File created
  */
 
@@ -36,29 +38,28 @@
 #error This source file requires a LINUX OS
 #endif
 
-#include <cstdio>
-#include <cstdlib>
-#include <string.h>
-#include <iostream>
-#include <fstream>
+#include <arpa/inet.h>
 #include <signal.h>
-#include <map>
-#include <vector>
+#include <string.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <vector>
 
-#include "gcrypt.h"
 #include <assert.h>
 #include <limits.h>
+#include "gcrypt.h"
 
-#include "lmon_api/lmon_mw.h"
 #include "lmon_api/lmon_lmonp_msg.h"
+#include "lmon_api/lmon_mw.h"
 #include "lmon_api/lmon_say_msg.hxx"
 #include "lmon_daemon_internal.hxx"
 #include "sdbg_rsh_spawner.hxx"
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -68,7 +69,6 @@
 //
 static int servsockfd = LMON_INIT;
 static per_mw_data_t mwdata;
-
 
 //////////////////////////////////////////////////////////////////////////////////
 //
@@ -81,19 +81,13 @@ static per_mw_data_t mwdata;
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_amIMaster ()
-{
-  if ( mwdata.daemon_data.myrank < 0 )
-    return LMON_EINVAL;
+extern "C" lmon_rc_e LMON_mw_amIMaster() {
+  if (mwdata.daemon_data.myrank < 0) return LMON_EINVAL;
 
-  return (( mwdata.daemon_data.myrank == 0) ? LMON_YES : LMON_NO);
+  return ((mwdata.daemon_data.myrank == 0) ? LMON_YES : LMON_NO);
 }
 
-
-extern "C" lmon_rc_e
-LMON_mw_daemon_internal_init(int *argc, char ***argv)
-{
+extern "C" lmon_rc_e LMON_mw_daemon_internal_init(int *argc, char ***argv) {
   char **nargv = *argv;
   int n_lmonopt = 0;
   int i;
@@ -105,495 +99,406 @@ LMON_mw_daemon_internal_init(int *argc, char ***argv)
    * The following code assumes middleware options are specified after all other
    * options are given.
    */
-  for (i=1; i < (*argc); ++i) 
-    {
-      if ( (nargv[i][0] == '-') && (nargv[i][1]) ) 
-        {
-          if ( strncmp(nargv[i], LMON_RSHSPAWNER_OPT, strlen(LMON_RSHSPAWNER_OPT)) 
-               == 0 )
-            {
-               //
-               // TODO: Can't handle daemon options yet
-               //
-               mwdata.daemon_data.daemon_spawner
-                 = new spawner_rsh_t((*argv)[0], 
-                                 std::vector<std::string>(), 
-                                 nargv[i]+1+strlen(LMON_RSHSPAWNER_OPT));
-               n_lmonopt++;
-            }
+  for (i = 1; i < (*argc); ++i) {
+    if ((nargv[i][0] == '-') && (nargv[i][1])) {
+      if (strncmp(nargv[i], LMON_RSHSPAWNER_OPT, strlen(LMON_RSHSPAWNER_OPT)) ==
+          0) {
+        //
+        // TODO: Can't handle daemon options yet
+        //
+        mwdata.daemon_data.daemon_spawner =
+            new spawner_rsh_t((*argv)[0], std::vector<std::string>(),
+                              nargv[i] + 1 + strlen(LMON_RSHSPAWNER_OPT));
+        n_lmonopt++;
       }
-    } /* for */
+    }
+  } /* for */
 
   (*argc) -= n_lmonopt;
-  nargv[(*argc)+0] = NULL;
+  nargv[(*argc) + 0] = NULL;
   char tmpbuf[PATH_MAX];
-  for (i=1; i < (n_lmonopt+1); ++i )
-    {
-      sprintf(tmpbuf, "LMONNOOP%d=%d", i,i);
-       /* this region of memory might not be safe to be freed, so we just leak */
-       /* and nargv[(*argc_p)+n_pmgropt] must be null */
-      nargv[(*argc)+i] = strdup (tmpbuf);
-    }
+  for (i = 1; i < (n_lmonopt + 1); ++i) {
+    sprintf(tmpbuf, "LMONNOOP%d=%d", i, i);
+    /* this region of memory might not be safe to be freed, so we just leak */
+    /* and nargv[(*argc_p)+n_pmgropt] must be null */
+    nargv[(*argc) + i] = strdup(tmpbuf);
+  }
 
   return lrc;
-} 
-
+}
 
 //! lmon_rc_e LMON_mw_init
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_init(int ver, int *argc, char ***argv )
-{
+extern "C" lmon_rc_e LMON_mw_init(int ver, int *argc, char ***argv) {
   lmon_rc_e lrc;
   int is_be = 0;
 
 #if VERBOSE && USE_VERBOSE_LOGDIR
   char local_hostname[PATH_MAX];
-  gethostname (local_hostname, PATH_MAX);
-  if ( (lrc = LMON_daemon_enable_verbose(VERBOSE_LOGDIR, local_hostname, is_be))
-         != LMON_OK)
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON MW fails to enable verbosity %d", lrc );
-    }
+  gethostname(local_hostname, PATH_MAX);
+  if ((lrc = LMON_daemon_enable_verbose(VERBOSE_LOGDIR, local_hostname,
+                                        is_be)) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "LMON MW fails to enable verbosity %d", lrc);
+  }
 #elif RM_ALPS_APRUN
   //
   // Hack but without this the no-verbose build will hang under ALPS
   //
-  if ( freopen ("/dev/null", "w", stdout) == NULL )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON MW fails to reopen stdouts");
+  if (freopen("/dev/null", "w", stdout) == NULL) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON MW fails to reopen stdouts");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
-  if ( freopen ("/dev/null", "w", stderr) == NULL )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON MW fails to reopen stderr");
+  if (freopen("/dev/null", "w", stderr) == NULL) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON MW fails to reopen stderr");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 #endif
 
 #if VERBOSE
-   LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-     "MW daemon spawned");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MW daemon spawned");
 #endif
 
-  if ( ver != LMON_daemon_return_ver() ) 
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON MW API version mismatch" );
+  if (ver != LMON_daemon_return_ver()) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON MW API version mismatch");
 
-      return LMON_EINVAL;
-    }
+    return LMON_EINVAL;
+  }
 
   set_client_name(LMON_MW_MSG_PREFIX);
 
+  if ((lrc = LMON_daemon_gethostname(
+           is_bluegene_ion(), mwdata.daemon_data.my_hostname,
+           LMON_DAEMON_HN_MAX, mwdata.daemon_data.my_ip, LMON_DAEMON_HN_MAX,
+           mwdata.daemon_data.host_aliases)) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "LMON_daemon_gethostname failed: %d");
 
-  if ( (lrc = LMON_daemon_gethostname ( is_bluegene_ion(),
-                               mwdata.daemon_data.my_hostname,
-                               LMON_DAEMON_HN_MAX,
-                               mwdata.daemon_data.my_ip,
-                               LMON_DAEMON_HN_MAX,
-                               mwdata.daemon_data.host_aliases ) )
-           != LMON_OK )
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-        "LMON_daemon_gethostname failed: %d");
-
-      return lrc;
-    }
+    return lrc;
+  }
 
 #if VERBOSE
-   LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-     "LMON_daemon_gethostname returned %s", mwdata.daemon_data.my_hostname);
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "LMON_daemon_gethostname returned %s",
+               mwdata.daemon_data.my_hostname);
 #endif
 
-  if ( (lrc = LMON_mw_daemon_internal_init ( argc, argv )) 
-         != LMON_OK )
-    {
-       LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-         "LMON_mw_daemon_internal_init returned non LMON_OK");
+  if ((lrc = LMON_mw_daemon_internal_init(argc, argv)) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+                 "LMON_mw_daemon_internal_init returned non LMON_OK");
 
-       return lrc;
-    }
+    return lrc;
+  }
 
-  if (mwdata.daemon_data.daemon_spawner)
-    {
-      mwdata.daemon_data.daemon_spawner->spawn();
-    }
-
-#if VERBOSE 
-   LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-     "LMON_mw_daemon_internal_init and spawn finished ");
-#endif
-
-  if ( LMON_daemon_internal_init ( argc, argv, mwdata.daemon_data.my_hostname, is_be )
-         != LMON_OK )
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-        "LMON_daemon_internal_init failed");
-
-      return LMON_ESUBCOM;
-    }
+  if (mwdata.daemon_data.daemon_spawner) {
+    mwdata.daemon_data.daemon_spawner->spawn();
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-    "LMON_daemon_internal_init done");
-  int atest=0;
-  for (atest=0; atest < (*argc); atest++)
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-        "argv[%d]: %s", atest, (*argv)[atest]);
-    }
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "LMON_mw_daemon_internal_init and spawn finished ");
 #endif
 
-  if ( LMON_daemon_internal_getMyRank ( &(mwdata.daemon_data.myrank) ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON_daemon_getMyRank failed" );
+  if (LMON_daemon_internal_init(argc, argv, mwdata.daemon_data.my_hostname,
+                                is_be) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON_daemon_internal_init failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
-  if ( LMON_daemon_internal_getSize ( &(mwdata.daemon_data.width ) ) != LMON_OK )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "LMON_daemon_getMyRank failed" );
+#if VERBOSE
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "LMON_daemon_internal_init done");
+  int atest = 0;
+  for (atest = 0; atest < (*argc); atest++) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, false, "argv[%d]: %s", atest,
+                 (*argv)[atest]);
+  }
+#endif
 
-      return LMON_ESUBCOM;
-    }
+  if (LMON_daemon_internal_getMyRank(&(mwdata.daemon_data.myrank)) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON_daemon_getMyRank failed");
 
-#if VERBOSE 
-  LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-    "My rank is %d, My size is %d", mwdata.daemon_data.myrank, mwdata.daemon_data.width);
+    return LMON_ESUBCOM;
+  }
+
+  if (LMON_daemon_internal_getSize(&(mwdata.daemon_data.width)) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "LMON_daemon_getMyRank failed");
+
+    return LMON_ESUBCOM;
+  }
+
+#if VERBOSE
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "My rank is %d, My size is %d",
+               mwdata.daemon_data.myrank, mwdata.daemon_data.width);
 #endif
 
   BEGIN_MASTER_ONLY(mwdata)
-    //
-    //
-    // The middleware master initiates a handshake with FE
-    //
-    //
-    unsigned int i;
-    lmonp_t initmsg;
-    char shared_key[LMON_KEY_LENGTH];
-    unsigned char sessID[LMON_KEY_LENGTH];
-    unsigned char *sid_traverse;
-    int32_t intsessID;
-    gcry_cipher_hd_t cipher_hndl;
-    gcry_error_t gcrc;
-    bzero ( shared_key, LMON_KEY_LENGTH );
+  //
+  //
+  // The middleware master initiates a handshake with FE
+  //
+  //
+  unsigned int i;
+  lmonp_t initmsg;
+  char shared_key[LMON_KEY_LENGTH];
+  unsigned char sessID[LMON_KEY_LENGTH];
+  unsigned char *sid_traverse;
+  int32_t intsessID;
+  gcry_cipher_hd_t cipher_hndl;
+  gcry_error_t gcrc;
+  bzero(shared_key, LMON_KEY_LENGTH);
 
-    if ( LMON_daemon_internal_getConnFd (&servsockfd) != LMON_OK )
-      {
-        LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-          "LMON_daemon_internal_getConnFd failed ");
+  if (LMON_daemon_internal_getConnFd(&servsockfd) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "LMON_daemon_internal_getConnFd failed ");
 
-        return LMON_ESUBCOM;
-      }
-
-#if VERBOSE 
-          LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-             "The master MW deamon now has a connection to the FE");
-#endif
-
-    //
-    // getting shared key and session ID that will be used 
-    // to securely connect to the front-end
-    //
-    if ( (lrc = LMON_daemon_getSharedKeyAndID ( shared_key, &intsessID) )
-              != LMON_OK)
-      {
-        LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-          "LMON_daemon_getSharedKeyAndID failed ");
-
-        return LMON_ESYS;
-      }
+    return LMON_ESUBCOM;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: got a shared key: %s %d", shared_key, intsessID);
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "The master MW deamon now has a connection to the FE");
 #endif
 
-    if ( ( gcrc = gcry_cipher_open ( &cipher_hndl,
-                                     GCRY_CIPHER_BLOWFISH,
-                                     GCRY_CIPHER_MODE_ECB,
-                                     0 )) 
-                != GPG_ERR_NO_ERROR )
-      {
-        LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-          "gcry_cipher_open failed: %s", gcry_strerror (gcrc));
+  //
+  // getting shared key and session ID that will be used
+  // to securely connect to the front-end
+  //
+  if ((lrc = LMON_daemon_getSharedKeyAndID(shared_key, &intsessID)) !=
+      LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "LMON_daemon_getSharedKeyAndID failed ");
 
-        return LMON_ESYS;
-      }
+    return LMON_ESYS;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: GCRYPT open");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MW master: got a shared key: %s %d",
+               shared_key, intsessID);
 #endif
 
-    //
-    // setting a 128 bit key 
-    //
-    if ( ( gcrc = gcry_cipher_setkey ( cipher_hndl,
-                                       shared_key,
-                                       LMON_KEY_LENGTH )) 
-                != GPG_ERR_NO_ERROR )
-      {
-        LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-          "gcry_cipher_setkey failed: %s", gcry_strerror (gcrc));
+  if ((gcrc = gcry_cipher_open(&cipher_hndl, GCRY_CIPHER_BLOWFISH,
+                               GCRY_CIPHER_MODE_ECB, 0)) != GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "gcry_cipher_open failed: %s",
+                 gcry_strerror(gcrc));
 
-        return LMON_ESYS;
-      }
+    return LMON_ESYS;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: GCRYPT setkey, %x:%x:%x:%x",
-      *(int *) shared_key, *(int *)(shared_key+4),
-      *(int *)(shared_key+8), *(int *)(shared_key+12));
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MW master: GCRYPT open");
 #endif
 
-    bzero ((void *)sessID, LMON_KEY_LENGTH );
-    memcpy ((void *)sessID,
-            (void *)&intsessID, sizeof(intsessID));
+  //
+  // setting a 128 bit key
+  //
+  if ((gcrc = gcry_cipher_setkey(cipher_hndl, shared_key, LMON_KEY_LENGTH)) !=
+      GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "gcry_cipher_setkey failed: %s",
+                 gcry_strerror(gcrc));
+
+    return LMON_ESYS;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: GCRYPT before encrypt, %x:%x:%x:%x",
-      *(int *) sessID,
-      *(int *)(sessID+4), *(int *)(sessID+8), *(int *)(sessID+12));
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: GCRYPT setkey, %x:%x:%x:%x", *(int *)shared_key,
+               *(int *)(shared_key + 4), *(int *)(shared_key + 8),
+               *(int *)(shared_key + 12));
 #endif
 
-    if ( ( gcrc = gcry_cipher_encrypt ( cipher_hndl,
-                                        (unsigned char*) &sessID,
-                                        LMON_KEY_LENGTH,
-                                        NULL,
-                                        0)) 
-                != GPG_ERR_NO_ERROR )
-      {
-        LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-          "gcry_cipher_encrypt failed: %s", gcry_strerror (gcrc));
-
-        return LMON_ESYS;
-      }
+  bzero((void *)sessID, LMON_KEY_LENGTH);
+  memcpy((void *)sessID, (void *)&intsessID, sizeof(intsessID));
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: GCRYPT encrypt, %x:%x:%x:%x",
-      *(int *)sessID, *(int *)(sessID+4),
-      *(int *)(sessID+8), *(int *)(sessID+12));
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: GCRYPT before encrypt, %x:%x:%x:%x", *(int *)sessID,
+               *(int *)(sessID + 4), *(int *)(sessID + 8),
+               *(int *)(sessID + 12));
 #endif
 
-    sid_traverse = sessID;
+  if ((gcrc = gcry_cipher_encrypt(cipher_hndl, (unsigned char *)&sessID,
+                                  LMON_KEY_LENGTH, NULL, 0)) !=
+      GPG_ERR_NO_ERROR) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "gcry_cipher_encrypt failed: %s",
+                 gcry_strerror(gcrc));
 
-    for (i=0; i < LMON_KEY_LENGTH/sizeof(int32_t); i++)
-      {
-        uint32_t tmpSK;
-        memcpy ( (void *) &tmpSK, sid_traverse, sizeof(uint32_t));
-        set_msg_header ( &initmsg,
-                         lmonp_fetomw,
-                         lmonp_femw_security_chk,
-                         0,      /* security_key1 */
-                         tmpSK,  /* security_key2 */
-                         0,0,0,0,0 );
-        if ( ( write_lmonp_long_msg ( servsockfd,
-                                      &initmsg,
-                                      sizeof (initmsg) )) < 0 )
-          {
-            LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-              "write_lmonp_long_msg failed");
-
-            return LMON_ESYS;
-          }
-
-        sid_traverse += sizeof(uint32_t);
-      }
-
-    gcry_cipher_close ( cipher_hndl );
+    return LMON_ESYS;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: wrote back the security key");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: GCRYPT encrypt, %x:%x:%x:%x", *(int *)sessID,
+               *(int *)(sessID + 4), *(int *)(sessID + 8),
+               *(int *)(sessID + 12));
 #endif
 
-    //
-    // ** End of the MASTER ONLY SECTION **
-    //
-    //
-    //
+  sid_traverse = sessID;
+
+  for (i = 0; i < LMON_KEY_LENGTH / sizeof(int32_t); i++) {
+    uint32_t tmpSK;
+    memcpy((void *)&tmpSK, sid_traverse, sizeof(uint32_t));
+    set_msg_header(&initmsg, lmonp_fetomw, lmonp_femw_security_chk,
+                   0,     /* security_key1 */
+                   tmpSK, /* security_key2 */
+                   0, 0, 0, 0, 0);
+    if ((write_lmonp_long_msg(servsockfd, &initmsg, sizeof(initmsg))) < 0) {
+      LMON_say_msg(LMON_MW_MSG_PREFIX, true, "write_lmonp_long_msg failed");
+
+      return LMON_ESYS;
+    }
+
+    sid_traverse += sizeof(uint32_t);
+  }
+
+  gcry_cipher_close(cipher_hndl);
+
+#if VERBOSE
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: wrote back the security key");
+#endif
+
+  //
+  // ** End of the MASTER ONLY SECTION **
+  //
+  //
+  //
   END_MASTER_ONLY
 
   //
-  // Synch-point: the master just finished sending 
-  // "ack-back" to FE. Thus at this point every MW's 
+  // Synch-point: the master just finished sending
+  // "ack-back" to FE. Thus at this point every MW's
   // init should have completed.
   //
-  if ( LMON_mw_barrier() != LMON_OK )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "barrier failed" );
+  if (LMON_mw_barrier() != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "barrier failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MWs: exiting mw_init");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MWs: exiting mw_init");
 #endif
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_barrier
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_barrier()
-{
-  if ( LMON_daemon_internal_barrier () != LMON_OK )
-    return LMON_ESUBCOM;
+extern "C" lmon_rc_e LMON_mw_barrier() {
+  if (LMON_daemon_internal_barrier() != LMON_OK) return LMON_ESUBCOM;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_gather
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_gather( void *sendbuf, int numbyte_per_elem, void *recvbuf)
-{
-  if ( LMON_daemon_internal_gather ( sendbuf,
-         numbyte_per_elem, recvbuf ) != LMON_OK )
+extern "C" lmon_rc_e LMON_mw_gather(void *sendbuf, int numbyte_per_elem,
+                                    void *recvbuf) {
+  if (LMON_daemon_internal_gather(sendbuf, numbyte_per_elem, recvbuf) !=
+      LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_scatter
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_scatter(void *sendbuf, int numbyte_per_element, void *recvbuf)
-{
-  if ( LMON_daemon_internal_scatter ( sendbuf,
-         numbyte_per_element, recvbuf ) != LMON_OK )
+extern "C" lmon_rc_e LMON_mw_scatter(void *sendbuf, int numbyte_per_element,
+                                     void *recvbuf) {
+  if (LMON_daemon_internal_scatter(sendbuf, numbyte_per_element, recvbuf) !=
+      LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_broadcast
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_broadcast(void *buf, int numbyte)
-{
-  if ( LMON_daemon_internal_broadcast ( buf, numbyte ) != LMON_OK )
+extern "C" lmon_rc_e LMON_mw_broadcast(void *buf, int numbyte) {
+  if (LMON_daemon_internal_broadcast(buf, numbyte) != LMON_OK)
     return LMON_ESUBCOM;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_mw_getSize
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_getSize(int *size)
-{
-  if ( LMON_daemon_internal_getSize (size) != LMON_OK ) 
-    return LMON_EINVAL;
+extern "C" lmon_rc_e LMON_mw_getSize(int *size) {
+  if (LMON_daemon_internal_getSize(size) != LMON_OK) return LMON_EINVAL;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_getMyRank
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_getMyRank(int *rank)
-{
-  if ( LMON_daemon_internal_getMyRank (rank) != LMON_OK ) 
-    return LMON_EINVAL;
+extern "C" lmon_rc_e LMON_mw_getMyRank(int *rank) {
+  if (LMON_daemon_internal_getMyRank(rank) != LMON_OK) return LMON_EINVAL;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_regPackForMwToFe
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_regPackForMwToFe(
-                int (*packMwfe)
-                ( void *udata,void *msgbuf,int msgbufmax,int *msgbuflen ) )
-{
-  if ( mwdata.daemon_data.pack != NULL )
-  {
-    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-      "pack has already been registered or has not been initialized");
-    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-      "replacing the pack function...");
+extern "C" lmon_rc_e LMON_mw_regPackForMwToFe(
+    int (*packMwfe)(void *udata, void *msgbuf, int msgbufmax, int *msgbuflen)) {
+  if (mwdata.daemon_data.pack != NULL) {
+    LMON_say_msg(
+        LMON_MW_MSG_PREFIX, true,
+        "pack has already been registered or has not been initialized");
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "replacing the pack function...");
   }
 
   mwdata.daemon_data.pack = packMwfe;
 
-  return LMON_OK; 
+  return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_regUnpackForFeToMw
 /*!
 
 */
-extern "C" lmon_rc_e 
-LMON_mw_regUnpackForFeToMw(
-                int (*unpackFemw)
-                (void *udatabuf,int udatabuflen, void *udata))
-{
-  if ( mwdata.daemon_data.unpack != NULL )
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+extern "C" lmon_rc_e LMON_mw_regUnpackForFeToMw(
+    int (*unpackFemw)(void *udatabuf, int udatabuflen, void *udata)) {
+  if (mwdata.daemon_data.unpack != NULL) {
+    LMON_say_msg(
+        LMON_MW_MSG_PREFIX, true,
         "pack has already been registered or has not been initialized");
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-        "replacing the pack function...");
-    }
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "replacing the pack function...");
+  }
 
   mwdata.daemon_data.unpack = unpackFemw;
 
   return LMON_OK;
 }
 
-
 //! lmon_rc_e LMON_mw_handshake
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_handshake(void *udata)
-{
+extern "C" lmon_rc_e LMON_mw_handshake(void *udata) {
   using namespace std;
 
   //
-  // gathering hostnames and other tool specific data 
+  // gathering hostnames and other tool specific data
   // to piggyback to FE
   //
   int i;
@@ -601,476 +506,379 @@ LMON_mw_handshake(void *udata)
 
   BEGIN_MASTER_ONLY(mwdata)
 
-    hngatherbuf = (char *) malloc ( LMON_DAEMON_HN_MAX * mwdata.daemon_data.width );
-    if ( hngatherbuf == NULL )
-      {
-	LMON_say_msg(LMON_MW_MSG_PREFIX, true, 
-      	  "malloc returned zero");
+  hngatherbuf = (char *)malloc(LMON_DAEMON_HN_MAX * mwdata.daemon_data.width);
+  if (hngatherbuf == NULL) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "malloc returned zero");
 
-	return LMON_ENOMEM;
-      }
+    return LMON_ENOMEM;
+  }
 #if VERBOSE
-	LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-         "MW master: alloc buf of size %d x %d", 
-         LMON_DAEMON_HN_MAX, mwdata.daemon_data.width);
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: alloc buf of size %d x %d", LMON_DAEMON_HN_MAX,
+               mwdata.daemon_data.width);
 #endif
   END_MASTER_ONLY
 
   //
-  // once mw_gather is performed, hngatherbuf 
+  // once mw_gather is performed, hngatherbuf
   // should hold all the hostnames
   //
-  if ( LMON_mw_gather ( mwdata.daemon_data.my_hostname, LMON_DAEMON_HN_MAX, hngatherbuf ) != LMON_OK )
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true, 
-        "gather failed");
+  if (LMON_mw_gather(mwdata.daemon_data.my_hostname, LMON_DAEMON_HN_MAX,
+                     hngatherbuf) != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "gather failed");
 
-      return LMON_ESUBCOM;
-    }
+    return LMON_ESUBCOM;
+  }
 #if VERBOSE
-	LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-          "MWs: host names are gathered");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MWs: host names are gathered");
 #endif
 
   BEGIN_MASTER_ONLY(mwdata)
 
-    map<string, vector<unsigned int> > hostName;
+  map<string, vector<unsigned int> > hostName;
 
-    lmonp_t *sendbuf;
-    int sendbufsize;
-    unsigned int offset = 0;
-    char *hntrav = NULL;
-    hntrav = hngatherbuf; // hntrav will traverse the gathered hostnames
-    string tmpstr;
+  lmonp_t *sendbuf;
+  int sendbufsize;
+  unsigned int offset = 0;
+  char *hntrav = NULL;
+  hntrav = hngatherbuf;  // hntrav will traverse the gathered hostnames
+  string tmpstr;
 
-    for ( i=0; i < mwdata.daemon_data.width ; ++i )
-      {
-    	//
-    	// the first pass to compute the size of the string table
-    	//
-    	tmpstr = hntrav;
-    	if ( hostName.find (tmpstr) == hostName.end ())
-	  {
-    	    hostName[tmpstr].push_back(offset);
-            hostName[tmpstr].push_back(0);
-    	    offset += (strlen (hntrav) + 1 );
-	  }
-    	 hntrav += LMON_DAEMON_HN_MAX;
-       }
-
+  for (i = 0; i < mwdata.daemon_data.width; ++i) {
     //
-    // sendbuf alloc and message header work
+    // the first pass to compute the size of the string table
     //
-    sendbufsize = sizeof (lmonp_t)
-                + mwdata.daemon_data.width * sizeof(int)
-                + offset;
-    sendbuf = (lmonp_t *) malloc ( sendbufsize );
+    tmpstr = hntrav;
+    if (hostName.find(tmpstr) == hostName.end()) {
+      hostName[tmpstr].push_back(offset);
+      hostName[tmpstr].push_back(0);
+      offset += (strlen(hntrav) + 1);
+    }
+    hntrav += LMON_DAEMON_HN_MAX;
+  }
 
-    if (mwdata.daemon_data.width < LMON_NTASKS_THRE)
-      {
-        set_msg_header (
-                sendbuf,
-                lmonp_fetomw,
-                (int) lmonp_mwfe_hostname,
-                (unsigned short) mwdata.daemon_data.width,
-                0,
-                0,
-                mwdata.daemon_data.width,
-                0,
-                offset+mwdata.daemon_data.width*sizeof(int),
-                0 );
-      }
-    else
-      {
-        set_msg_header (
-                sendbuf,
-                lmonp_fetomw,
-                (int) lmonp_mwfe_hostname,
-                LMON_NTASKS_THRE,
-                0,
-                0,
-                mwdata.daemon_data.width,
-                mwdata.daemon_data.width,
-                offset+mwdata.daemon_data.width*sizeof(int),
-                0 );
-      }
+  //
+  // sendbuf alloc and message header work
+  //
+  sendbufsize =
+      sizeof(lmonp_t) + mwdata.daemon_data.width * sizeof(int) + offset;
+  sendbuf = (lmonp_t *)malloc(sendbufsize);
+
+  if (mwdata.daemon_data.width < LMON_NTASKS_THRE) {
+    set_msg_header(sendbuf, lmonp_fetomw, (int)lmonp_mwfe_hostname,
+                   (unsigned short)mwdata.daemon_data.width, 0, 0,
+                   mwdata.daemon_data.width, 0,
+                   offset + mwdata.daemon_data.width * sizeof(int), 0);
+  } else {
+    set_msg_header(sendbuf, lmonp_fetomw, (int)lmonp_mwfe_hostname,
+                   LMON_NTASKS_THRE, 0, 0, mwdata.daemon_data.width,
+                   mwdata.daemon_data.width,
+                   offset + mwdata.daemon_data.width * sizeof(int), 0);
+  }
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: set a msg header of lmonp_bemw_hostname type");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: set a msg header of lmonp_bemw_hostname type");
 #endif
 
-    //
-    // packing hostname indices and string table into the message
-    //
-    char *packptr   = get_lmonpayload_begin (sendbuf);
-    char *strtabptr = get_strtab_begin (sendbuf);
-    if ( packptr == NULL || strtabptr == NULL )
-      {
-	LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-	  "cannot pack hostname index and string into a message" );
-	return LMON_EBDMSG;
-      }
-    hntrav = hngatherbuf;
-    for ( i=0; i < mwdata.daemon_data.width; ++i )
-      {
-        tmpstr = hntrav;
-        memcpy ((void*) packptr,
-                (void*) &(hostName[tmpstr][0]),
-                sizeof (unsigned int));
-        packptr += sizeof (unsigned int);
+  //
+  // packing hostname indices and string table into the message
+  //
+  char *packptr = get_lmonpayload_begin(sendbuf);
+  char *strtabptr = get_strtab_begin(sendbuf);
+  if (packptr == NULL || strtabptr == NULL) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "cannot pack hostname index and string into a message");
+    return LMON_EBDMSG;
+  }
+  hntrav = hngatherbuf;
+  for (i = 0; i < mwdata.daemon_data.width; ++i) {
+    tmpstr = hntrav;
+    memcpy((void *)packptr, (void *)&(hostName[tmpstr][0]),
+           sizeof(unsigned int));
+    packptr += sizeof(unsigned int);
 
-        if (hostName[tmpstr][1] == 0)
-          {
-            memcpy ((void*) strtabptr,
-                    (void*) hntrav,
-                    (strlen(hntrav) + 1));
+    if (hostName[tmpstr][1] == 0) {
+      memcpy((void *)strtabptr, (void *)hntrav, (strlen(hntrav) + 1));
 
-            strtabptr += ( strlen (hntrav) + 1 );
-            hostName[tmpstr][1] = 1;
-          }
-        hntrav += LMON_DAEMON_HN_MAX;
-      }
-    free ( hngatherbuf );
+      strtabptr += (strlen(hntrav) + 1);
+      hostName[tmpstr][1] = 1;
+    }
+    hntrav += LMON_DAEMON_HN_MAX;
+  }
+  free(hngatherbuf);
 
-    //assert((strtabptr - (char *) sendbuf) == sendbufsize);
+// assert((strtabptr - (char *) sendbuf) == sendbufsize);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: about to write the hosts list to the FE");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: about to write the hosts list to the FE");
 #endif
 
-    //
-    // shipping it out and free the message buffer
-    //
-    write_lmonp_long_msg (servsockfd, sendbuf, sendbufsize );
+  //
+  // shipping it out and free the message buffer
+  //
+  write_lmonp_long_msg(servsockfd, sendbuf, sendbufsize);
 
-    free (sendbuf);
+  free(sendbuf);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: the hosts list written to the FE");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MW master: the hosts list written to the FE");
 #endif
 
+  //
+  // receiving the USRDATA stream from the front-end
+  //
+  lmonp_t recvmsg;
+  unsigned int bytesread;
+  read_lmonp_msgheader(servsockfd, &recvmsg);
+  if (recvmsg.type.fetomw_type != lmonp_femw_usrdata) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "Wrong msg type: expected a febe user data");
+    return LMON_EBDMSG;
+  }
+  int usrpayloadlen = recvmsg.usr_payload_length;
+  if (usrpayloadlen > 0) {
+    char *usrpl = (char *)malloc(recvmsg.usr_payload_length);
+    bytesread =
+        read_lmonp_payloads(servsockfd, usrpl, recvmsg.usr_payload_length);
     //
-    // receiving the USRDATA stream from the front-end
+    // with the following unpack func, udata comes to have
+    // deserialized usr data
     //
-    lmonp_t recvmsg;
-    unsigned int bytesread;
-    read_lmonp_msgheader ( servsockfd, &recvmsg );
-    if ( recvmsg.type.fetomw_type != lmonp_femw_usrdata )
-      {
-        LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-          "Wrong msg type: expected a febe user data"); 
-        return LMON_EBDMSG; 
-      }
-    int usrpayloadlen = recvmsg.usr_payload_length;
-    if ( usrpayloadlen > 0 )
-      {
-    	char *usrpl = (char *) malloc ( recvmsg.usr_payload_length );
-    	bytesread = read_lmonp_payloads (
-    			servsockfd,
-    			usrpl,
-    			recvmsg.usr_payload_length );
-    	//
-    	// with the following unpack func, udata comes to have
-    	// deserialized usr data
-    	//
-    	mwdata.daemon_data.unpack ( usrpl, recvmsg.usr_payload_length, udata );
+    mwdata.daemon_data.unpack(usrpl, recvmsg.usr_payload_length, udata);
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-      "MW master: received USRDATA"); 
+    LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MW master: received USRDATA");
 #endif
-      }
+  }
 
   END_MASTER_ONLY
 
   //
   // synch-point
   //
-  if ( LMON_mw_barrier () != LMON_OK )
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-        "Barrier failed");
-      return LMON_ESUBCOM;
-    }
+  if (LMON_mw_barrier() != LMON_OK) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "Barrier failed");
+    return LMON_ESUBCOM;
+  }
 
 #if VERBOSE
-  LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-    "MWs: returning from LMON_mw_handshake"); 
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false,
+               "MWs: returning from LMON_mw_handshake");
 #endif
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_ready
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_ready(void *udata)
-{
+extern "C" lmon_rc_e LMON_mw_ready(void *udata) {
   BEGIN_MASTER_ONLY(mwdata)
-    lmonp_t *readymsg;
+  lmonp_t *readymsg;
 
-    if ( (udata != NULL) && (mwdata.daemon_data.pack != NULL) )
-      {
-    	char *uoffset;
-        int upl_leng;
+  if ((udata != NULL) && (mwdata.daemon_data.pack != NULL)) {
+    char *uoffset;
+    int upl_leng;
 
-    	readymsg = (lmonp_t *) malloc (sizeof (lmonp_t)+LMON_MAX_USRPAYLOAD );
+    readymsg = (lmonp_t *)malloc(sizeof(lmonp_t) + LMON_MAX_USRPAYLOAD);
 
-        set_msg_header (
-                    readymsg,
-                    lmonp_fetomw,
-                    (int) lmonp_mwfe_ready,
-                    0,0,0,0,0,0,
-                    LMON_MAX_USRPAYLOAD);
+    set_msg_header(readymsg, lmonp_fetomw, (int)lmonp_mwfe_ready, 0, 0, 0, 0, 0,
+                   0, LMON_MAX_USRPAYLOAD);
 
-    	uoffset = get_usrpayload_begin ( readymsg );
+    uoffset = get_usrpayload_begin(readymsg);
 
-    	mwdata.daemon_data.pack ( udata,
-    		      uoffset,
-    		      LMON_MAX_USRPAYLOAD,
-    		      &upl_leng );
-    	//assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
-        readymsg->usr_payload_length = upl_leng;
-      }
-    else
-      {
-    	readymsg = (lmonp_t *) malloc ( sizeof (lmonp_t));
-    	readymsg->usr_payload_length = 0;
-      }
+    mwdata.daemon_data.pack(udata, uoffset, LMON_MAX_USRPAYLOAD, &upl_leng);
+    // assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
+    readymsg->usr_payload_length = upl_leng;
+  } else {
+    readymsg = (lmonp_t *)malloc(sizeof(lmonp_t));
+    readymsg->usr_payload_length = 0;
+  }
 
-    readymsg->msgclass = lmonp_fetomw;
-    readymsg->type.fetomw_type = lmonp_mwfe_ready;
-    readymsg->sec_or_jobsizeinfo.security_key1 = 0;
-    readymsg->sec_or_stringinfo.security_key2 = 0;
-    readymsg->lmon_payload_length = 0;
-    write_lmonp_long_msg (servsockfd,
-               readymsg,
-               (sizeof (lmonp_t)
-               +readymsg->lmon_payload_length  
-               +readymsg->usr_payload_length));
+  readymsg->msgclass = lmonp_fetomw;
+  readymsg->type.fetomw_type = lmonp_mwfe_ready;
+  readymsg->sec_or_jobsizeinfo.security_key1 = 0;
+  readymsg->sec_or_stringinfo.security_key2 = 0;
+  readymsg->lmon_payload_length = 0;
+  write_lmonp_long_msg(servsockfd, readymsg,
+                       (sizeof(lmonp_t) + readymsg->lmon_payload_length +
+                        readymsg->usr_payload_length));
 
 #if VERBOSE
-    LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-        "mw ready msg has been sent");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "mw ready msg has been sent");
 #endif
 
   END_MASTER_ONLY
 
-  if ( LMON_mw_barrier() != LMON_OK )
-    return LMON_ESUBCOM;
+  if (LMON_mw_barrier() != LMON_OK) return LMON_ESUBCOM;
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_finalize
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_finalize()
-{
+extern "C" lmon_rc_e LMON_mw_finalize() {
   int is_be = 0;
-  if ( LMON_daemon_internal_finalize (is_be) != LMON_OK )
-    return LMON_ESUBCOM;
+  if (LMON_daemon_internal_finalize(is_be) != LMON_OK) return LMON_ESUBCOM;
 
 #if VERBOSE
-   LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-     "MW daemon finalized");
+  LMON_say_msg(LMON_MW_MSG_PREFIX, false, "MW daemon finalized");
 #endif
 
-  if (mwdata.daemon_data.daemon_spawner)
-    {
-      delete mwdata.daemon_data.daemon_spawner;
-    }
+  if (mwdata.daemon_data.daemon_spawner) {
+    delete mwdata.daemon_data.daemon_spawner;
+  }
 
   return LMON_OK;
 }
-
 
 //! lmon_rc_e LMON_mw_recvUsrData
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_recvUsrData(void *udata)
-{
+extern "C" lmon_rc_e LMON_mw_recvUsrData(void *udata) {
   lmonp_t recvmsg;
   unsigned int bytesread;
   lmon_rc_e lrc = LMON_OK;
 
   BEGIN_MASTER_ONLY(mwdata)
+  //
+  // receiving the USRDATA stream from the frontend
+  //
+  if (read_lmonp_msgheader(servsockfd, &recvmsg) < 0) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "read_lmonp return a neg value");
+
+    lrc = LMON_ESYS;
+    goto something_bad;
+  }
+
+  if (recvmsg.type.fetomw_type != lmonp_femw_usrdata) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                 "the received message doesn't match with the expected type");
+
+    lrc = LMON_EBDMSG;
+    goto something_bad;
+  }
+
+  int usrpayloadlen = recvmsg.usr_payload_length;
+  if (usrpayloadlen > 0) {
+    char *usrpl = (char *)malloc(recvmsg.usr_payload_length);
+    if (usrpl == NULL) {
+      LMON_say_msg(LMON_MW_MSG_PREFIX, true, "Out of memory");
+
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
+
+    bytesread =
+        read_lmonp_payloads(servsockfd, usrpl, recvmsg.usr_payload_length);
     //
-    // receiving the USRDATA stream from the frontend
+    // with the following unpack func, udata comes to have
+    // deserialized usr data
     //
-    if ( read_lmonp_msgheader ( servsockfd, &recvmsg ) < 0 )
-      {
-	LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-	  "read_lmonp return a neg value");
+    if (mwdata.daemon_data.unpack) {
+      if (mwdata.daemon_data.unpack(usrpl, recvmsg.usr_payload_length, udata) <
+          0) {
+        LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                     "a negative return code from mwdata.daemon_data.unpack.");
 
-	lrc = LMON_ESYS;
-        goto something_bad;
+        lrc = LMON_ENEGCB;
       }
+    } else {
+      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
+                   "mwdata.daemon_data.unpack has not been registered!  ");
 
-    if ( recvmsg.type.fetomw_type != lmonp_femw_usrdata )
-      {
-	LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-          "the received message doesn't match with the expected type");
-
-	lrc = LMON_EBDMSG;
-        goto something_bad; 
-      }
-
-    int usrpayloadlen = recvmsg.usr_payload_length;
-    if ( usrpayloadlen > 0 )
-      {
-    	char *usrpl = (char *) malloc ( recvmsg.usr_payload_length );
-	if ( usrpl == NULL)
-	  {
-	    LMON_say_msg(LMON_MW_MSG_PREFIX, true, 
-	      "Out of memory");
-
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-
-    	bytesread = read_lmonp_payloads (
-    			servsockfd,
-    			usrpl,
-    			recvmsg.usr_payload_length );
-    	//
-    	// with the following unpack func, udata comes to have
-    	// deserialized usr data
-    	//
-	if ( mwdata.daemon_data.unpack )
-	  {
-	    if (mwdata.daemon_data.unpack ( usrpl, recvmsg.usr_payload_length, udata ) < 0)
-              {
-	        LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-                "a negative return code from mwdata.daemon_data.unpack.");
-
-                lrc = LMON_ENEGCB;
-              }
-          }
-	else
-	  {
-	    LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-	      "mwdata.daemon_data.unpack has not been registered!  ");
-
-	    lrc = LMON_ENCLLB;
-	  }
-	free (usrpl);
-      }
-    else
-      {
-	lrc = LMON_ENOPLD;
-      }
+      lrc = LMON_ENCLLB;
+    }
+    free(usrpl);
+  } else {
+    lrc = LMON_ENOPLD;
+  }
 
   END_MASTER_ONLY
-
 
 something_bad:
   //
   // duplicating the return code
   //
-  if ( LMON_mw_broadcast ( &lrc, sizeof(lrc) != LMON_OK ))
-    {
-      LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-        "Broadcast failed");
+  if (LMON_mw_broadcast(&lrc, sizeof(lrc) != LMON_OK)) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "Broadcast failed");
 
-      lrc = LMON_ESUBCOM;
-    }
+    lrc = LMON_ESUBCOM;
+  }
 
-    return lrc;
+  return lrc;
 }
-
 
 //! lmon_rc_e LMON_mw_sendUsrData
 /*!
 
 */
-extern "C" lmon_rc_e
-LMON_mw_sendUsrData(void *udata)
-{
+extern "C" lmon_rc_e LMON_mw_sendUsrData(void *udata) {
   lmon_rc_e lrc = LMON_OK;
 
   BEGIN_MASTER_ONLY(mwdata)
 
-    lmonp_t *usrmsg;
+  lmonp_t *usrmsg;
 
-    if ( (udata != NULL) && (mwdata.daemon_data.pack != NULL) )
-      {
-    	char *uoffset;
-        int upl_leng;
-    	usrmsg = (lmonp_t *) malloc (sizeof (lmonp_t)+LMON_MAX_USRPAYLOAD );
-	if ( usrmsg == NULL )
-	  {
-	    LMON_say_msg(LMON_MW_MSG_PREFIX, true, 
- 	      "Out of memory");
+  if ((udata != NULL) && (mwdata.daemon_data.pack != NULL)) {
+    char *uoffset;
+    int upl_leng;
+    usrmsg = (lmonp_t *)malloc(sizeof(lmonp_t) + LMON_MAX_USRPAYLOAD);
+    if (usrmsg == NULL) {
+      LMON_say_msg(LMON_MW_MSG_PREFIX, true, "Out of memory");
 
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-	
-        set_msg_header (
-                    usrmsg,
-                    lmonp_fetomw,
-                    (int) lmonp_mwfe_usrdata,
-                    0,0,0,0,0,0,
-                    LMON_MAX_USRPAYLOAD);
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
 
-    	uoffset = get_usrpayload_begin ( usrmsg );
-        if ( mwdata.daemon_data.pack ( udata, uoffset, LMON_MAX_USRPAYLOAD, &upl_leng ) < 0 )
-          {
-	    lrc = LMON_ENEGCB;
-	    goto something_bad;
-          }
+    set_msg_header(usrmsg, lmonp_fetomw, (int)lmonp_mwfe_usrdata, 0, 0, 0, 0, 0,
+                   0, LMON_MAX_USRPAYLOAD);
 
-    	//assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
-        usrmsg->usr_payload_length = upl_leng;
-      }
-    else
-      {
-    	usrmsg = (lmonp_t *) malloc ( sizeof (lmonp_t));
-	if ( usrmsg == NULL )
-	  {
-	    LMON_say_msg(LMON_MW_MSG_PREFIX, true, 
-	      "Out of memory");
+    uoffset = get_usrpayload_begin(usrmsg);
+    if (mwdata.daemon_data.pack(udata, uoffset, LMON_MAX_USRPAYLOAD,
+                                &upl_leng) < 0) {
+      lrc = LMON_ENEGCB;
+      goto something_bad;
+    }
 
-	    lrc = LMON_ENOMEM;
-            goto something_bad;
-	  }
-    	usrmsg->usr_payload_length = 0;
-	lrc = LMON_ENCLLB;
-      }
+    // assert ( upl_leng <= LMON_MAX_USRPAYLOAD );
+    usrmsg->usr_payload_length = upl_leng;
+  } else {
+    usrmsg = (lmonp_t *)malloc(sizeof(lmonp_t));
+    if (usrmsg == NULL) {
+      LMON_say_msg(LMON_MW_MSG_PREFIX, true, "Out of memory");
 
-    usrmsg->msgclass = lmonp_fetomw;
-    usrmsg->type.fetomw_type = lmonp_mwfe_usrdata;
-    usrmsg->sec_or_jobsizeinfo.security_key1 = 0;
-    usrmsg->sec_or_stringinfo.security_key2 = 0;
-    usrmsg->lmon_payload_length = 0;
-    if ( (write_lmonp_long_msg (servsockfd,
-            usrmsg,
-            sizeof (lmonp_t) + usrmsg->usr_payload_length ))
-	  < 0 )
-      {
-	LMON_say_msg(LMON_MW_MSG_PREFIX, true,
-          "write_lmonp returned a neg value");
+      lrc = LMON_ENOMEM;
+      goto something_bad;
+    }
+    usrmsg->usr_payload_length = 0;
+    lrc = LMON_ENCLLB;
+  }
 
-	lrc = LMON_ESYS;
-        goto something_bad;
-      }
-    free (usrmsg);
+  usrmsg->msgclass = lmonp_fetomw;
+  usrmsg->type.fetomw_type = lmonp_mwfe_usrdata;
+  usrmsg->sec_or_jobsizeinfo.security_key1 = 0;
+  usrmsg->sec_or_stringinfo.security_key2 = 0;
+  usrmsg->lmon_payload_length = 0;
+  if ((write_lmonp_long_msg(servsockfd, usrmsg,
+                            sizeof(lmonp_t) + usrmsg->usr_payload_length)) <
+      0) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "write_lmonp returned a neg value");
+
+    lrc = LMON_ESYS;
+    goto something_bad;
+  }
+  free(usrmsg);
 
 #if VERBOSE
-    LMON_say_msg(LMON_BE_MSG_PREFIX, false,
-        "Master MW daemon sent a user data");
+  LMON_say_msg(LMON_BE_MSG_PREFIX, false, "Master MW daemon sent a user data");
 #endif
 
   END_MASTER_ONLY
@@ -1079,17 +887,15 @@ something_bad:
   //
   // duplicating the return code
   //
-  if ( LMON_mw_broadcast ( &lrc, sizeof(lrc) != LMON_OK ))
-    {
-      LMON_say_msg(LMON_BE_MSG_PREFIX, true,
-        "Broadcast failed on LMON_mw_sendUsrData");
+  if (LMON_mw_broadcast(&lrc, sizeof(lrc) != LMON_OK)) {
+    LMON_say_msg(LMON_BE_MSG_PREFIX, true,
+                 "Broadcast failed on LMON_mw_sendUsrData");
 
-      lrc = LMON_ESUBCOM;
-    }
+    lrc = LMON_ESUBCOM;
+  }
 
   return lrc;
 }
-
 
 //! lmon_rc_e LMON_mw_regErrorCB
 /*!
@@ -1097,25 +903,25 @@ something_bad:
     invoked whenever an error message should
     go out.
 */
-extern "C"
-lmon_rc_e
-LMON_mw_regErrorCB (int (*func) (const char *format, va_list ap))
-{
-  if ( func == NULL)
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, true,
-        "an argument is invalid" );
+extern "C" lmon_rc_e LMON_mw_regErrorCB(int (*func)(const char *format,
+                                                    va_list ap)) {
+  if (func == NULL) {
+    LMON_say_msg(LMON_MW_MSG_PREFIX, true, "an argument is invalid");
 
-      return LMON_EBDARG;
-    }
+    return LMON_EBDARG;
+  }
 
-  if ( errorCB !=  NULL )
-    {
-      LMON_say_msg ( LMON_MW_MSG_PREFIX, false,
-        "previously registered error callback func will be invalidated" );
-    }
+  if (errorCB != NULL) {
+    LMON_say_msg(
+        LMON_MW_MSG_PREFIX, false,
+        "previously registered error callback func will be invalidated");
+  }
 
   errorCB = func;
 
   return LMON_OK;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/lmon_api/lmon_say_msg.cxx
+++ b/launchmon/src/linux/lmon_api/lmon_say_msg.cxx
@@ -1,35 +1,36 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/lmon_api/lmon_say_msg.cxx,v 1.5.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jun  11 1010 DHA: Remove pipe_t
- *        Dec  23 2009 DHA: Added explict config.h inclusion 
+ *        Dec  23 2009 DHA: Added explict config.h inclusion
  *        Feb  09 2008 DHA: Added LLNS Copyright
- *        Dec  29 2006 DHA: Created file.          
+ *        Dec  29 2006 DHA: Created file.
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -42,107 +43,95 @@
 #error This source file requires a LINUX OS
 #endif
 
-#include <iostream>
-#include <cstdarg>
-#include <unistd.h>
-#include <ctime>
-#include <sys/time.h>
 #include <limits.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <cstdarg>
+#include <ctime>
+#include <iostream>
 #include <lmon_api/lmon_say_msg.hxx>
 
-int (*errorCB) (const char *format, va_list ap) = NULL;
+int (*errorCB)(const char *format, va_list ap) = NULL;
 
-double gettimeofdayD ()
-{
+double gettimeofdayD() {
   struct timeval ts;
   double rt;
 
-  gettimeofday (&ts, NULL);
-  rt = (double) (ts.tv_sec);
-  rt += (double) ((double)(ts.tv_usec))/1000000.0;
+  gettimeofday(&ts, NULL);
+  rt = (double)(ts.tv_sec);
+  rt += (double)((double)(ts.tv_usec)) / 1000000.0;
 
   return rt;
 }
 
-int
-LMON_timestamp ( const char *m, const char *ei, const char *fstr, char *obuf, uint32_t len)
-{
+int LMON_timestamp(const char *m, const char *ei, const char *fstr, char *obuf,
+                   uint32_t len) {
   char timelog[PATH_MAX];
   const char *format = "%b %d %T";
   time_t t;
 
   time(&t);
-  strftime (timelog, PATH_MAX, format, localtime(&t));
+  strftime(timelog, PATH_MAX, format, localtime(&t));
   return (snprintf(obuf, len, "<%s> %s (%s): %s\n", timelog, m, ei, fstr));
-
 }
 
-void 
-LMON_say_msg ( const char *m, bool error_or_info, const char *output, ... )
-{
+void LMON_say_msg(const char *m, bool error_or_info, const char *output, ...) {
   va_list ap;
   char log[PATH_MAX];
   const char *ei_str = error_or_info ? "ERROR" : "INFO";
- 
-  if (LMON_timestamp(m, ei_str, output, log, PATH_MAX) >= 0)
-    {
-      va_start(ap, output);
-      if (errorCB)
-        {
-          errorCB (log, ap);
-        }
-      else
-        {
-          vfprintf(stdout, log, ap);
-          fflush(stdout);	
-        }
-      va_end(ap);
+
+  if (LMON_timestamp(m, ei_str, output, log, PATH_MAX) >= 0) {
+    va_start(ap, output);
+    if (errorCB) {
+      errorCB(log, ap);
+    } else {
+      vfprintf(stdout, log, ap);
+      fflush(stdout);
     }
+    va_end(ap);
+  }
 }
 
-void
-LMON_TotalView_debug ()
-{
+void LMON_TotalView_debug() {
   char cmd[128];
   char exen[128];
   char lk[128];
-  int len;  
+  int len;
   sprintf(cmd, "%d", getpid());
   sprintf(exen, "/proc/%d/exe", getpid());
-  len = readlink (exen, lk, 128);
-  if (len >= 0 )
-    lk[len]='\0';
-  	
-  if (!fork())
-    {
-      std::cout << "FE DEBUG SUPPORT: invoking totalview" << std::endl;
-      execlp ("totalview", "totalview", "-pid", cmd, lk, (char*) 0 );
-    }
+  len = readlink(exen, lk, 128);
+  if (len >= 0) lk[len] = '\0';
+
+  if (!fork()) {
+    std::cout << "FE DEBUG SUPPORT: invoking totalview" << std::endl;
+    execlp("totalview", "totalview", "-pid", cmd, lk, (char *)0);
+  }
   int stuck = 0;
 
   // DEBUGGING SUPPORT
-  // change the value of "stuck" to be 1 to break out of 
+  // change the value of "stuck" to be 1 to break out of
   // this loop.
-  // 	
-  while (!stuck);
+  //
+  while (!stuck)
+    ;
 }
 
-int
-LMON_get_execpath( int pid, std::string &opath )
-{
+int LMON_get_execpath(int pid, std::string &opath) {
   char path[PATH_MAX];
   char tar[PATH_MAX];
   int cnt;
 
-  sprintf(path, "/proc/%d/exe", pid);   
+  sprintf(path, "/proc/%d/exe", pid);
   cnt = readlink(path, tar, PATH_MAX);
-  if ( cnt >= 0 )
-    {
-      tar[cnt] = '\0';
-      cnt++;
-      opath = tar;
-    }
+  if (cnt >= 0) {
+    tar[cnt] = '\0';
+    cnt++;
+    opath = tar;
+  }
 
   return cnt;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/main.cxx
+++ b/launchmon/src/linux/main.cxx
@@ -1,34 +1,35 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/main.cxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May  02 2018 KMD: Added aarch64 support
  *        Nov  08 2010 DHA: Added a lexical scope around the driver object
- *                          to support memory tools 
+ *                          to support memory tools
  *        Aug  10 2008 DHA: Now returns EXIT_FAILURE
  *        Mar  11 2008 DHA: Added Linux PPC support
  *        Feb  09 2008 DHA: Added LLNS Copyright
@@ -39,56 +40,43 @@
 #include "sdbg_std.hxx"
 
 #ifndef LINUX_CODE_REQUIRED
-# error This source file requires a LINUX OS
+#error This source file requires a LINUX OS
 #endif
 
 #include "sdbg_base_launchmon.hxx"
 #include "sdbg_base_launchmon_impl.hxx"
 
-#include "linux/sdbg_linux_mach.hxx"
 #include "linux/sdbg_linux_driver.hxx"
 #include "linux/sdbg_linux_driver_impl.hxx"
+#include "linux/sdbg_linux_mach.hxx"
 
-
-int main(int argc, char* argv[])
-{
-  try 
-  {
+int main(int argc, char* argv[]) {
+  try {
     int rc = EXIT_FAILURE;
-      {
-#if X86_ARCHITECTURE || X86_64_ARCHITECTURE || PPC_ARCHITECTURE || AARCH64_ARCHITECTURE
-        //
-        // driver instantiation for the linux platform.
-        //
-        //
-        linux_driver_t<T_VA,T_WT,T_IT,T_GRS,T_FRS> driver;
+#if X86_ARCHITECTURE || X86_64_ARCHITECTURE || PPC_ARCHITECTURE || \
+    AARCH64_ARCHITECTURE
+    //
+    // driver instantiation for the linux platform.
+    //
+    //
+    linux_driver_t<T_VA, T_WT, T_IT, T_GRS, T_FRS> driver;
 #endif
-        rc = driver.driver_main(argc, argv); 
-      }
-    return rc; 
+    return driver.driver_main(argc, argv);
+  } catch (symtab_exception_t e) {
+    e.report();
+    //
+    // return EXIT_FAILURE
+    //
+    return EXIT_FAILURE;
+  } catch (tracer_exception_t e) {
+    e.report();
+    //
+    // return EXIT_FAILURE
+    //
+    return EXIT_FAILURE;
   }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      //
-      // return EXIT_FAILURE
-      //
-      return EXIT_FAILURE;
-    }
-  //catch ( thread_tracer_exception_t e )
-  //  {
-  //    e.report();
-  //    //
-  //    // return EXIT_FAILURE
-  //    //
-  //    return EXIT_FAILURE;
-  //  }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      //
-      // return EXIT_FAILURE
-      //
-      return EXIT_FAILURE;
-    }
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_bp.hxx
+++ b/launchmon/src/linux/sdbg_linux_bp.hxx
@@ -1,38 +1,39 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May 02 2018 KMD: Added aarch64 support
  *        Mar 06 2008 DHA: Added indirect breakpoint support
- *        Mar 11 2008 DHA: Added Linux PowerPC support 
+ *        Mar 11 2008 DHA: Added Linux PowerPC support
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jan 09 2007 DHA: Linux X86/64 Port
  *        Feb 07 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_LINUX_BP_HXX
 #define SDBG_LINUX_BP_HXX 1
@@ -41,85 +42,74 @@
 #include "sdbg_linux_mach.hxx"
 
 #if BIT64
-# if X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
-  const int NUM_BYTE_INCR_AFTER_SINGLESTEP = 8;
-# else
-  const int NUM_BYTE_INCR_AFTER_SINGLESTEP = 4;
-# endif //X86_64_ARCHITECTURE
+#if X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
+const int NUM_BYTE_INCR_AFTER_SINGLESTEP = 8;
+#else
+const int NUM_BYTE_INCR_AFTER_SINGLESTEP = 4;
+#endif  // X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
 #else
 const int NUM_BYTE_INCR_AFTER_SINGLESTEP = 4;
 #endif
 
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE
-const int NUM_BYTE_INCR_AFTER_TRAP       = 1;
+const int NUM_BYTE_INCR_AFTER_TRAP = 1;
 #else
-const int NUM_BYTE_INCR_AFTER_TRAP       = 0;
-#endif
+const int NUM_BYTE_INCR_AFTER_TRAP = 0;
+#endif // X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
 
 //! linux_breakpoint_t:
 /*!
     linux_breakpoint_t is linux implementation of breakpoint_base_t
     class.
 */
-class linux_breakpoint_t : public breakpoint_base_t<T_VA, T_IT>
-{
+class linux_breakpoint_t : public breakpoint_base_t<T_VA, T_IT> {
+ public:
+  linux_breakpoint_t() {
+    unset_use_indirection();
+    set_trap_instruction(T_TRAP_INSTRUCTION);
+    set_orig_instruction(IT_UNINIT_HEX);
+    set_address_at(T_UNINIT_HEX);
+    set_indirect_address_at(T_UNINIT_HEX);
+    set_blend_mask(T_BLEND_MASK);
+    set_return_addr(T_UNINIT_HEX);
+  }
 
-public:
+  virtual ~linux_breakpoint_t() {}
 
-  linux_breakpoint_t()
-    { 
-      unset_use_indirection();
-      set_trap_instruction(T_TRAP_INSTRUCTION); 
-      set_orig_instruction(IT_UNINIT_HEX);
-      set_address_at(T_UNINIT_HEX);
-      set_indirect_address_at(T_UNINIT_HEX);
-      set_blend_mask(T_BLEND_MASK);
-      set_return_addr(T_UNINIT_HEX);
+  virtual T_VA const& get_where_pc_would_be() {
+    where_pc_would_be =
+        get_use_indirection() ? get_indirect_address_at() : get_address_at();
+
+    where_pc_would_be += NUM_BYTE_INCR_AFTER_TRAP;
+
+    return (where_pc_would_be);
+  }
+
+  virtual bool is_pc_part_of_bp_op(T_VA pc) {
+    bool rval = false;
+    T_VA taddr =
+        get_use_indirection() ? get_indirect_address_at() : get_address_at();
+
+    if ((pc == get_where_pc_would_be()) ||
+        ((pc > get_where_pc_would_be()) &&
+         (pc <= taddr + NUM_BYTE_INCR_AFTER_SINGLESTEP))) {
+      rval = true;
+    } else {
+      // check if PC happens to match with return_addr which is
+      // gathered whenever the breakpoint is hit during the BP
+      // prelogue operation.
+      rval = (pc == get_return_addr()) ? true : false;
     }
 
-  virtual ~linux_breakpoint_t() { }
+    return rval;
+  }
 
-  virtual T_VA const & get_where_pc_would_be() 
-    {
-      where_pc_would_be 
-        = get_use_indirection()
-	  ? get_indirect_address_at()
-	  : get_address_at();
-
-      where_pc_would_be += NUM_BYTE_INCR_AFTER_TRAP;
-
-      return ( where_pc_would_be );
-    }
-
-  virtual bool is_pc_part_of_bp_op(T_VA pc) 
-    { 
-      bool rval = false;
-      T_VA taddr
-        = get_use_indirection()
-	  ? get_indirect_address_at()
-	  : get_address_at();
-
-      if ( (pc == get_where_pc_would_be())
-	   || ((pc > get_where_pc_would_be())
-	      && (pc <= taddr+NUM_BYTE_INCR_AFTER_SINGLESTEP)))
-	{
-	  rval = true;
-	}
-      else
-	{
-	  // check if PC happens to match with return_addr which is
-	  // gathered whenever the breakpoint is hit during the BP
-	  // prelogue operation.
-	  rval = (pc == get_return_addr())? true : false;
-	}
-
-      return rval;
-    }
-
-private:
-
+ private:
   T_VA where_pc_would_be;
-
 };
 
-#endif // SDBG_LINUX_BP_HXX
+#endif  // SDBG_LINUX_BP_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_driver.hxx
+++ b/launchmon/src/linux/sdbg_linux_driver.hxx
@@ -1,35 +1,35 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_driver.hxx,v 1.4.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
- *                  
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Feb  09 2008 DHA: Added LLNS Copyright
- *        Jan  08 2006 DHA: Created file.          
- */ 
+ *        Jan  08 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_LINUX_DRIVER_HXX
 #define SDBG_LINUX_DRIVER_HXX 1
@@ -38,25 +38,18 @@
 #include "sdbg_base_driver.hxx"
 #include "sdbg_linux_mach.hxx"
 
-#define LINUX_DRIVER_TEMPLATELIST typename VA, \
-                                  typename WT, \
-                                  typename IT, \
-                                  typename GRS,\
-                                  typename FRS
-#define LINUX_DRIVER_TEMPLPARAM   VA,WT,IT,GRS,FRS
-
+#define LINUX_DRIVER_TEMPLATELIST \
+  typename VA, typename WT, typename IT, typename GRS, typename FRS
+#define LINUX_DRIVER_TEMPLPARAM VA, WT, IT, GRS, FRS
 
 //! class linux_driver_t
 /*!
-    
+
 */
 template <LINUX_DRIVER_TEMPLATELIST>
-class linux_driver_t 
-  : public driver_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper> 
-{
-
-public:
-  
+class linux_driver_t
+    : public driver_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper> {
+ public:
   //
   // constructors & destructor
   //
@@ -65,19 +58,20 @@ public:
   virtual ~linux_driver_t();
 
   //
-  // "main" for the whole project 
+  // "main" for the whole project
   //
-  int driver_main (int argc, char *argv[]);
+  int driver_main(int argc, char* argv[]);
 
-  virtual process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>* 
-      create_process (pid_t pid, 
-		      const std::string& mi,
-		      const std::string& md, 
-		      const std::string& mt,
-		      const std::string& mc);
-  
-  virtual process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>* 
-      create_process ( pid_t pid, const std::string &mi);
+  virtual process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+  create_process(pid_t pid, const std::string& mi, const std::string& md,
+                 const std::string& mt, const std::string& mc);
+
+  virtual process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+  create_process(pid_t pid, const std::string& mi);
 };
 
-#endif // SDBG_LINUX_DRIVER_HXX
+#endif  // SDBG_LINUX_DRIVER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_driver_impl.hxx
+++ b/launchmon/src/linux/sdbg_linux_driver_impl.hxx
@@ -1,36 +1,37 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May  02 2018 KMD: Added aarch64 support
  *        Mar  11 2008 DHA: Added PowerPC support
  *        Feb  09 2008 DHA: Added LLNS Copyright
  *        Mar  13 2007 DHA: pipe_t support
- *        Jan  09 2006 DHA: Linux X86/64 support   
+ *        Jan  09 2006 DHA: Linux X86/64 support
  *        Dec  19 2006 DHA: Added driver_forkmain support
  *        Jan  08 2006 DHA: Created file.
  */
@@ -41,10 +42,9 @@
 #include "sdbg_base_driver.hxx"
 #include "sdbg_base_driver_impl.hxx"
 
-#include "sdbg_linux_mach.hxx"
-#include "sdbg_linux_launchmon.hxx"
 #include "sdbg_linux_driver.hxx"
- 
+#include "sdbg_linux_launchmon.hxx"
+#include "sdbg_linux_mach.hxx"
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -54,48 +54,40 @@
 
 //!
 /*!  driver_base_t<> constructors
-      
-    
+
+
 */
 template <LINUX_DRIVER_TEMPLATELIST>
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::linux_driver_t ()
-{
+linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::linux_driver_t() {
   // more init
 }
 
 template <LINUX_DRIVER_TEMPLATELIST>
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::linux_driver_t (
-                 const linux_driver_t& d )
-{
+linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::linux_driver_t(
+    const linux_driver_t& d) {
   // copy
 }
 
-
 template <LINUX_DRIVER_TEMPLATELIST>
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::~linux_driver_t ()
-{
+linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::~linux_driver_t() {
   // destroy
 }
 
-
 //!
 /*!  driver_base_t<> create_process
-     
-     creates a platform specific process object 
-    
+
+     creates a platform specific process object
+
 */
-template <LINUX_DRIVER_TEMPLATELIST> 
-process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>*
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::create_process ( 
-                 pid_t pid, 
-		 const std::string& mi, 
-		 const std::string& md, 
-		 const std::string& mt,
-		 const std::string& mc )
-{
-  
-  process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>* 
-    return_proc;
+template <LINUX_DRIVER_TEMPLATELIST>
+process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::create_process(pid_t pid,
+                                                        const std::string& mi,
+                                                        const std::string& md,
+                                                        const std::string& mt,
+                                                        const std::string& mc) {
+  process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+      return_proc;
 
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE
   return_proc = new linux_x86_process_t(pid, mi, md, mt, mc);
@@ -108,81 +100,77 @@ linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::create_process (
 #endif
 
   return return_proc;
-
 }
-
 
 //!
 /*!  driver_base_t<> create_process
-     
+
      Method that creates a platform specific process object.
      This is the method that is called by the ::drive_engine()
-    
-*/
-template <LINUX_DRIVER_TEMPLATELIST> 
-process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>*
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::create_process ( 
-		 pid_t pid, 
-		 const std::string &mi )
-{
-  process_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper> *return_proc;
 
-  //
-  // different architectures require different sublayer 
-  // in creating a process object.
-  //
+*/
+template <LINUX_DRIVER_TEMPLATELIST>
+process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::create_process(pid_t pid,
+                                                        const std::string& mi) {
+  process_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>*
+      return_proc;
+
+//
+// different architectures require different sublayer
+// in creating a process object.
+//
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE
-  return_proc = new linux_x86_process_t (pid, mi);
+  return_proc = new linux_x86_process_t(pid, mi);
 #elif PPC_ARCHITECTURE
-  return_proc = new linux_ppc_process_t (pid, mi);
+  return_proc = new linux_ppc_process_t(pid, mi);
 #elif IA64_ARCHITECTURE
-  return_proc = new linux_ia64_process_t (pid, mi);
+  return_proc = new linux_ia64_process_t(pid, mi);
 #elif AARCH64_ARCHITECTURE
-  return_proc = new linux_aarch64_process_t (pid, mi);
+  return_proc = new linux_aarch64_process_t(pid, mi);
 #endif
 
   return return_proc;
-
 }
 
-//int MPIR_being_debugged = 0;
+// int MPIR_being_debugged = 0;
 
 //!
 /*!  driver_base_t<> driver_main
-  
+
      main entry point that the standalone launchmon tool invokes
 
 */
-template <LINUX_DRIVER_TEMPLATELIST> 
-int 
-linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::driver_main
-( int argc, char **argv )
-{
-  try
-   {
-     driver_error_e error_code;
+template <LINUX_DRIVER_TEMPLATELIST>
+int linux_driver_t<LINUX_DRIVER_TEMPLPARAM>::driver_main(int argc,
+                                                         char** argv) {
+  try {
+    driver_error_e error_code;
 
-     event_manager_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>* em;
-     launchmon_base_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>* lm;
+    event_manager_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>* em;
+    launchmon_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t, elf_wrapper>* lm;
 
-     em = new event_manager_t<LINUX_DRIVER_TEMPLPARAM,my_thrinfo_t,elf_wrapper>();
-     lm = new linux_launchmon_t();
-     this->set_evman(em);
-     this->set_lmon(lm);
-  
-     //
-     // Start driving events, calling into the base driver layer 
-     //
-     error_code = driver_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t,elf_wrapper>::drive ( argc, argv );
+    em = new event_manager_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t,
+                             elf_wrapper>();
+    lm = new linux_launchmon_t();
+    this->set_evman(em);
+    this->set_lmon(lm);
 
-     return ( ( error_code == SDBG_DRIVER_OK) ? 0 : 1 );
-   }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+    //
+    // Start driving events, calling into the base driver layer
+    //
+    error_code = driver_base_t<LINUX_DRIVER_TEMPLPARAM, my_thrinfo_t,
+                               elf_wrapper>::drive(argc, argv);
+
+    return ((error_code == SDBG_DRIVER_OK) ? 0 : 1);
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
 
+#endif  // SDBG_LINUX_DRIVER_IMPL_HXX
 
-#endif // SDBG_LINUX_DRIVER_IMPL_HXX
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_launchmon.cxx
+++ b/launchmon/src/linux/sdbg_linux_launchmon.cxx
@@ -1,27 +1,28 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 - 2010, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -30,7 +31,7 @@
  *        Jul 22 2015 ADG: Fix for on demand proctable
  *        Feb 20 2015 andrewg@cray.com: Added support for RMs that build the
  *                         proctable on demand. Fixed a misplaced brace bug.
- *        Oct 26 2012 DHA: Removed catch clauses for deprecated thread tracers 
+ *        Oct 26 2012 DHA: Removed catch clauses for deprecated thread tracers
  *                         exceptions.
  *        Jul 31 2012 DHA: Added a fix for a thread race-related hang problem.
  *        Jun 01 2012 DHA: Merged with the middleware-support branch.
@@ -42,19 +43,21 @@
  *                         handle_mpir_variables.
  *        Sep 02 2010 DHA: Added MPIR_attach_fifo support
  *        Jul 02 2010 DHA: Decreased the verbose level for Daemon args too long
- *                         check. Cleaned up that code to enhance the readability.
+ *                         check. Cleaned up that code to enhance the
+ *                         readability.
  *        Jun 30 2010 DHA: Added faster parse error detection support
  *        Jun 28 2010 DHA: Added support to implement LMON_fe_getRMInfo
  *        Jun 10 2010 DHA: Added CRAY XT support and RM MAP support.
  *        Apr 27 2010 DHA: Added more MEASURE_TRACING_COST support.
  *        Dec 22 2009 DHA: Added auxilliary vector support to discover
  *                         the loader's load address accurately. (e.g.,
- *                         without having to rely on the "_start" symbol exported.
+ *                         without having to rely on the "_start" symbol
+ *                         exported.
  *        Dec 16 2009 DHA: Added COBO support
- *        May 07 2009 DHA: Added a patch to fix the attach-detach-and-reattach failure
- *                         on BlueGene. This requires IBM efix27.
+ *        May 07 2009 DHA: Added a patch to fix the attach-detach-and-reattach
+ *                         failure on BlueGene. This requires IBM efix27.
  *        Mar 04 2009 DHA: Added BlueGene/P support.
- *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN 
+ *                         In particular, changed RM_BGL_MPIRUN to RM_BG_MPIRUN
  *                         to genericize BlueGene Support.
  *                         Added indirect breakpoint support.
  *        Sep 24 2008 DHA: Enforced the error handling semantics
@@ -73,8 +76,10 @@
  *                         use the API mode when higher scalability is
  *                         desired. In addition, I removed envVar exporting
  *                         for the model checking case.
- *        Dec 04 2007 DHA: freed launcher_proctable (TV detects a memory leak there).
- *        Mar 13 2007 DHA: pipe_t support. Better coding for proctab message packing.
+ *        Dec 04 2007 DHA: freed launcher_proctable (TV detects a memory leak
+ *                         there).
+ *        Mar 13 2007 DHA: pipe_t support. Better coding for proctab message
+ *                         packing.
  *                         Turned on the PID environment variable support for
  *                         standalone launchmon utility.
  *        Jan 09 2006 DHA: Linux X86/64 support
@@ -106,7 +111,6 @@
  *        Jan 12 2006 DHA: Created file.
  */
 
-
 #include "sdbg_std.hxx"
 
 #ifndef LINUX_CODE_REQUIRED
@@ -114,34 +118,34 @@
 #endif
 
 extern "C" {
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/socket.h>
 #include <arpa/inet.h>
-#include <link.h>
-#include <thread_db.h>
+#include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
+#include <link.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <thread_db.h>
 }
 
-#include "sdbg_self_trace.hxx"
-#include "sdbg_base_symtab.hxx" 
-#include "sdbg_base_symtab_impl.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_mach_impl.hxx"
+#include "sdbg_base_symtab.hxx"
+#include "sdbg_base_symtab_impl.hxx"
 #include "sdbg_base_tracer.hxx"
+#include "sdbg_self_trace.hxx"
 
 #include "sdbg_base_launchmon.hxx"
 #include "sdbg_base_launchmon_impl.hxx"
 #include "sdbg_rm_map.hxx"
 
-#include "sdbg_linux_std.hxx"
 #include "sdbg_linux_bp.hxx"
-#include "sdbg_linux_mach.hxx"
 #include "sdbg_linux_launchmon.hxx"
+#include "sdbg_linux_mach.hxx"
 #include "sdbg_linux_ptracer.hxx"
 #include "sdbg_linux_ptracer_impl.hxx"
+#include "sdbg_linux_std.hxx"
 
 #if MEASURE_TRACING_COST
 static double accum = 0.0;
@@ -167,10 +171,7 @@ static double endTS;
      NOTE: Dec 23 2009 DHA: This function shouldn't be used if other
      more standard methods are available like get_auxv below
 */
-static
-T_VA 
-get_va_from_procfs ( pid_t pid, const std::string& dynname )
-{ 
+static T_VA get_va_from_procfs(pid_t pid, const std::string &dynname) {
   using namespace std;
 
   FILE *fptr = NULL;
@@ -184,106 +185,94 @@ get_va_from_procfs ( pid_t pid, const std::string& dynname )
 
   T_VA ret_pc = T_UNINIT_HEX;
 
-  sprintf ( mapfile, "/proc/%d/maps", pid );
+  sprintf(mapfile, "/proc/%d/maps", pid);
 
-  if ( ( fptr = fopen(mapfile, "r")) == NULL )   
-    return ret_pc;   
+  if ((fptr = fopen(mapfile, "r")) == NULL) return ret_pc;
 
-  while ( fgets ( aline, MAX_STRING_SIZE, fptr ) ) 
-    {
-      vir_addr_range = strdup ( strtok ( aline, " " ) );
-      perm = strdup ( strtok ( NULL, " " ) );
-      strtok ( NULL, " " );
-      strtok ( NULL, " " );
-      strtok ( NULL, " " );
-      libname = strdup ( strtok ( NULL, " " ) );
+  while (fgets(aline, MAX_STRING_SIZE, fptr)) {
+    vir_addr_range = strdup(strtok(aline, " "));
+    perm = strdup(strtok(NULL, " "));
+    strtok(NULL, " ");
+    strtok(NULL, " ");
+    strtok(NULL, " ");
+    libname = strdup(strtok(NULL, " "));
 
-      // removing the trailing newline character
-      //
-      libname[strlen(libname)-1] = '\0'; 
-      strncpy ( libnamecp, libname, PATH_MAX );
-      if ( strcmp(dynname.c_str(), basename(libnamecp)) == 0 )
-	{
-	  if ( strcmp("r-xp", perm) == 0 ) 
-	    {
-	      lowerpc = strtok ( vir_addr_range, "-" );
-#if BIT64 
-	      sscanf ( lowerpc, "%lx", &ret_pc );
+    // removing the trailing newline character
+    //
+    libname[strlen(libname) - 1] = '\0';
+    strncpy(libnamecp, libname, PATH_MAX);
+    if (strcmp(dynname.c_str(), basename(libnamecp)) == 0) {
+      if (strcmp("r-xp", perm) == 0) {
+        lowerpc = strtok(vir_addr_range, "-");
+#if BIT64
+        sscanf(lowerpc, "%lx", &ret_pc);
 #else
-	      sscanf ( lowerpc, "%x", &ret_pc );
+        sscanf(lowerpc, "%x", &ret_pc);
 #endif
-	      break;
-	    }
-	}
-
-      free ( vir_addr_range );
-      free ( perm );
-      free ( libname );
-      vir_addr_range = NULL;
-      perm = NULL;
-      libname = NULL;
+        break;
+      }
     }
 
-  fclose ( fptr );
+    free(vir_addr_range);
+    free(perm);
+    free(libname);
+    vir_addr_range = NULL;
+    perm = NULL;
+    libname = NULL;
+  }
+
+  fclose(fptr);
 
   return ret_pc;
 }
-
 
 //!  File scope  get_auxv
 /*!  get_auxv
 
-     returns the base address of the loader through the auxvector information 
+     returns the base address of the loader through the auxvector information
      that OS provides.
 */
-static
-T_VA 
-get_auxv ( pid_t pid )
-{ 
+static T_VA get_auxv(pid_t pid) {
   using namespace std;
 
   FILE *fptr = NULL;
   char auxvFile[PATH_MAX];
-  
+
 #if BIT64
   Elf64_auxv_t auxvBuf;
-  int len = sizeof (Elf64_auxv_t);
+  int len = sizeof(Elf64_auxv_t);
 #else
   Elf32_auxv_t auxvBuf;
-  int len = sizeof (Elf32_auxv_t);
+  int len = sizeof(Elf32_auxv_t);
 #endif
 
   T_VA ret_pc = T_UNINIT_HEX;
 
-  sprintf ( auxvFile, "/proc/%d/auxv", pid );
+  sprintf(auxvFile, "/proc/%d/auxv", pid);
 
-  if ( ( fptr = fopen(auxvFile, "r")) == NULL )   
-    {
+  if ((fptr = fopen(auxvFile, "r")) == NULL) {
+    //
+    // In case we see problems with opening up auxv pseudo file,
+    // simply return T_UNITNIT_HEX
+    //
+    return ret_pc;
+  }
+
+  do {
+    if (fread(&auxvBuf, len, 1, fptr) < 0) {
       //
-      // In case we see problems with opening up auxv pseudo file,
-      // simply return T_UNITNIT_HEX
+      // Should I wrap this call as well w.r.t. EINTR?
       //
       return ret_pc;
     }
-    
-  do {
-    if (fread (&auxvBuf, len, 1, fptr) < 0)
-      {
-	//
-	// Should I wrap this call as well w.r.t. EINTR?
-	//
-        return ret_pc;
-      }
   } while (auxvBuf.a_type != AT_BASE);
-
 
   fclose(fptr);
 
-  ret_pc = (auxvBuf.a_type == AT_BASE)? auxvBuf.a_un.a_val : T_UNINIT_HEX;
+  ret_pc = (auxvBuf.a_type == AT_BASE) ? auxvBuf.a_un.a_val : T_UNINIT_HEX;
 
   return ret_pc;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //                                                                //
@@ -291,13 +280,11 @@ get_auxv ( pid_t pid )
 //                                                                //
 ////////////////////////////////////////////////////////////////////
 
-//!  PRIVATE: 
+//!  PRIVATE:
 /*! linux_launchmon_t::init_API initialize API support
     within the engine
 */
-launchmon_rc_e
-linux_launchmon_t::init_API(opts_args_t *opt)
-{ 
+launchmon_rc_e linux_launchmon_t::init_API(opts_args_t *opt) {
   char *tokenize = NULL;
   char *FEip = NULL;
   char *FEport = NULL;
@@ -306,96 +293,81 @@ linux_launchmon_t::init_API(opts_args_t *opt)
   int clientsockfd;
   struct sockaddr_in servaddr;
 
-  if (!opt->get_my_opt()->remote) 
-    {
-      //
-      // if this isn't API mode, apparently you don't have to 
-      // do anything.
-      //
-      goto no_error;
-    }
+  if (!opt->get_my_opt()->remote) {
+    //
+    // if this isn't API mode, apparently you don't have to
+    // do anything.
+    //
+    goto no_error;
+  }
 
   //
   // parsing ip:port info
   //
   tokenize = strdup(opt->get_my_opt()->remote_info.c_str());
-  FEip = strtok ( tokenize, ":" );
-  FEport = strtok ( NULL, ":" );
+  FEip = strtok(tokenize, ":");
+  FEport = strtok(NULL, ":");
 
   servaddr.sin_family = AF_INET;
-  servaddr.sin_port = htons((uint16_t) atoi(FEport));
+  servaddr.sin_port = htons((uint16_t)atoi(FEport));
 
   //
   // converting the text IP (or hostname) to binary
   //
-  if ( inet_pton(AF_INET, (const char*) FEip, &(servaddr.sin_addr)) < 0 )
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "inet_pton failed in the engine init handler.");
-      goto has_error;
-    }
+  if (inet_pton(AF_INET, (const char *)FEip, &(servaddr.sin_addr)) < 0) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "inet_pton failed in the engine init handler.");
+    goto has_error;
+  }
 
   free(tokenize);
 
-  if ( ( clientsockfd = socket ( AF_INET, SOCK_STREAM, 0 )) < 0 )
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "socket failed in the engine init handler.");
-      goto has_error;
-    }
+  if ((clientsockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "socket failed in the engine init handler.");
+    goto has_error;
+  }
 
-  if( setsockopt(clientsockfd, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen) < 0 )
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "setting socket keepalive failed.");
-      goto has_error;
-    }
+  if (setsockopt(clientsockfd, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen) < 0) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "setting socket keepalive failed.");
+    goto has_error;
+  }
 
-  if ( ( connect ( clientsockfd, 
-	 	   (struct sockaddr *)&servaddr,
-                   sizeof(servaddr) )) < 0 )
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "connect failed in the engine's init handler.");
-      goto has_error;
-    }
+  if ((connect(clientsockfd, (struct sockaddr *)&servaddr, sizeof(servaddr))) <
+      0) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "connect failed in the engine's init handler.");
+    goto has_error;
+  }
 
   //
   // registering the FD for FE-client and engine connection
   //
-  set_FE_sockfd ( clientsockfd );
+  set_FE_sockfd(clientsockfd);
 
   //
   // setting API mode flag
   //
-  set_API_mode ( true );
+  set_API_mode(true);
 
   {
-    self_trace_t::trace ( LEVELCHK(level2),
-      MODULENAME,0,
-      "linux_launchmon_t initialized.");
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "linux_launchmon_t initialized.");
   }
 
   //
   // communicate to the FE API that there was a parse error
   //
-  if (opt->get_has_parse_error())
-    {
-      say_fetofe_msg ( lmonp_conn_ack_parse_error );
-      self_trace_t::trace ( true,
-        MODULENAME,1,
-        "the engine deteced parsing errors.");
-      goto has_error;
-    } 
-  else
-    {
-      say_fetofe_msg ( lmonp_conn_ack_no_error );
-    }
-  
+  if (opt->get_has_parse_error()) {
+    say_fetofe_msg(lmonp_conn_ack_parse_error);
+    self_trace_t::trace(true, MODULENAME, 1,
+                        "the engine deteced parsing errors.");
+    goto has_error;
+  } else {
+    say_fetofe_msg(lmonp_conn_ack_no_error);
+  }
+
 no_error:
   return LAUNCHMON_OK;
 
@@ -403,412 +375,340 @@ has_error:
   return LAUNCHMON_FAILED;
 }
 
-
-//!  PRIVATE: 
+//!  PRIVATE:
 /*! linux_launchmon_t::free_engine_resources constructors & destructor
     free resources that the engine created here including
     files.
 */
-void
-linux_launchmon_t::free_engine_resources (
-  process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p )
-{
-  const char *hostnamesfn 
-    = p.get_myopts()->get_my_rmconfig()->get_hostnames_fn();
+void linux_launchmon_t::free_engine_resources(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  const char *hostnamesfn =
+      p.get_myopts()->get_my_rmconfig()->get_hostnames_fn();
 
-  if (hostnamesfn)
-    {
-      remove(hostnamesfn);
-    }
+  if (hostnamesfn) {
+    remove(hostnamesfn);
+  }
 }
 
-
-//! PRIVATE: 
+//! PRIVATE:
 /*! linux_launchmon_t<> constructors & destructor
     Making copy Ctor private keep an object from being copied
 
 */
-linux_launchmon_t::linux_launchmon_t ( const linux_launchmon_t& l )
-{
+linux_launchmon_t::linux_launchmon_t(const linux_launchmon_t &l) {
   // launchmon object must not be copied, exiting.
 }
-
 
 //! PRIVATE: linux_launchmon_t::launch_tool_daemons
 /*!
     launches the target tool deamons.
 
 */
-bool
-linux_launchmon_t::launch_tool_daemons ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p )
-{
+bool linux_launchmon_t::launch_tool_daemons(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
   using namespace std;
 
-  if (get_proctable_copy().empty())
-    {
-      self_trace_t::trace ( true, 
-          MODULENAME,0,
-          "Proctab is empty!");
+  if (get_proctable_copy().empty()) {
+    self_trace_t::trace(true, MODULENAME, 0, "Proctab is empty!");
 
-      return false;
+    return false;
+  }
+
+  if (!get_API_mode() && (!p.rmgr()->is_modelchecker())) {
+    //
+    // Standalone launchmon. The launchmon session is not
+    // driven by LMON APIs...
+    //
+    // In this case, we must communicate the RPDTAB info via
+    // environment variables.
+    // Assuming the system will copy the envVar list of the parallel
+    // launcher to remote nodes, following creates envVars
+    // of the format,
+    // LAUNCHMON_hostname=pid1:pid2:pid3...
+    //
+    // Each of the tool daemons spawned on to the remote nodes can find
+    // its own target PID list by looking at hostname specific
+    // environment variable.
+    //
+    // Note that this method won't scale beyond 2K-ish.
+    // For example, at 4K, the sheer number of environment variables
+    // causes a following execvp to fail, returning to the caller.
+    // For higher scalability, the developer should consider
+    // using the API mode.
+    //
+
+    map<string, vector<MPIR_PROCDESC_EXT *> >::const_iterator pos;
+    vector<MPIR_PROCDESC_EXT *>::const_iterator vpos;
+    char *execname = NULL;
+
+    for (pos = get_proctable_copy().begin(); pos != get_proctable_copy().end();
+         pos++) {
+      string pidlist;
+      for (vpos = pos->second.begin(); vpos != pos->second.end(); vpos++) {
+        char pidbuf[10];
+        sprintf(pidbuf, "%d:", (*vpos)->pd.pid);
+        pidlist = pidlist + string(pidbuf);
+
+        if (!execname) execname = strdup((*vpos)->pd.executable_name);
+      }
+
+      //
+      // envVar looks like LAUNCHMON_alc0=12376:23452
+      //
+      string envname = string("LAUNCHMON_") + string(pos->first);
+      setenv(envname.c_str(), pidlist.c_str(), 1);
     }
+  }
 
-  if ( !get_API_mode()
-       && (!p.rmgr()->is_modelchecker()))
-    {
-      //
-      // Standalone launchmon. The launchmon session is not
-      // driven by LMON APIs...
-      //
-      // In this case, we must communicate the RPDTAB info via 
-      // environment variables.
-      // Assuming the system will copy the envVar list of the parallel
-      // launcher to remote nodes, following creates envVars
-      // of the format,
-      // LAUNCHMON_hostname=pid1:pid2:pid3...
-      //
-      // Each of the tool daemons spawned on to the remote nodes can find 
-      // its own target PID list by looking at hostname specific 
-      // environment variable.
-      //
-      // Note that this method won't scale beyond 2K-ish.
-      // For example, at 4K, the sheer number of environment variables
-      // causes a following execvp to fail, returning to the caller.
-      // For higher scalability, the developer should consider
-      // using the API mode.
-      //
+  if (p.get_myopts()->get_my_rmconfig()->is_modelchecker()) {
+    //
+    // mpirun model checker support
+    //
 
-      map<string, vector<MPIR_PROCDESC_EXT*> >::const_iterator pos;
-      vector<MPIR_PROCDESC_EXT*>::const_iterator vpos;
-      char *execname = NULL;
+    map<string, vector<MPIR_PROCDESC_EXT *> >::const_iterator pos;
+    vector<MPIR_PROCDESC_EXT *>::const_iterator vpos;
 
-      for (pos = get_proctable_copy().begin(); pos != get_proctable_copy().end(); pos++) 
-	{	
-	  string pidlist;
-	  for(vpos = pos->second.begin(); vpos != pos->second.end(); vpos++) 
-	    {
-	      char pidbuf[10];
-	      sprintf(pidbuf, "%d:", (*vpos)->pd.pid);
-	      pidlist = pidlist + string(pidbuf);
-
-	      if(!execname) 
-		execname = strdup((*vpos)->pd.executable_name);
-	}				
-
-	// 
-	// envVar looks like LAUNCHMON_alc0=12376:23452
-	//
-	string envname = string("LAUNCHMON_") + string(pos->first);
-	setenv(envname.c_str(), pidlist.c_str(), 1);
-	}
+    for (pos = get_proctable_copy().begin(); pos != get_proctable_copy().end();
+         pos++) {
+      for (vpos = pos->second.begin(); vpos != pos->second.end(); vpos++) {
+        self_trace_t::trace(1, MODULENAME, 0, "MODEL CHECKER: %s, %d, %s",
+                            (*vpos)->pd.host_name, (*vpos)->pd.pid,
+                            (*vpos)->pd.executable_name);
+      }
     }
- 
-  if ( p.get_myopts()->get_my_rmconfig()->is_modelchecker())
-    {
-      //
-      // mpirun model checker support
-      //
+    return LAUNCHMON_OK;
+  }
 
-      map<string, vector<MPIR_PROCDESC_EXT*> >::const_iterator pos;
-      vector<MPIR_PROCDESC_EXT*>::const_iterator vpos;
-
-      for (pos = get_proctable_copy().begin(); 
-               pos != get_proctable_copy().end(); pos++) 
-	{	
-	  for(vpos = pos->second.begin(); vpos != pos->second.end(); vpos++) 
-	    {
-	      self_trace_t::trace ( 1, 
-	       MODULENAME,0,
-	       "MODEL CHECKER: %s, %d, %s",
-				    (*vpos)->pd.host_name,
-				    (*vpos)->pd.pid,
-				    (*vpos)->pd.executable_name);
-	    }
-	}
-       return LAUNCHMON_OK;
-    }
- 
   map<string, string>::const_iterator envListPos;
 
-  for (envListPos = p.get_myopts()->get_my_opt()->envMap.begin(); 
-       envListPos !=  p.get_myopts()->get_my_opt()->envMap.end(); envListPos++)
-    {
-      setenv(envListPos->first.c_str(), envListPos->second.c_str(), 1);	
-    }
+  for (envListPos = p.get_myopts()->get_my_opt()->envMap.begin();
+       envListPos != p.get_myopts()->get_my_opt()->envMap.end(); envListPos++) {
+    setenv(envListPos->first.c_str(), envListPos->second.c_str(), 1);
+  }
 
   //
   // W/ new RM MAP support
   //
-  if (p.get_myopts()->get_my_rmconfig()->is_coloc_sup())
-    {
-      //
-      // there isn't much you want to do here,
-      // because RM that supports colocation service 
-      // co-spawns daemons as part of its MPIR APAI extension. 
-      // This includes BGRM
+  if (p.get_myopts()->get_my_rmconfig()->is_coloc_sup()) {
+    //
+    // there isn't much you want to do here,
+    // because RM that supports colocation service
+    // co-spawns daemons as part of its MPIR APAI extension.
+    // This includes BGRM
 
-      //
-      // TODO: We may not want to release the mpirun process until the 
-      // tool set up is done...
-      //
-      //
-      // DHA 3/4/2009, reviewed and looks fine for BGP
-      // Changed RM_BGL_MPIRUN to RM_BG_MPIRUN to genericize BlueGene Support
-      //
-    }
-  else
-    {
+    //
+    // TODO: We may not want to release the mpirun process until the
+    // tool set up is done...
+    //
+    //
+    // DHA 3/4/2009, reviewed and looks fine for BGP
+    // Changed RM_BGL_MPIRUN to RM_BG_MPIRUN to genericize BlueGene Support
+    //
+  } else {
 #if MEASURE_TRACING_COST
-      {
-        self_trace_t::trace ( true, /* print always */
- 	   MODULENAME,0,
-	  "About to fork a RM process to bulk-launch daemons");
-        self_trace_t::trace ( true, /* print always */ 
-           MODULENAME,0,
-	  "COUNT: %d, ACCUM TIME (except for the proctab fetching): %f", countHandler, accum);
-      } 
+    {
+      self_trace_t::trace(true, /* print always */
+                          MODULENAME, 0,
+                          "About to fork a RM process to bulk-launch daemons");
+      self_trace_t::trace(
+          true, /* print always */
+          MODULENAME, 0,
+          "COUNT: %d, ACCUM TIME (except for the proctab fetching): %f",
+          countHandler, accum);
+    }
 #endif
 
-      char *tokenize2 = strdup(p.get_myopts()->get_my_opt()->lmon_sec_info.c_str());
-      char *sharedsecret = strtok (tokenize2, ":");
-      char *randomID = strtok (NULL, ":");
-      char hnfn[PATH_MAX] = {'\0'};
-      char tmpsuf[128] = {'\0'};
+    char *tokenize2 =
+        strdup(p.get_myopts()->get_my_opt()->lmon_sec_info.c_str());
+    char *sharedsecret = strtok(tokenize2, ":");
+    char *randomID = strtok(NULL, ":");
+    char hnfn[PATH_MAX] = {'\0'};
+    char tmpsuf[128] = {'\0'};
 
-      //
-      //
-      // Handle the file that contains hostnames of the target nodes
-      if (!getcwd(hnfn, PATH_MAX))
-        {
-          self_trace_t::trace ( true, /* print always */ 
-          MODULENAME,1,
-	  "getcwd failed" );
+    //
+    //
+    // Handle the file that contains hostnames of the target nodes
+    if (!getcwd(hnfn, PATH_MAX)) {
+      self_trace_t::trace(true, /* print always */
+                          MODULENAME, 1, "getcwd failed");
 
-          return false;
-        }
+      return false;
+    }
 
-      strcat(hnfn, "/");
-      strcat(hnfn, LMON_HOSTS_FN_BASE);
-      snprintf(tmpsuf, 128, ".%d", getpid());
+    strcat(hnfn, "/");
+    strcat(hnfn, LMON_HOSTS_FN_BASE);
+    snprintf(tmpsuf, 128, ".%d", getpid());
+    strcat(hnfn, tmpsuf);
+    ofstream hnstream;
+    hnstream.open(hnfn, ios::out);
+
+    if (hnstream.fail()) {
+      self_trace_t::trace(true, MODULENAME, 0,
+                          "open %s failed, trying /tmp/%s instead", hnfn,
+                          LMON_HOSTS_FN_BASE);
+
+      snprintf(hnfn, PATH_MAX, "/tmp/%s", LMON_HOSTS_FN_BASE);
       strcat(hnfn, tmpsuf);
-      ofstream hnstream;
+
+      // try open again
       hnstream.open(hnfn, ios::out);
+      if (hnstream.fail()) {
+        self_trace_t::trace(true, MODULENAME, 0, "open %s also failed!", hnfn);
+        return false;
+      }
+    }
 
-      if (hnstream.fail())
-        {
-          self_trace_t::trace ( true, 
-            MODULENAME,0,
-            "open %s failed, trying /tmp/%s instead", hnfn, LMON_HOSTS_FN_BASE );
+    std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::const_iterator
+        pos;
+    int count = 0;
+    for (pos = get_proctable_copy().begin(); pos != get_proctable_copy().end();
+         ++pos) {
+      hnstream << pos->first;
+      count++;
+      hnstream << "\n";
+    }
+    hnstream.flush();
+    hnstream.close();
 
-          snprintf(hnfn, PATH_MAX, "/tmp/%s", LMON_HOSTS_FN_BASE);
-          strcat(hnfn, tmpsuf);
+    p.rmgr()->set_paramset(get_proctable_copy().size(),
+                           get_proctable_copy().size(), sharedsecret, randomID,
+                           get_resid(), hnfn);
 
-          // try open again
-          hnstream.open(hnfn, ios::out);
-          if (hnstream.fail())
-            {
-              self_trace_t::trace ( true, 
-                MODULENAME,0,
-                "open %s also failed!", hnfn);
-              return false;
-            }
-          }
+    free(tokenize2);
 
-      std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::const_iterator pos;
-      int count=0;
-      for (pos = get_proctable_copy().begin(); pos != get_proctable_copy().end(); ++pos)
-        {
-          hnstream << pos->first;
-          count++;
-          hnstream << "\n";
-        }
-      hnstream.flush();
-      hnstream.close();
+    std::string expandstr;
+    std::list<std::string> alist = p.rmgr()->expand_launch_string(expandstr);
 
-      p.rmgr()->set_paramset(
-	    get_proctable_copy().size(),
-	    get_proctable_copy().size(),
-	    sharedsecret,
-	    randomID,
-	    get_resid(),
-            hnfn
-      );
+    {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                          "launching daemons with: %s", expandstr.c_str());
+    }
 
-      free(tokenize2);
+    //
+    // For non-colocation RM, we need to fork/exec
+    //
+    set_toollauncherpid(fork());
+    if (!get_toollauncherpid()) {
+      char **av = (char **)malloc((alist.size() + 1) * sizeof(char *));
+      size_t indx = 0;
+      std::list<std::string>::iterator iter;
+      for (iter = alist.begin(); iter != alist.end(); iter++) {
+        av[indx] = strdup((*iter).c_str());
+        indx++;
+      }
 
-      std::string expandstr;
-      std::list<std::string> alist
-        = p.rmgr()->expand_launch_string(expandstr);
-
-      {
-        self_trace_t::trace (
-          LEVELCHK(level1),
-          MODULENAME,0,
-          "launching daemons with: %s",
-          expandstr.c_str());
-       }
+      av[indx] = NULL;
 
       //
-      // For non-colocation RM, we need to fork/exec
+      // Sink
       //
-      set_toollauncherpid  (fork());
-      if ( !get_toollauncherpid ())
-        {
-          char **av = (char **) malloc((alist.size() + 1)*sizeof(char *));
-          size_t indx=0;
-          std::list<std::string>::iterator iter;
-          for (iter = alist.begin(); iter != alist.end(); iter++)
-            {
-              av[indx] = strdup((*iter).c_str());
-              indx++;
-            }
+      if (execvp(av[0], av) < 0) {
+        self_trace_t::trace(true, MODULENAME, 1,
+                            "execvp to launch tool daemon failed");
+        perror("");
+        exit(1);
+      }
+    }  // Child vs. parent
+    // Only parent reaches here
+  }  // Co-location vs. traditional daemon launching
 
-          av[indx] = NULL;
-
-          //
-          // Sink
-          //
-          if ( execvp ( av[0], av) < 0 )
-            {
-              self_trace_t::trace ( true,
-                MODULENAME,1,
-                "execvp to launch tool daemon failed");
-                perror("");
-                exit(1);
-            }
-        } //Child vs. parent
-        // Only parent reaches here
-    } // Co-location vs. traditional daemon launching
-
-    return LAUNCHMON_OK;
+  return LAUNCHMON_OK;
 }
-
 
 //! PRIVATE: handle_bp_prologue
 /*!
-    performs the breakpoint event prologue. It includes 
+    performs the breakpoint event prologue. It includes
     stepping over the target breakpoint.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_bp_prologue ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
-		 breakpoint_base_t<T_VA,T_IT> *bp)
-{
-  try 
-    {
-      T_VA pc           = T_UNINIT_HEX;
-      T_VA adjusted_pc  = T_UNINIT_HEX;    
-      T_VA retaddr      = T_UNINIT_HEX;
-      bool use_cxt      = true;
+launchmon_rc_e linux_launchmon_t::handle_bp_prologue(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+    breakpoint_base_t<T_VA, T_IT> *bp) {
+  try {
+    T_VA pc = T_UNINIT_HEX;
+    T_VA adjusted_pc = T_UNINIT_HEX;
+    T_VA retaddr = T_UNINIT_HEX;
+    bool use_cxt = true;
 
-      get_tracer()->tracer_getregs(p, use_cxt);
-      pc = p.get_gprset(use_cxt)->get_pc();
+    get_tracer()->tracer_getregs(p, use_cxt);
+    pc = p.get_gprset(use_cxt)->get_pc();
 
-      //
-      // We must keep track of the "return address" 
-      // in case the following single step causing the caller
-      // to return from the target function,  
-      // to simply execute the very next instruction. 
-      //
-      retaddr = p.get_gprset(use_cxt)->get_ret_addr();
-      if ( retaddr == T_UNINIT_HEX )
-        {
-          T_VA mem_retaddr
-            = p.get_gprset(use_cxt)->get_memloc_for_ret_addr();
+    //
+    // We must keep track of the "return address"
+    // in case the following single step causing the caller
+    // to return from the target function,
+    // to simply execute the very next instruction.
+    //
+    retaddr = p.get_gprset(use_cxt)->get_ret_addr();
+    if (retaddr == T_UNINIT_HEX) {
+      T_VA mem_retaddr = p.get_gprset(use_cxt)->get_memloc_for_ret_addr();
 
-          get_tracer()->tracer_read(p,
-                                    mem_retaddr,
-                                    &retaddr,
-                                    sizeof(retaddr),
-                                    use_cxt );
-        }
-
-      bp->set_return_addr(retaddr);
-      get_tracer()->disable_breakpoint(p, *bp, use_cxt); 
-      adjusted_pc = bp->get_address_at(); 
-      p.get_gprset(use_cxt)->set_pc(adjusted_pc);
-      get_tracer()->tracer_setregs(p, use_cxt);
-      get_tracer()->tracer_singlestep(p, use_cxt);
-
-      {
-	self_trace_t::trace ( 
-          LEVELCHK(level3), 
-	  MODULENAME,0, 
-	  "breakpoint event prologue completed. [pc=0x%x]", 
-	  pc);
-      }
-
-      return LAUNCHMON_BP_PROLOGUE;
+      get_tracer()->tracer_read(p, mem_retaddr, &retaddr, sizeof(retaddr),
+                                use_cxt);
     }
-  catch ( symtab_exception_t e ) 
+
+    bp->set_return_addr(retaddr);
+    get_tracer()->disable_breakpoint(p, *bp, use_cxt);
+    adjusted_pc = bp->get_address_at();
+    p.get_gprset(use_cxt)->set_pc(adjusted_pc);
+    get_tracer()->tracer_setregs(p, use_cxt);
+    get_tracer()->tracer_singlestep(p, use_cxt);
+
     {
-      e.report();
-      return LAUNCHMON_FAILED;
+      self_trace_t::trace(LEVELCHK(level3), MODULENAME, 0,
+                          "breakpoint event prologue completed. [pc=0x%x]", pc);
     }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }  
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+
+    return LAUNCHMON_BP_PROLOGUE;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PRIVATE: is_bp_prologue_done
 /*!
-    checks if the prologue for the breakpoint event has been 
+    checks if the prologue for the breakpoint event has been
     performed. If not, it calls into the prologue.
 */
-bool
-linux_launchmon_t::is_bp_prologue_done ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
-		 breakpoint_base_t<T_VA,T_IT> *bp )
-{
-  try 
-    {
-      T_VA pc = T_UNINIT_HEX;    
-      bool use_cxt = true;
+bool linux_launchmon_t::is_bp_prologue_done(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+    breakpoint_base_t<T_VA, T_IT> *bp) {
+  try {
+    T_VA pc = T_UNINIT_HEX;
+    bool use_cxt = true;
 
-      get_tracer()->tracer_getregs(p,use_cxt);
-      pc = p.get_gprset(use_cxt)->get_pc();  
+    get_tracer()->tracer_getregs(p, use_cxt);
+    pc = p.get_gprset(use_cxt)->get_pc();
 
-      if ( bp->is_disabled() ) 
-	{
-	  get_tracer()->enable_breakpoint ( p, *bp, use_cxt);
+    if (bp->is_disabled()) {
+      get_tracer()->enable_breakpoint(p, *bp, use_cxt);
 
-	  {
-	    self_trace_t::trace ( 
-              LEVELCHK(level3), 
-	      MODULENAME,0,
-	      "breakpoint event prologue was already done. [pc=0x%x]",
-	      pc);
-	  }
+      {
+        self_trace_t::trace(
+            LEVELCHK(level3), MODULENAME, 0,
+            "breakpoint event prologue was already done. [pc=0x%x]", pc);
+      }
 
-	  return true;
-	}  
-
-      return (handle_bp_prologue(p, bp) == LAUNCHMON_BP_PROLOGUE)? false : true; 
+      return true;
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }    
+
+    return (handle_bp_prologue(p, bp) == LAUNCHMON_BP_PROLOGUE) ? false : true;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
 
 //! PRIVATE: linux_launchmon_t::continue_on_attach
@@ -816,868 +716,651 @@ linux_launchmon_t::is_bp_prologue_done (
     Builds the on-demand proctable if it hasn't been built already.
 
 */
-bool
-linux_launchmon_t::continue_on_attach (
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p,
-         bool use_cxt )
-{
-  try
-    {
-      using namespace std;
+bool linux_launchmon_t::continue_on_attach(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool use_cxt) {
+  try {
+    using namespace std;
 
-      image_base_t<T_VA,elf_wrapper>* main_im;
+    image_base_t<T_VA, elf_wrapper> *main_im;
 
-      int local_pcount = 0;
+    int local_pcount = 0;
 #if MEASURE_TRACING_COST
-      double c_start_ts;
-      double c_end_ts;
-      c_start_ts = gettimeofdayD();
+    double c_start_ts;
+    double c_end_ts;
+    c_start_ts = gettimeofdayD();
 #endif
-      main_im  = p.get_myimage();
-      if (!main_im)
-        {
-          self_trace_t::trace (
-             true,
-             MODULENAME, 1,
-             "main image not processed");
-          return false;
-        }
+    main_im = p.get_myimage();
+    if (!main_im) {
+      self_trace_t::trace(true, MODULENAME, 1, "main image not processed");
+      return false;
+    }
 
-      //
-      // fetching the RPDTAB size
-      //
-      symbol_base_t<T_VA> debug_ps
-        = main_im->get_a_symbol ( p.get_launch_proctable_size() );
+    //
+    // fetching the RPDTAB size
+    //
+    symbol_base_t<T_VA> debug_ps =
+        main_im->get_a_symbol(p.get_launch_proctable_size());
 
-      if (!debug_ps && p.get_myrmso_image())
-        {
-          debug_ps
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable_size());
-        }
+    if (!debug_ps && p.get_myrmso_image()) {
+      debug_ps =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable_size());
+    }
 
-      T_VA procsize_addr = debug_ps.get_relocated_address();
+    T_VA procsize_addr = debug_ps.get_relocated_address();
 
-      get_tracer()->tracer_read( p,
-                 procsize_addr,
-                 &(local_pcount),
-                 sizeof(local_pcount),
-                 use_cxt );
+    get_tracer()->tracer_read(p, procsize_addr, &(local_pcount),
+                              sizeof(local_pcount), use_cxt);
 
-      if (local_pcount < 0 )
-        {
-          self_trace_t::trace (
-             true,
-             MODULENAME, 1,
-             "MPIR_proctable_size is negative");
-          return false;
-        }
+    if (local_pcount < 0) {
+      self_trace_t::trace(true, MODULENAME, 1,
+                          "MPIR_proctable_size is negative");
+      return false;
+    }
 
-      // If the local_pcount is non-zero, the proctable has already been built
-      // and we should not issue the continue command.
-      if (local_pcount > 0)
-        {
-          return false;
-        }
+    // If the local_pcount is non-zero, the proctable has already been built
+    // and we should not issue the continue command.
+    if (local_pcount > 0) {
+      return false;
+    }
 
-      // Need to continue since the proctable hasn't been build yet.
-      get_tracer()->tracer_continue (p, use_cxt);
+    // Need to continue since the proctable hasn't been build yet.
+    get_tracer()->tracer_continue(p, use_cxt);
 
 #if MEASURE_TRACING_COST
-      c_end_ts = gettimeofdayD();
-      {
-        self_trace_t::trace ( true,
-           MODULENAME,0,
-           "PROCTAB(%d) Continue_on_attach: %f ",
-           local_pcount, (c_end_ts - c_start_ts));
-      }
+    c_end_ts = gettimeofdayD();
+    {
+      self_trace_t::trace(true, MODULENAME, 0,
+                          "PROCTAB(%d) Continue_on_attach: %f ", local_pcount,
+                          (c_end_ts - c_start_ts));
+    }
 #endif
 
-      return true;
-    }
-  catch ( symtab_exception_t e )
-    {
-      e.report ();
-      return false;
-    }
-  catch ( tracer_exception_t e )
-    {
-      e.report ();
-      return false;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report ();
-      return false;
-    }
+    return true;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return false;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return false;
+  } catch (machine_exception_t e) {
+    e.report();
+    return false;
+  }
 }
-
 
 //! PRIVATE: linux_launchmon_t::acquire_proctable
 /*!
-    acquires RPDTAB as well as the resource ID if available. 
+    acquires RPDTAB as well as the resource ID if available.
     (e.g., totalview_jobid)
 
 */
-bool 
-linux_launchmon_t::acquire_proctable (
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p, 
-		 bool use_cxt )
-{
-  try
-    {
-      using namespace std;
+bool linux_launchmon_t::acquire_proctable(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool use_cxt) {
+  try {
+    using namespace std;
 
-      char resource_id[MAX_STRING_SIZE];
-      image_base_t<T_VA,elf_wrapper>* main_im;
+    char resource_id[MAX_STRING_SIZE];
+    image_base_t<T_VA, elf_wrapper> *main_im;
 
-      T_VA proctable_loc;
-      unsigned long long i, maxcount;   // proctable index can be large!
-      int local_pcount;      
-#if MEASURE_TRACING_COST   
-      double c_start_ts;
-      double c_end_ts;
-      c_start_ts = gettimeofdayD();
+    T_VA proctable_loc;
+    unsigned long long i, maxcount;  // proctable index can be large!
+    int local_pcount;
+#if MEASURE_TRACING_COST
+    double c_start_ts;
+    double c_end_ts;
+    c_start_ts = gettimeofdayD();
 #endif
-      main_im  = p.get_myimage();
-      if (!main_im)
-        {
-	  self_trace_t::trace ( 
-             true, 
-	     MODULENAME, 1, 
-	     "main image not processed");  
-          return false;
-        } 
+    main_im = p.get_myimage();
+    if (!main_im) {
+      self_trace_t::trace(true, MODULENAME, 1, "main image not processed");
+      return false;
+    }
+
+    //
+    // fetching the RPDTAB size
+    //
+    symbol_base_t<T_VA> debug_ps =
+        main_im->get_a_symbol(p.get_launch_proctable_size());
+
+    if (!debug_ps && p.get_myrmso_image()) {
+      debug_ps =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable_size());
+    }
+
+    T_VA procsize_addr = debug_ps.get_relocated_address();
+
+    get_tracer()->tracer_read(p, procsize_addr, &(local_pcount),
+                              sizeof(local_pcount), use_cxt);
+    set_pcount(local_pcount);
+    if (get_pcount() <= 0) {
+      self_trace_t::trace(true, MODULENAME, 1,
+                          "MPIR_proctable_size is negative");
+      return false;
+    }
+
+    //
+    // launcher_proctable holds the MPIR_PROCDESC array. Note that
+    // it only contains scalars and pointer addresses. To fetch
+    // the strings pointed by those pointer addresses, we must
+    // perform separate read operations using those addresses.
+    //
+    MPIR_PROCDESC *launcher_proctable =
+        (MPIR_PROCDESC *)malloc(sizeof(MPIR_PROCDESC) * get_pcount());
+
+    if (!launcher_proctable) {
+      self_trace_t::trace(true, MODULENAME, 1, "Out of memory!");
+
+      return false;
+    }
+
+    symbol_base_t<T_VA> debug_pt =
+        main_im->get_a_symbol(p.get_launch_proctable());
+    if (!debug_pt && p.get_myrmso_image()) {
+      debug_pt = p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable());
+    }
+
+    T_VA proctable_addr = debug_pt.get_relocated_address();
+    get_tracer()->tracer_read(p, proctable_addr, &proctable_loc,
+                              sizeof(proctable_loc), use_cxt);
+    get_tracer()->tracer_read(p, proctable_loc, launcher_proctable,
+                              (sizeof(MPIR_PROCDESC) * get_pcount()), use_cxt);
+
+    //
+    // fetching each proctable entry including strings pointed by
+    // C pointers.
+    //
+    maxcount = (unsigned long long)get_pcount();
+    for (i = 0; i < maxcount; ++i) {
+      MPIR_PROCDESC_EXT *an_entry =
+          (MPIR_PROCDESC_EXT *)malloc(sizeof(MPIR_PROCDESC_EXT));
+
+      if (!an_entry) {
+        self_trace_t::trace(true, MODULENAME, 1, "Out of memory!");
+
+        return false;
+      }
 
       //
-      // fetching the RPDTAB size
+      // allocating storages for "an_entry"
       //
-      symbol_base_t<T_VA> debug_ps 
-        = main_im->get_a_symbol ( p.get_launch_proctable_size() );
-
-      if (!debug_ps && p.get_myrmso_image())
-        {
-          debug_ps
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable_size());
-        }
-
-      T_VA procsize_addr = debug_ps.get_relocated_address();  
-
-      get_tracer()->tracer_read( p, 
-				 procsize_addr, 
-				 &(local_pcount), 
-				 sizeof(local_pcount), 
-				 use_cxt );     
-      set_pcount (local_pcount);
-      if (get_pcount() <= 0 )
-        {
-          self_trace_t::trace ( 
-          true, 
-	      MODULENAME, 1, 
-	      "MPIR_proctable_size is negative");  
-          return false;
-        }
-
-      //
-      // launcher_proctable holds the MPIR_PROCDESC array. Note that
-      // it only contains scalars and pointer addresses. To fetch 
-      // the strings pointed by those pointer addresses, we must
-      // perform separate read operations using those addresses.
-      //
-      MPIR_PROCDESC* launcher_proctable 
-        = (MPIR_PROCDESC *) malloc (sizeof (MPIR_PROCDESC) * get_pcount());   
-
-      if (!launcher_proctable)
-        {
-	      self_trace_t::trace ( 
-          true, 
-	      MODULENAME, 
-          1, 
-	      "Out of memory!");  
-
-          return false;
-        }
-
-      symbol_base_t<T_VA> debug_pt 
-	    = main_im->get_a_symbol ( p.get_launch_proctable() );
-      if (!debug_pt && p.get_myrmso_image())
-        {
-          debug_pt
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_proctable());
-        }
-
-      T_VA proctable_addr = debug_pt.get_relocated_address();
-      get_tracer()->tracer_read ( p, 
-				  proctable_addr, 
-				  &proctable_loc,
-				  sizeof(proctable_loc), 
-				  use_cxt );
-      get_tracer()->tracer_read ( p, 
-				  proctable_loc,
-				  launcher_proctable,
-				  ( sizeof (MPIR_PROCDESC) * get_pcount()), 
-				  use_cxt );
-
- 
-      //
-      // fetching each proctable entry including strings pointed by 
-      // C pointers.
-      //
-      maxcount = (unsigned long long) get_pcount();
-      for ( i = 0; i < maxcount; ++i ) 
-        {
-          MPIR_PROCDESC_EXT* an_entry 
-            = (MPIR_PROCDESC_EXT* ) malloc(sizeof(MPIR_PROCDESC_EXT));
-
-          if (!an_entry)
-            {
-              self_trace_t::trace ( 
-              true, 
-	          MODULENAME, 1, 
-	         "Out of memory!");  
-
-              return false;
-            }
-
-          //
-          // allocating storages for "an_entry"
-          //	
-          an_entry->pd.host_name 
-                 = (char*) malloc(MAX_STRING_SIZE);
-          an_entry->pd.executable_name 
-                 = (char*) malloc(MAX_STRING_SIZE);
+      an_entry->pd.host_name = (char *)malloc(MAX_STRING_SIZE);
+      an_entry->pd.executable_name = (char *)malloc(MAX_STRING_SIZE);
 #if SUB_ARCH_BGQ
-	      an_entry->cnodeid
-                 = launcher_proctable[i].pid;      
+      an_entry->cnodeid = launcher_proctable[i].pid;
 #else
-	      an_entry->pd.pid 
-                 = launcher_proctable[i].pid;      
-	      an_entry->cnodeid = -1;      
+      an_entry->pd.pid = launcher_proctable[i].pid;
+      an_entry->cnodeid = -1;
 #endif
-	      an_entry->mpirank = i; /* The mpi rank is the index into the global tab */
+      an_entry->mpirank = i; /* The mpi rank is the index into the global tab */
 
 #if SUB_ARCH_BGQ
-	      an_entry->pd.pid = i; /* The mpi rank is the index into the global tab */
+      an_entry->pd.pid = i; /* The mpi rank is the index into the global tab */
 #endif
 
-          //
-          // memory-fetching to get the "host_name" 
-          //
-          get_tracer()->tracer_read_string(p, 
-			  (T_VA) launcher_proctable[i].host_name,
-			  (void*) (an_entry->pd.host_name),
-			  MAX_STRING_SIZE,
-			  use_cxt );   
-   
-          //
-          // memory-fetching to get the "executable name" 
-          //	 
-          get_tracer()->tracer_read_string(p, 
-              (T_VA)launcher_proctable[i].executable_name,
-			  (void*)an_entry->pd.executable_name,
-			  MAX_STRING_SIZE,
-			  use_cxt );
+      //
+      // memory-fetching to get the "host_name"
+      //
+      get_tracer()->tracer_read_string(p, (T_VA)launcher_proctable[i].host_name,
+                                       (void *)(an_entry->pd.host_name),
+                                       MAX_STRING_SIZE, use_cxt);
 
-          get_proctable_copy()[an_entry->pd.host_name].push_back(an_entry);
+      //
+      // memory-fetching to get the "executable name"
+      //
+      get_tracer()->tracer_read_string(
+          p, (T_VA)launcher_proctable[i].executable_name,
+          (void *)an_entry->pd.executable_name, MAX_STRING_SIZE, use_cxt);
+
+      get_proctable_copy()[an_entry->pd.host_name].push_back(an_entry);
+    }
+
+    free(launcher_proctable);
+
+    if (get_proctable_copy().empty()) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "proctable is empty!");
+
+      return false;
+    }
+
+    if (p.get_myopts()->get_my_rmconfig()->is_rid_sup()) {
+      if (p.get_myopts()->get_my_rmconfig()->is_rid_via_symbol()) {
+        resource_manager_t r_mgr;
+        r_mgr = p.get_myopts()->get_my_rmconfig()->get_resource_manager();
+        std::string rid_sym = r_mgr.get_job_id().id.symbol_name;
+
+        symbol_base_t<T_VA> rid = main_im->get_a_symbol(rid_sym);
+        if (!rid && p.get_myrmso_image()) {
+          rid = p.get_myrmso_image()->get_a_symbol(rid_sym);
         }
 
-      free ( launcher_proctable );
+        if (r_mgr.get_job_id().dtype == cstring) {
+          T_VA where_is_rid;
 
-      if ( get_proctable_copy().empty() )
-        {
-          self_trace_t::trace ( LEVELCHK(level1),
-          MODULENAME, 1,
-          "proctable is empty!");
+          get_tracer()->tracer_read(p, rid.get_relocated_address(),
+                                    (void *)&where_is_rid, sizeof(T_VA),
+                                    use_cxt);
 
-          return false;
+          get_tracer()->tracer_read_string(p, where_is_rid, (void *)resource_id,
+                                           MAX_STRING_SIZE, use_cxt);
+
+          set_resid(atoi(resource_id));
+          p.set_rid(get_resid());
+
+          // -1 is the init value that SLURM sets internally
+          // for "totalview_jobid"
+          if (get_resid() == -1) {
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                                "resource ID is not valid!");
+
+            return false;
+          }
+        } else if (r_mgr.get_job_id().dtype == integer32) {
+          uint32_t int_val;
+
+          get_tracer()->tracer_read(p, rid.get_relocated_address(),
+                                    (void *)&int_val, sizeof(int_val), use_cxt);
+          set_resid(int_val);
+          p.set_rid(get_resid());
         }
-
-      if (p.get_myopts()->get_my_rmconfig()->is_rid_sup())
-        {
-          if (p.get_myopts()->get_my_rmconfig()->is_rid_via_symbol())
-            {
-              resource_manager_t r_mgr;
-              r_mgr = p.get_myopts()->get_my_rmconfig()->get_resource_manager();
-              std::string rid_sym = r_mgr.get_job_id().id.symbol_name;
-
-              symbol_base_t<T_VA> rid
-                = main_im->get_a_symbol(rid_sym);
-              if (!rid && p.get_myrmso_image())
-                {
-                  rid = p.get_myrmso_image()->get_a_symbol(rid_sym);
-                }
-
-
-              if (r_mgr.get_job_id().dtype == cstring)
-                {
-                  T_VA where_is_rid;
-
-                  get_tracer()->tracer_read(
-                                        p,
-                                        rid.get_relocated_address(),
-                                        (void *) &where_is_rid,
-                                        sizeof(T_VA),
-                                        use_cxt);
-
-                  get_tracer()->tracer_read_string (
-                                        p,
-                                        where_is_rid,
-                                        (void*) resource_id,
-                                        MAX_STRING_SIZE,
-                                        use_cxt);
-
-                  set_resid(atoi(resource_id));
-                  p.set_rid(get_resid());
-
-                  // -1 is the init value that SLURM sets internally 
-                  // for "totalview_jobid"
-                  if ( get_resid() == -1 )
-                    {
-                      self_trace_t::trace ( LEVELCHK(level1),
-                      MODULENAME, 1,
-                      "resource ID is not valid!");
-
-	                  return false;
-                    }
-                }
-              else if (r_mgr.get_job_id().dtype == integer32)
-                {
-                  uint32_t int_val;
-
-                  get_tracer()->tracer_read(
-                                        p,
-                                        rid.get_relocated_address(),
-                                        (void *) &int_val,
-                                        sizeof(int_val),
-                                        use_cxt);
-                  set_resid(int_val);
-                  p.set_rid(get_resid());
-                }
-            }
-          else if (p.get_myopts()->get_my_rmconfig()->is_rid_via_pid())
-            {
-              set_resid (p.get_pid(false));
-              p.set_rid (get_resid());
-            }
-        }
+      } else if (p.get_myopts()->get_my_rmconfig()->is_rid_via_pid()) {
+        set_resid(p.get_pid(false));
+        p.set_rid(get_resid());
+      }
+    }
 
 #if MEASURE_TRACING_COST
-      c_end_ts = gettimeofdayD();
-      {
-        self_trace_t::trace ( true,
-           MODULENAME,0,
-           "PROCTAB(%d) Fetching: %f ",
-           get_pcount(), (c_end_ts - c_start_ts));
-      }
+    c_end_ts = gettimeofdayD();
+    {
+      self_trace_t::trace(true, MODULENAME, 0, "PROCTAB(%d) Fetching: %f ",
+                          get_pcount(), (c_end_ts - c_start_ts));
+    }
 #endif
 
-      return true;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report ();
-      return false;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report ();
-      return false;
-    }  
-  catch ( machine_exception_t e )
-    {
-      e.report ();
-      return false;
-    }
+    return true;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return false;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return false;
+  } catch (machine_exception_t e) {
+    e.report();
+    return false;
+  }
 }
-
 
 //!  PRIVATE: linux_launchmon_t::disable_all_BPs
-/*! 
-     disables all the hidden breakpoints    
+/*!
+     disables all the hidden breakpoints
 */
-bool 
-linux_launchmon_t::disable_all_BPs ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p, 
-		 bool use_cxt, bool change_state )
-{
-  try 
-    {
+bool linux_launchmon_t::disable_all_BPs(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool use_cxt,
+    bool change_state) {
+  try {
+    tracer_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *tr = get_tracer();
 
-      tracer_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *tr = get_tracer(); 
- 
-      if ( p.get_launch_hidden_bp() ) 
-	{
-	 tr->disable_breakpoint ( 
-           p, 
-	   *(p.get_launch_hidden_bp()), 
-	   use_cxt,
-           change_state);
-	}
+    if (p.get_launch_hidden_bp()) {
+      tr->disable_breakpoint(p, *(p.get_launch_hidden_bp()), use_cxt,
+                             change_state);
+    }
 
-      if ( p.get_loader_hidden_bp() ) 
-	{
-	 tr->disable_breakpoint ( 
-           p, 
-           *(p.get_loader_hidden_bp()), 
-	   use_cxt,
-           change_state);
-	}
+    if (p.get_loader_hidden_bp()) {
+      tr->disable_breakpoint(p, *(p.get_loader_hidden_bp()), use_cxt,
+                             change_state);
+    }
 
-      return true;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return false;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return false;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return false;
-    }
+    return true;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return false;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return false;
+  } catch (machine_exception_t e) {
+    e.report();
+    return false;
+  }
 }
-
 
 //!  PRIVATE: linux_launchmon_t::set_mpir_variables
-/*!   
+/*!
      set MPIR variables
 */
-bool 
-linux_launchmon_t::handle_mpir_variables (
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
-                image_base_t<T_VA,elf_wrapper> &image )
-{
-  try
-    {
-      bool use_cxt = true;
-      breakpoint_base_t<T_VA, T_IT> *la_bp;
-      T_VA debug_state_flag;
-      int bdbg = 1;
+bool linux_launchmon_t::handle_mpir_variables(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+    image_base_t<T_VA, elf_wrapper> &image) {
+  try {
+    bool use_cxt = true;
+    breakpoint_base_t<T_VA, T_IT> *la_bp;
+    T_VA debug_state_flag;
+    int bdbg = 1;
 
-      //
-      // registering p.launch_hidden_bp 
-      //
-      const symbol_base_t<T_VA>& launch_bp_sym
-        = image.get_a_symbol (p.get_launch_breakpoint_sym());
+    //
+    // registering p.launch_hidden_bp
+    //
+    const symbol_base_t<T_VA> &launch_bp_sym =
+        image.get_a_symbol(p.get_launch_breakpoint_sym());
 
-      if (!(!launch_bp_sym) && launch_bp_sym.is_defined())
-        {
-          if ( p.get_launch_hidden_bp() )
-            {
-               if (p.get_launch_hidden_bp()->is_enabled())
-                 {
-                   //
-                   // If bp already inserted, remove it.
-                   //
-                   get_tracer()->disable_breakpoint( p,
-                                   *(p.get_launch_hidden_bp()),
-                                   use_cxt);
-                  }
-              delete p.get_launch_hidden_bp();
-              p.set_launch_hidden_bp(NULL);
-            }
-          la_bp = new linux_breakpoint_t();
-          la_bp->set_address_at(launch_bp_sym.get_relocated_address());
+    if (!(!launch_bp_sym) && launch_bp_sym.is_defined()) {
+      if (p.get_launch_hidden_bp()) {
+        if (p.get_launch_hidden_bp()->is_enabled()) {
+          //
+          // If bp already inserted, remove it.
+          //
+          get_tracer()->disable_breakpoint(p, *(p.get_launch_hidden_bp()),
+                                           use_cxt);
+        }
+        delete p.get_launch_hidden_bp();
+        p.set_launch_hidden_bp(NULL);
+      }
+      la_bp = new linux_breakpoint_t();
+      la_bp->set_address_at(launch_bp_sym.get_relocated_address());
 
 #if PPC_ARCHITECTURE
-          //
-          // DHA Mar 05 2009
-          // PowerPC Linux has begun to change the linking convention
-          // such that binaries no longer export direct function
-          // symbols. (e.g., .MPIR_Breakpoint). But rather, undotted
-          // global data symbols (e.g., MPIR_Breakpoint) contains the
-          // address for the corresponding function.
-          //
-          // Added indirect breakpoint support for that and use this
-          // method on all PPC systems across the board including
-          // BGL and BGP
-          //
-          la_bp->set_use_indirection();
+      //
+      // DHA Mar 05 2009
+      // PowerPC Linux has begun to change the linking convention
+      // such that binaries no longer export direct function
+      // symbols. (e.g., .MPIR_Breakpoint). But rather, undotted
+      // global data symbols (e.g., MPIR_Breakpoint) contains the
+      // address for the corresponding function.
+      //
+      // Added indirect breakpoint support for that and use this
+      // method on all PPC systems across the board including
+      // BGL and BGP
+      //
+      la_bp->set_use_indirection();
 #endif
-          la_bp->set();
+      la_bp->set();
 
-          p.set_launch_hidden_bp(la_bp);
-          get_tracer()->enable_breakpoint(p,
-                                          *(p.get_launch_hidden_bp()),
-                                          use_cxt );
+      p.set_launch_hidden_bp(la_bp);
+      get_tracer()->enable_breakpoint(p, *(p.get_launch_hidden_bp()), use_cxt);
+    }
+
+    //
+    // setting MPIR_being_debugged
+    //
+    const symbol_base_t<T_VA> &debug_state =
+        image.get_a_symbol(p.get_launch_being_debug());
+    if (!(!debug_state)) {
+      debug_state_flag = debug_state.get_relocated_address();
+      get_tracer()->tracer_write(p, debug_state_flag, &bdbg, sizeof(bdbg),
+                                 use_cxt);
+    }
+
+    if (p.rmgr()->is_coloc_sup()) {
+      //
+      // Always check correctness of BG_SERVERARG_LENGTH
+      // and BG_EXECPATH_LENGTH
+      //
+      const int BG_SERVERARG_LENGTH = 1024;
+      const int BG_EXECPATH_LENGTH = 256;
+      const symbol_base_t<T_VA> &executablepath =
+          image.get_a_symbol(p.get_launch_exec_path());
+      const symbol_base_t<T_VA> &sa =
+          image.get_a_symbol(p.get_launch_server_args());
+
+      if (!(!executablepath) && !(!sa)) {
+        T_VA ep_addr = executablepath.get_relocated_address();
+        std::string daemon_pth;
+        daemon_pth = p.rmgr()->get_const_coloc_paramset().rm_daemon_path;
+        size_t dpsize = daemon_pth.size() + 1;
+
+        if (dpsize > BG_EXECPATH_LENGTH) {
+          self_trace_t::trace(true, MODULENAME, 1,
+                              "daemon path(%d) exceeds the buffer length: %d",
+                              dpsize, BG_EXECPATH_LENGTH);
+
+          return LAUNCHMON_FAILED;
         }
 
-      //
-      // setting MPIR_being_debugged
-      //
-      const symbol_base_t<T_VA>& debug_state
-        = image.get_a_symbol (p.get_launch_being_debug());
-      if (!(!debug_state))
-        {
-          debug_state_flag = debug_state.get_relocated_address();
-          get_tracer()->tracer_write ( p,
-                                       debug_state_flag,
-                                       &bdbg,
-                                       sizeof(bdbg),
-                                       use_cxt );
-        }
+        get_tracer()->tracer_write(p, ep_addr, daemon_pth.c_str(), dpsize,
+                                   use_cxt);
 
-      if (p.rmgr()->is_coloc_sup())
-        {
-          //
-          // Always check correctness of BG_SERVERARG_LENGTH 
-          // and BG_EXECPATH_LENGTH
-          //
-          const int BG_SERVERARG_LENGTH = 1024;
-          const int BG_EXECPATH_LENGTH = 256;
-          const symbol_base_t<T_VA>& executablepath
-            = image.get_a_symbol (p.get_launch_exec_path ());
-          const symbol_base_t<T_VA> &sa
-            = image.get_a_symbol (p.get_launch_server_args ());
+        char *tokenize2 =
+            strdup(p.get_myopts()->get_my_opt()->lmon_sec_info.c_str());
+        char *sharedsecret = strtok(tokenize2, ":");
+        char *randomID = strtok(NULL, ":");
+        p.rmgr()->set_paramset(0, 0, sharedsecret, randomID, -1, NULL);
 
-          if (!(!executablepath) && !(!sa))
-            { 
-              T_VA ep_addr = executablepath.get_relocated_address();
-              std::string daemon_pth;
-              daemon_pth = p.rmgr()->get_const_coloc_paramset().rm_daemon_path;
-              size_t dpsize = daemon_pth.size() + 1;
+        std::string expstr;
+        std::list<std::string> alist;
+        //
+        // Change this for vector<string> interface
+        //
+        alist = p.rmgr()->expand_launch_string(expstr);
+        char serverargs[BG_SERVERARG_LENGTH] = {0};
+        T_VA sa_addr = sa.get_relocated_address();
 
-              if (dpsize > BG_EXECPATH_LENGTH)
-                {
-                  self_trace_t::trace ( true,
-                    MODULENAME,1,
-                    "daemon path(%d) exceeds the buffer length: %d",
-                    dpsize,
-                    BG_EXECPATH_LENGTH);
-
-                  return LAUNCHMON_FAILED;
-                }
-
-              get_tracer()->tracer_write(p,
-                                         ep_addr,
-                                         daemon_pth.c_str(),
-                                         dpsize,
-                                         use_cxt);
-
-              char *tokenize2 
-                = strdup(p.get_myopts()->get_my_opt()->lmon_sec_info.c_str());
-              char *sharedsecret = strtok (tokenize2, ":");
-              char *randomID = strtok (NULL, ":");
-              p.rmgr()->set_paramset(0,
-                                     0,
-                                     sharedsecret,
-                                     randomID,
-                                     -1,
-                                     NULL);
-
-              std::string expstr;
-              std::list<std::string> alist;
-              //
-              // Change this for vector<string> interface
-              //
-              alist = p.rmgr()->expand_launch_string(expstr);
-              char serverargs[BG_SERVERARG_LENGTH] = {0};
-              T_VA sa_addr = sa.get_relocated_address();
-
-              if (expstr != "")
-                {
-                  if (expstr.size() >= BG_SERVERARG_LENGTH)
-                    {
-                      self_trace_t::trace (true,
-                        MODULENAME, 1,
-                        "Daemon args list too long to fit %s", expstr.c_str());
-                    }
-                  else
-                    {
-                      char *traverse = serverargs;
-                      std::list<std::string>::iterator iter;
-                      for (iter = alist.begin(); iter != alist.end(); iter++)
-                        {
-                          memcpy((void *)traverse,
-                             (const void *)((*iter).c_str()),
-                             (size_t)((*iter).size()));
-                          traverse += ((*iter).size());
-                          (*traverse) = '\0';
-                          traverse += 1;
-                        }
-
-                      get_tracer()->tracer_write(p,
-                                                 sa_addr,
-                                                 serverargs,
-                                                 BG_SERVERARG_LENGTH,
-                                                 use_cxt);
-                    }
-                }
+        if (expstr != "") {
+          if (expstr.size() >= BG_SERVERARG_LENGTH) {
+            self_trace_t::trace(true, MODULENAME, 1,
+                                "Daemon args list too long to fit %s",
+                                expstr.c_str());
+          } else {
+            char *traverse = serverargs;
+            std::list<std::string>::iterator iter;
+            for (iter = alist.begin(); iter != alist.end(); iter++) {
+              memcpy((void *)traverse, (const void *)((*iter).c_str()),
+                     (size_t)((*iter).size()));
+              traverse += ((*iter).size());
+              (*traverse) = '\0';
+              traverse += 1;
             }
 
-          if (p.rmgr()->is_attfifo_sup())
-            {
-              const symbol_base_t<T_VA>& af_sym 
-                = image.get_a_symbol(p.get_launch_attach_fifo());
+            get_tracer()->tracer_write(p, sa_addr, serverargs,
+                                       BG_SERVERARG_LENGTH, use_cxt);
+          }
+        }
+      }
 
-              if (!(!af_sym) && !(p.get_sym_attach_fifo()))
-                {
-                  symbol_base_t<T_VA> *af_sym_copy
-                    = new symbol_base_t<T_VA>(af_sym);
-                  p.set_sym_attach_fifo(af_sym_copy);
-                }
-            } // RM with MPIR_attach_fifo support
-        } // With MPIR Colocation service
-    }
-  catch ( symtab_exception_t e )
-    {
-      e.report();
-      return false;
-    }
-  catch ( tracer_exception_t e )
-    {
-      e.report();
-      return false;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return false;
-    }
+      if (p.rmgr()->is_attfifo_sup()) {
+        const symbol_base_t<T_VA> &af_sym =
+            image.get_a_symbol(p.get_launch_attach_fifo());
+
+        if (!(!af_sym) && !(p.get_sym_attach_fifo())) {
+          symbol_base_t<T_VA> *af_sym_copy = new symbol_base_t<T_VA>(af_sym);
+          p.set_sym_attach_fifo(af_sym_copy);
+        }
+      }  // RM with MPIR_attach_fifo support
+    }    // With MPIR Colocation service
+  } catch (symtab_exception_t e) {
+    e.report();
+    return false;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return false;
+  } catch (machine_exception_t e) {
+    e.report();
+    return false;
+  }
 }
-
 
 //!  PRIVATE: linux_launchmon_t::enable_all_BPs
-/*!   
+/*!
      enables all the hidden breakpoints
 */
-bool 
-linux_launchmon_t::enable_all_BPs ( 
-	         process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, 
-		 bool use_cxt,
-                 bool change_state )
-{
-  try 
-    {
-      tracer_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *tr = get_tracer();
- 
-      if (p.get_launch_hidden_bp()) 
-	{
-	  tr->enable_breakpoint ( 
-            p, 
-	    *(p.get_launch_hidden_bp()), 
-	    use_cxt,
-            change_state);
-	}
+bool linux_launchmon_t::enable_all_BPs(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool use_cxt,
+    bool change_state) {
+  try {
+    tracer_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *tr = get_tracer();
 
-      if (p.get_loader_hidden_bp()) 
-	{
-	  tr->enable_breakpoint ( 
-            p, 
-	    *(p.get_loader_hidden_bp()), 
-	    use_cxt,
-            change_state);
-	}
+    if (p.get_launch_hidden_bp()) {
+      tr->enable_breakpoint(p, *(p.get_launch_hidden_bp()), use_cxt,
+                            change_state);
+    }
 
-      return true;
+    if (p.get_loader_hidden_bp()) {
+      tr->enable_breakpoint(p, *(p.get_loader_hidden_bp()), use_cxt,
+                            change_state);
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return false;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return false;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return false;
-    }
+
+    return true;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return false;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return false;
+  } catch (machine_exception_t e) {
+    e.report();
+    return false;
+  }
 }
-
 
 //!  PRIVATE: linux_launchmon_t::check_dependent_SOs
 /*!
      checks to see if libpthread is linked, and if so
      initializes the thread tracer
-     Sep 13 2010, we now handle RM SO here as well. 
+     Sep 13 2010, we now handle RM SO here as well.
 */
-bool 
-linux_launchmon_t::check_dependent_SOs ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
+bool linux_launchmon_t::check_dependent_SOs(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 
-      bool use_cxt = true;
-      bool rc = false;
-      image_base_t<T_VA,elf_wrapper> *dynloader_im;
-      image_base_t<T_VA,elf_wrapper> *thr_im;
-      image_base_t<T_VA,elf_wrapper> *libc_im;
-      image_base_t<T_VA,elf_wrapper> *rmso_im;
-      breakpoint_base_t<T_VA, T_IT> *frbp;
-      T_VA where_to_read;
-      struct r_debug r_debug_buf;
-      struct link_map a_map;
-      char lname[MAX_STRING_SIZE];
+    bool use_cxt = true;
+    bool rc = false;
+    image_base_t<T_VA, elf_wrapper> *dynloader_im;
+    image_base_t<T_VA, elf_wrapper> *thr_im;
+    image_base_t<T_VA, elf_wrapper> *libc_im;
+    image_base_t<T_VA, elf_wrapper> *rmso_im;
+    breakpoint_base_t<T_VA, T_IT> *frbp;
+    T_VA where_to_read;
+    struct r_debug r_debug_buf;
+    struct link_map a_map;
+    char lname[MAX_STRING_SIZE];
 
-      thr_im = p.get_mythread_lib_image();
-      libc_im = p.get_mylibc_image();
-      rmso_im = p.get_myrmso_image();
+    thr_im = p.get_mythread_lib_image();
+    libc_im = p.get_mylibc_image();
+    rmso_im = p.get_myrmso_image();
 
-      if (!thr_im || !libc_im || !rmso_im)
-        {
-	  {
-	    self_trace_t::trace (true, 
-	      MODULENAME, 0,
-	      "objects for key binary images are not allocated");
-	  }
+    if (!thr_im || !libc_im || !rmso_im) {
+      {
+        self_trace_t::trace(true, MODULENAME, 0,
+                            "objects for key binary images are not allocated");
+      }
 
-          return false;
+      return false;
+    }
+
+    if ((libc_im->get_image_base_address() != SYMTAB_UNINIT_ADDR) &&
+        (thr_im->get_image_base_address() != SYMTAB_UNINIT_ADDR) &&
+        (!p.rmgr()->need_check_launcher_so() ||
+         rmso_im->get_image_base_address() != SYMTAB_UNINIT_ADDR)) {
+      {
+        self_trace_t::trace(LEVELCHK(level3), MODULENAME, 0,
+                            "dependent libraries have been already found.");
+      }
+
+      return false;
+    }
+
+    dynloader_im = p.get_mydynloader_image();
+    const symbol_base_t<T_VA> &r_debug_sym =
+        dynloader_im->get_a_symbol(p.get_loader_r_debug_sym());
+
+    get_tracer()->tracer_read(p, r_debug_sym.get_relocated_address(),
+                              &r_debug_buf, sizeof(struct r_debug), use_cxt);
+
+    assert(r_debug_buf.r_map != 0);
+
+    where_to_read = (T_VA)r_debug_buf.r_map;
+
+    do {
+      get_tracer()->tracer_read(p, where_to_read, &a_map,
+                                sizeof(struct link_map), use_cxt);
+      if (a_map.l_name) {
+        string slname;
+        char *cplname1, *cplname2, *dn, *bn;
+
+        get_tracer()->tracer_read_string(p, (T_VA)(a_map.l_name), lname,
+                                         MAX_STRING_SIZE, use_cxt);
+
+        cplname1 = strdup(lname);
+        cplname2 = strdup(lname);
+        dn = dirname(cplname1);
+        bn = basename(cplname2);
+        slname = lname;
+
+        if (strncmp(LIBPTHREAD_IDEN, bn, strlen(LIBPTHREAD_IDEN)) == 0) {
+          /*
+           * The linked map for the POSIX thread library is found
+           *
+           */
+          if (thr_im->get_image_base_address() == SYMTAB_UNINIT_ADDR) {
+            thr_im->init(slname);
+            thr_im->read_linkage_symbols();
+            thr_im->set_image_base_address(a_map.l_addr);
+            thr_im->compute_reloc();
+
+            rc = true;
+          }
+        } else if (strncmp(LIBC_IDEN, bn, strlen(LIBC_IDEN)) == 0) {
+          /*
+           * The linked map for the C runtime library is found
+           *
+           */
+          if (libc_im->get_image_base_address() == SYMTAB_UNINIT_ADDR) {
+            libc_im->init(slname);
+            libc_im->read_linkage_symbols();
+            libc_im->set_image_base_address(a_map.l_addr);
+            libc_im->compute_reloc();
+          }
+        } else if (p.rmgr()->need_check_launcher_so()) {
+          /*
+           * The linked map for RM SO is found
+           *
+           */
+          std::string rmso = p.rmgr()->get_launcher_so_name();
+          if ((strncmp(rmso.c_str(), bn, rmso.size()) == 0)) {
+            if (rmso_im->get_image_base_address() == SYMTAB_UNINIT_ADDR) {
+              rmso_im->init(slname);
+              rmso_im->read_linkage_symbols();
+              rmso_im->set_image_base_address(a_map.l_addr);
+              rmso_im->compute_reloc();
+
+              //
+              // we want to reset mpir variables because rmso might
+              // hold the actual storage for those variables
+              // and thus variables could have been (re)-initialized
+              // as part of SO init right before this dl breakpoint
+              // is called.
+              //
+              handle_mpir_variables(p, *(p.get_myimage()));
+              p.set_myrmso_image(rmso_im);
+
+              //
+              // Some RM's base image doesn't "define" MPIR_Breakpoint
+              // In that case, we use the same symbol defined within the RM lib.
+              //
+              handle_mpir_variables(p, *(p.get_myrmso_image()));
+            }
+          }
         }
 
-      if ( (libc_im->get_image_base_address() != SYMTAB_UNINIT_ADDR)
-           && (thr_im->get_image_base_address() !=  SYMTAB_UNINIT_ADDR )
-           && (!p.rmgr()->need_check_launcher_so()
-               || rmso_im->get_image_base_address() !=  SYMTAB_UNINIT_ADDR))
-	{
-	  {
-	    self_trace_t::trace ( LEVELCHK(level3), 
-	      MODULENAME, 0,
-	      "dependent libraries have been already found.");
-	  }
+        free(cplname1);
+        free(cplname2);
+      }
 
-	  return false;
-	}
+      where_to_read = (T_VA)a_map.l_next;
 
-      dynloader_im = p.get_mydynloader_image();
-      const symbol_base_t<T_VA>& r_debug_sym
-	    = dynloader_im->get_a_symbol (p.get_loader_r_debug_sym());
+    } while (where_to_read && where_to_read != T_UNINIT_HEX);
 
-      get_tracer()->tracer_read ( p, 
-	r_debug_sym.get_relocated_address(), 
-	&r_debug_buf, 
-	sizeof(struct r_debug),
-	use_cxt);
-
-      assert ( r_debug_buf.r_map != 0 );  
-
-      where_to_read = (T_VA) r_debug_buf.r_map;
-
-    do 
-      {
-	get_tracer()->tracer_read ( p, 
-				    where_to_read, &a_map, 
-				    sizeof(struct link_map),
-				    use_cxt);
-	if (a_map.l_name) 
-	  {
-	    string slname;
-	    char *cplname1, *cplname2, *dn, *bn;
-
-	    get_tracer()->tracer_read_string ( p, 
-	      (T_VA)(a_map.l_name), 
-	      lname, 
-	      MAX_STRING_SIZE,
-	      use_cxt);
-
-	    cplname1 = strdup(lname);
-	    cplname2 = strdup(lname);
-            dn = dirname(cplname1);
-            bn = basename(cplname2);
-	    slname = lname;
-
-	    if ( strncmp(LIBPTHREAD_IDEN,bn,strlen(LIBPTHREAD_IDEN)) == 0 ) 
-              {
-                /*
-                 * The linked map for the POSIX thread library is found
-                 *
-                 */
-                if (thr_im->get_image_base_address() == SYMTAB_UNINIT_ADDR)
-                  {
-                    thr_im->init(slname);
-		    thr_im->read_linkage_symbols();
-	            thr_im->set_image_base_address(a_map.l_addr);
-		    thr_im->compute_reloc(); 
-
-		    rc = true;
-                  }
-	      } 
-	    else if (strncmp(LIBC_IDEN,bn,strlen(LIBC_IDEN)) == 0 ) 
-              {
-                /*
-                 * The linked map for the C runtime library is found
-                 *
-                 */
-                if (libc_im->get_image_base_address() == SYMTAB_UNINIT_ADDR)
-                  {
-                    libc_im->init(slname);
-                    libc_im->read_linkage_symbols();
-                    libc_im->set_image_base_address(a_map.l_addr);	 	
-		    libc_im->compute_reloc();
-                  }
-              }
-            else if ( p.rmgr()->need_check_launcher_so() )
-              {
-                /*
-                 * The linked map for RM SO is found
-                 *
-                 */
-                std::string rmso = p.rmgr()->get_launcher_so_name();
-                if ( (strncmp(rmso.c_str(), bn, rmso.size()) == 0) )
-                  {
-                    if (rmso_im->get_image_base_address() == SYMTAB_UNINIT_ADDR)
-                      {
-                        rmso_im->init(slname);
-                        rmso_im->read_linkage_symbols();
-                        rmso_im->set_image_base_address(a_map.l_addr);
-                        rmso_im->compute_reloc();
-
-                        //
-                        // we want to reset mpir variables because rmso might
-                        // hold the actual storage for those variables 
-                        // and thus variables could have been (re)-initialized 
-                        // as part of SO init right before this dl breakpoint
-                        // is called.
-                        //
-                        handle_mpir_variables(p, *(p.get_myimage()));
-                        p.set_myrmso_image(rmso_im);
-
-
-                        //
-                        // Some RM's base image doesn't "define" MPIR_Breakpoint
-                        // In that case, we use the same symbol defined within the RM lib.  
-                        //
-                        handle_mpir_variables(p, *(p.get_myrmso_image()));
-                      }
-                  }
-              }
-
-            free(cplname1);
-            free(cplname2);
-	  }
-
-	where_to_read =  (T_VA) a_map.l_next;
-
-      } while (where_to_read && where_to_read != T_UNINIT_HEX );
- 
     return rc;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //                                                                //
@@ -1685,38 +1368,31 @@ linux_launchmon_t::check_dependent_SOs (
 //                                                                //
 ////////////////////////////////////////////////////////////////////
 
-//! PUBLIC: 
+//! PUBLIC:
 /*! linux_launchmon_t<> constructors & destructor
 
 
 */
-linux_launchmon_t::linux_launchmon_t () 
-  : MODULENAME(self_trace_t::self_trace().launchmon_module_trace.module_name)
-{
+linux_launchmon_t::linux_launchmon_t()
+    : MODULENAME(
+          self_trace_t::self_trace().launchmon_module_trace.module_name) {
   // more initialization here
 }
 
-
-//! PUBLIC: 
+//! PUBLIC:
 /*! linux_launchmon_t<> constructors & destructor
 
 
 */
-linux_launchmon_t::~linux_launchmon_t ()
-{
-
-}
-
+linux_launchmon_t::~linux_launchmon_t() {}
 
 //! PUBLIC: init
 /*!
-    Method that registers platform specific process/thread 
-    tracers into the platform indepdent layer. It also initializes 
+    Method that registers platform specific process/thread
+    tracers into the platform indepdent layer. It also initializes
     the FE-engine connection in API mode.
 */
-launchmon_rc_e 
-linux_launchmon_t::init ( opts_args_t *opt )
-{
+launchmon_rc_e linux_launchmon_t::init(opts_args_t *opt) {
   launchmon_rc_e lrc;
 
   //
@@ -1733,1828 +1409,1474 @@ linux_launchmon_t::init ( opts_args_t *opt )
   //
   lrc = init_API(opt);
 
-  set_last_seen(gettimeofdayD()); 
+  set_last_seen(gettimeofdayD());
 
   return lrc;
 }
 
-
-
 //! decipher_an_event:
 /*!
-    deciphers an event of debug_event_t and returns a 
+    deciphers an event of debug_event_t and returns a
     corresponding launchmon_event_e code.
 */
-launchmon_event_e 
-linux_launchmon_t::decipher_an_event 
-(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, const debug_event_t &event)
-{
-
+launchmon_event_e linux_launchmon_t::decipher_an_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+    const debug_event_t &event) {
   launchmon_event_e return_ev = LM_INVALID;
   bool use_context = true;
 
-  switch ( event.get_ev () ) {
+  switch (event.get_ev()) {
+    //
+    // all debug events that come from waitpid have to
+    // go through this switch statement.
+    //
 
-  //
-  // all debug events that come from waitpid have to
-  // go through this switch statement.
-  //
-
-  case EV_STOPPED:
-    {
+    case EV_STOPPED: {
       //
       // set the FSM state of the focus thread to STOPPED
       // when a race condition occurs, it will simply print
       // out a warning message. But that kind of race condition
       // will be very very low
       //
-      p.set_lwp_state (LMON_RM_STOPPED, use_context);
-      get_tracer()->tracer_getregs ( p, use_context );
+      p.set_lwp_state(LMON_RM_STOPPED, use_context);
+      get_tracer()->tracer_getregs(p, use_context);
       T_VA pc = p.get_gprset(use_context)->get_pc();
 
       {
-        self_trace_t::trace ( LEVELCHK(level3), 
-	  MODULENAME, 0,
-	  "converting [pc=0x%x] of tid=%d into an debug event.",
-	  pc, p.get_cur_thread_ctx());
+        self_trace_t::trace(
+            LEVELCHK(level3), MODULENAME, 0,
+            "converting [pc=0x%x] of tid=%d into an debug event.", pc,
+            p.get_cur_thread_ctx());
       }
 
-      if ( p.get_never_trapped() )
-        {
+      if (p.get_never_trapped()) {
+        //
+        // This is the first trap ... easy
+        //
+        return_ev = (p.get_myopts()->get_my_opt()->attach)
+                        ? LM_STOP_AT_FIRST_ATTACH
+                        : LM_STOP_AT_FIRST_EXEC;
+      } else if (p.get_please_detach()) {
+        //
+        // This method gives priority to the detach request, thereby
+        // eliminating race conditions that can occur: e.g., a BP stop event
+        // of a process/thread, (not a detach-stop event) after a detach request
+        // is considered to be LM_STOP_FOR_DETACH. It doesn't matter
+        // why p/t stopped once a detach request is made; the detach handler
+        // should be invoked.
+        //
+        return_ev = LM_STOP_FOR_DETACH;
+      } else if (p.get_please_kill()) {
+        //
+        // This method gives priority to the detach request, thereby
+        // eliminating race conditions that can occur: e.g., a BP stop event
+        // of a process/thread, (not a detach-stop event) after a kill request
+        // is considered to be LM_STOP_FOR_KILl. It doesn't matter
+        // why p/t stopped once a kill request is made; the kill handler
+        // should be invoked.
+        //
+        return_ev = LM_STOP_FOR_KILL;
+      } else if (p.get_launch_hidden_bp() &&
+                 (p.get_launch_hidden_bp()->is_pc_part_of_bp_op(pc))) {
+        return_ev = LM_STOP_AT_LAUNCH_BP;
+      } else if (p.get_loader_hidden_bp() &&
+                 (p.get_loader_hidden_bp()->is_pc_part_of_bp_op(pc))) {
+        return_ev = LM_STOP_AT_LOADER_BP;
+      } else if (event.get_signum() == SIGTRAP) {
+        //
+        // Parent gets SIGTRAP when a new thread is created
+        // Used to be: return_ev = LM_STOP_NOT_INTERESTED;
+        int upper16;
+        upper16 = event.get_rawstatus() >> 16;
+        if (upper16 == LINUX_TRACER_EVENT_CLONE) {
+          return_ev = LM_STOP_AT_THREAD_CREATION;
+        } else {
           //
-          // This is the first trap ... easy
+          // SIGTRAP due to fork for example
           //
-	  return_ev = (p.get_myopts()->get_my_opt()->attach )
-	    ? LM_STOP_AT_FIRST_ATTACH
-	    : LM_STOP_AT_FIRST_EXEC;
+          return_ev = LM_STOP_NOT_INTERESTED;
         }
-      else if ( p.get_please_detach()) 
-	{
-          //
-          // This method gives priority to the detach request, thereby
-          // eliminating race conditions that can occur: e.g., a BP stop event 
-          // of a process/thread, (not a detach-stop event) after a detach request 
-          // is considered to be LM_STOP_FOR_DETACH. It doesn't matter 
-          // why p/t stopped once a detach request is made; the detach handler
-          // should be invoked.  
-          //
-	  return_ev = LM_STOP_FOR_DETACH;
-	}
-      else if ( p.get_please_kill ())
-	{
-          //
-          // This method gives priority to the detach request, thereby
-          // eliminating race conditions that can occur: e.g., a BP stop event 
-          // of a process/thread, (not a detach-stop event) after a kill request 
-          // is considered to be LM_STOP_FOR_KILl. It doesn't matter 
-          // why p/t stopped once a kill request is made; the kill handler
-          // should be invoked.  
-          //
-	  return_ev = LM_STOP_FOR_KILL;
-	}
-      else if ( p.get_launch_hidden_bp() 
-	        && ( p.get_launch_hidden_bp()->is_pc_part_of_bp_op(pc)))
-	{
-	  return_ev = LM_STOP_AT_LAUNCH_BP;
-	}
-      else if ( p.get_loader_hidden_bp() 
-                && ( p.get_loader_hidden_bp()->is_pc_part_of_bp_op(pc)))
-	{
-	  return_ev = LM_STOP_AT_LOADER_BP;
-	}
-      else if ( event.get_signum () == SIGTRAP )
-        {
-	  //
-	  // Parent gets SIGTRAP when a new thread is created
-	  // Used to be: return_ev = LM_STOP_NOT_INTERESTED;
-	  int upper16;
-          upper16 = event.get_rawstatus() >> 16; 
-	  if (upper16 == LINUX_TRACER_EVENT_CLONE) 
-            {
-              return_ev = LM_STOP_AT_THREAD_CREATION;
-            }  
-          else
-            {
-              //
-              // SIGTRAP due to fork for example
-              //
-              return_ev = LM_STOP_NOT_INTERESTED;
-            }
+      } else if (event.get_signum() == SIGSTOP) {
+        return_ev = LM_RELAY_SIGNAL;
+
+        if (p.get_thrlist().find(p.get_pid(use_context)) !=
+            p.get_thrlist().end()) {
+          if (!(p.get_thrlist()[p.get_pid(use_context)]->get_traced())) {
+            return_ev = LM_STOP_NEW_THREAD_TRACE;
+          }
+        } else {
+          self_trace_t::trace(true,  // print always
+                              MODULENAME, 0,
+                              "event decode requires a thread data structure "
+                              "already available!");
         }
-      else if ( event.get_signum () == SIGSTOP ) 
-        {
-          return_ev = LM_RELAY_SIGNAL;
+      } else {
+        return_ev = LM_RELAY_SIGNAL;
+      }
+    } break;
 
-          if (p.get_thrlist().find( p.get_pid(use_context) )
-                != p.get_thrlist().end()) 
-            {
-              if (!(p.get_thrlist()[p.get_pid(use_context)]->get_traced()))
-                {
-                  return_ev = LM_STOP_NEW_THREAD_TRACE;
-                }
-            }
-          else
-            {
-              self_trace_t::trace (
-                true, // print always 
-                MODULENAME,
-                0,
-               "event decode requires a thread data structure already available!");
-            }
-        }
-      else 
-        {
-          return_ev = LM_RELAY_SIGNAL;
-        }
-    }
-    break;
+    case EV_EXITED:
+      //
+      // set the FSM state of the focus thread to EXITED
+      //
+      p.set_lwp_state(LMON_RM_EXITED, use_context);
+      return_ev = LM_EXITED;
+      break;
 
-  case EV_EXITED:
-    //
-    // set the FSM state of the focus thread to EXITED
-    //
-    p.set_lwp_state (LMON_RM_EXITED, use_context);
-    return_ev = LM_EXITED;
-    break;
+    case EV_TERMINATED:
+      //
+      // set the FSM state of the focus thread to EXITED
+      //
+      p.set_lwp_state(LMON_RM_EXITED, use_context);
+      return_ev = LM_EXITED;
+      break;
 
-  case EV_TERMINATED:
-    //
-    // set the FSM state of the focus thread to EXITED
-    //
-    p.set_lwp_state (LMON_RM_EXITED, use_context);
-    return_ev = LM_EXITED;
-    break; 
-
-  default:
-    return_ev = LM_INVALID;
-    break;
-  } 
+    default:
+      return_ev = LM_INVALID;
+      break;
+  }
 
   return return_ev;
 }
 
-
 ////////////////////////////////////////////////////////////////////
 //
-// EVENT HANDLERS 
+// EVENT HANDLERS
 //
 //
 
-//! PUBLIC: handle_attach_event 
+//! PUBLIC: handle_attach_event
 /*!
     handles an attach event.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_attach_event
-( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      get_tracer()->tracer_attach(p, false, -1);
-      set_last_seen(gettimeofdayD());
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED; 
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+launchmon_rc_e linux_launchmon_t::handle_attach_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    get_tracer()->tracer_attach(p, false, -1);
+    set_last_seen(gettimeofdayD());
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_trap_after_attach_event
 /*!
     handles a trap-after-attach event.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_trap_after_attach_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{ 
-  try 
-    {    
-      using namespace std; 
+launchmon_rc_e linux_launchmon_t::handle_trap_after_attach_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 
 #if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD ();
-      {
-        self_trace_t::trace ( 
-          true, // print always 
-          MODULENAME,
-          0,
-          "The RM process has just been trapped due to attach"); 
-      }
+    beginTS = gettimeofdayD();
+    {
+      self_trace_t::trace(true,  // print always
+                          MODULENAME, 0,
+                          "The RM process has just been trapped due to attach");
+    }
 #endif
 
-      bool use_cxt = true;
-      image_base_t<T_VA,elf_wrapper> *dynloader_im = NULL;
-      image_base_t<T_VA,elf_wrapper> *main_im = NULL;  
-      breakpoint_base_t<T_VA, T_IT> *lo_bp = NULL;
-      breakpoint_base_t<T_VA, T_IT> *la_bp = NULL;
-      int bdbg = 1;
-      T_VA lpc = T_UNINIT_HEX;
-      T_VA debug_state_flag = T_UNINIT_HEX;
-      T_VA debug_state_addr = T_UNINIT_HEX;
-      T_VA addr_dl_bp = T_UNINIT_HEX;
+    bool use_cxt = true;
+    image_base_t<T_VA, elf_wrapper> *dynloader_im = NULL;
+    image_base_t<T_VA, elf_wrapper> *main_im = NULL;
+    breakpoint_base_t<T_VA, T_IT> *lo_bp = NULL;
+    breakpoint_base_t<T_VA, T_IT> *la_bp = NULL;
+    int bdbg = 1;
+    T_VA lpc = T_UNINIT_HEX;
+    T_VA debug_state_flag = T_UNINIT_HEX;
+    T_VA debug_state_addr = T_UNINIT_HEX;
+    T_VA addr_dl_bp = T_UNINIT_HEX;
 
-      {
-	self_trace_t::trace ( 
-          LEVELCHK(level2), 
-	  MODULENAME,
-          0,
-	  " trap after attach event handler invoked. ");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          " trap after attach event handler invoked. ");
+    }
 
-      main_im  = p.get_myimage();
-      if ( !main_im )
-	{
-	  self_trace_t::trace ( 
-            LEVELCHK(level1), 
-            MODULENAME,
-            1,
-	    "main image is null.");
-				
-	  return LAUNCHMON_FAILED;
-	}
-      
-      dynloader_im = p.get_mydynloader_image();
-      if ( !dynloader_im )
-      {
-	self_trace_t::trace ( 
-          LEVELCHK(level1), 
-	  MODULENAME,
-          1,
-	  "dynamic loader image is null.");
-			      
-	return LAUNCHMON_FAILED;
-      }      
+    main_im = p.get_myimage();
+    if (!main_im) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "main image is null.");
 
-      main_im->set_image_base_address(0);
-      main_im->compute_reloc();
+      return LAUNCHMON_FAILED;
+    }
 
-      //
-      // handle_mpir_variables method requires main image has been relocated
-      // (though this is meaningless almost all platforms
-      handle_mpir_variables(p, *main_im); 
+    dynloader_im = p.get_mydynloader_image();
+    if (!dynloader_im) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "dynamic loader image is null.");
 
-      lpc = get_va_from_procfs ( p.get_master_thread_pid(), 
-				 dynloader_im->get_base_image_name() );
+      return LAUNCHMON_FAILED;
+    }
 
-      if ( (lpc = get_auxv (p.get_master_thread_pid()) ) == T_UNINIT_HEX)
-      {
-	 lpc = get_va_from_procfs ( p.get_master_thread_pid(), 
-		 dynloader_im->get_base_image_name() );
-      }
-      
-      if ( lpc == T_UNINIT_HEX )
-      {
-	self_trace_t::trace ( 
-          LEVELCHK(level1), 
-	  MODULENAME,
-          1,
-	  "can't resolve the base address of the loader.");
-			      
-	return LAUNCHMON_FAILED;
-      }	
-      
-      dynloader_im->set_image_base_address(lpc);
-      dynloader_im->compute_reloc();
+    main_im->set_image_base_address(0);
+    main_im->compute_reloc();
 
-      // registering p.loader_hidden_bp. 
-      // 
-      const symbol_base_t<T_VA>& dynload_sym 
-	    = dynloader_im->get_a_symbol (p.get_loader_breakpoint_sym());   
+    //
+    // handle_mpir_variables method requires main image has been relocated
+    // (though this is meaningless almost all platforms
+    handle_mpir_variables(p, *main_im);
 
-      lo_bp = new linux_breakpoint_t();
-      addr_dl_bp = dynload_sym.get_relocated_address();
-      lo_bp->set_address_at ( addr_dl_bp );
+    lpc = get_va_from_procfs(p.get_master_thread_pid(),
+                             dynloader_im->get_base_image_name());
+
+    if ((lpc = get_auxv(p.get_master_thread_pid())) == T_UNINIT_HEX) {
+      lpc = get_va_from_procfs(p.get_master_thread_pid(),
+                               dynloader_im->get_base_image_name());
+    }
+
+    if (lpc == T_UNINIT_HEX) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "can't resolve the base address of the loader.");
+
+      return LAUNCHMON_FAILED;
+    }
+
+    dynloader_im->set_image_base_address(lpc);
+    dynloader_im->compute_reloc();
+
+    // registering p.loader_hidden_bp.
+    //
+    const symbol_base_t<T_VA> &dynload_sym =
+        dynloader_im->get_a_symbol(p.get_loader_breakpoint_sym());
+
+    lo_bp = new linux_breakpoint_t();
+    addr_dl_bp = dynload_sym.get_relocated_address();
+    lo_bp->set_address_at(addr_dl_bp);
 #if PPC_ARCHITECTURE
-      lo_bp->set_use_indirection();
+    lo_bp->set_use_indirection();
 #endif
-      lo_bp->set();
+    lo_bp->set();
 
-      p.set_loader_hidden_bp(lo_bp);
-      get_tracer()->enable_breakpoint (p, 
-				       (*p.get_loader_hidden_bp()),
-				       use_cxt );
+    p.set_loader_hidden_bp(lo_bp);
+    get_tracer()->enable_breakpoint(p, (*p.get_loader_hidden_bp()), use_cxt);
 
-      check_dependent_SOs(p);
-      p.set_never_trapped(false); 
+    check_dependent_SOs(p);
+    p.set_never_trapped(false);
 
-      if (p.rmgr()->is_coloc_sup())
-        {
-          if (p.rmgr()->is_attfifo_sup())
-            {
-              if (p.get_sym_attach_fifo())
-                {
-                  //
-                  // MPIR_attach_fifo support is only applicable to attach mode.
-                  // 
-                  char fifopathbuf[256]; 
-                  T_VA fifo_addr = p.get_sym_attach_fifo()->get_relocated_address();
-                  get_tracer()->tracer_read_string(p, 
-                                               fifo_addr,
-				               (void*) fifopathbuf,
-				               256,
-				               use_cxt);
-                  std::string fip = fifopathbuf;
-                  p.rmgr()->set_attach_fifo_path(fip);
+    if (p.rmgr()->is_coloc_sup()) {
+      if (p.rmgr()->is_attfifo_sup()) {
+        if (p.get_sym_attach_fifo()) {
+          //
+          // MPIR_attach_fifo support is only applicable to attach mode.
+          //
+          char fifopathbuf[256];
+          T_VA fifo_addr = p.get_sym_attach_fifo()->get_relocated_address();
+          get_tracer()->tracer_read_string(p, fifo_addr, (void *)fifopathbuf,
+                                           256, use_cxt);
+          std::string fip = fifopathbuf;
+          p.rmgr()->set_attach_fifo_path(fip);
 
-	          //
-	          // We have to continue the target process before starting FIFO
-	          // otherwise open on the FIFO will block
-	          //
-	          get_tracer()->tracer_continue (p, use_cxt);
-                  int fifofd = 0;
-                  if ( (fifofd = open(fifopathbuf, O_WRONLY)) >= 0)
-                    {
-                      char wakeup = (char) 1; 
-                      if ( lmon_write_raw(fifofd, &wakeup, 1) != 1 )
-                        {
-                          self_trace_t::trace(
-                            true,  
-                            MODULENAME,
-                            0,
-                            "lmon_write_raw returned a value that is not equal to 1");
-                        }
-                      close(fifofd);
-                    }
-                  else
-                    {
-                      self_trace_t::trace(
-                        true,  
-                        MODULENAME,
-                        0,
-                        "Open a FIFO (%s) failed, errno(%d)", fifopathbuf, errno);
-                    } 
-                } 
-              else
-                {
-                  self_trace_t::trace(
-                    true,  
-                    MODULENAME,
-                    0,
-                    "MPIR_attach_fifo symbol not found");
-                } 
-            } 
-          else
-            {
-	      get_tracer()->tracer_continue (p, use_cxt);
+          //
+          // We have to continue the target process before starting FIFO
+          // otherwise open on the FIFO will block
+          //
+          get_tracer()->tracer_continue(p, use_cxt);
+          int fifofd = 0;
+          if ((fifofd = open(fifopathbuf, O_WRONLY)) >= 0) {
+            char wakeup = (char)1;
+            if (lmon_write_raw(fifofd, &wakeup, 1) != 1) {
+              self_trace_t::trace(
+                  true, MODULENAME, 0,
+                  "lmon_write_raw returned a value that is not equal to 1");
             }
-        } // With MPIR Colocation service
-      else
-        {
-           bool ptab_ready = true;
-           //
-           // Some RMs will build the Proctable on demand. If so, we may need to
-           // continue until the MPIR_Breakpoint is hit.
-           //
-           if (p.rmgr()->is_cont_on_att())
-             {
-               if (continue_on_attach ( p, use_cxt ))
-                 {
-                   ptab_ready = false;
-                 }
-             }
-           // If the proctable was already built, we do not want to continue,
-           // instead we can read it right away.
-           if (ptab_ready)
-             {
-               //
-               // Without MPIR Colocation service, you would have
-               // Proctable available on attach and you would be 
-               // ready to launch daemon at this point
-               // 
-               // 
-               acquire_proctable ( p, use_cxt );
-               ship_proctab_msg ( lmonp_proctable_avail );
-               ship_resourcehandle_msg ( lmonp_resourcehandle_avail, get_resid() );
-               ship_rminfo_msg ( lmonp_rminfo,
-                                 (int) p.get_pid(false),
-                                 p.rmgr()->get_resource_manager().get_rm());
-               say_fetofe_msg ( lmonp_stop_at_first_attach );
-               launch_tool_daemons(p);
-               get_tracer()->tracer_continue (p, use_cxt);
-             }
-         }
+            close(fifofd);
+          } else {
+            self_trace_t::trace(true, MODULENAME, 0,
+                                "Open a FIFO (%s) failed, errno(%d)",
+                                fifopathbuf, errno);
+          }
+        } else {
+          self_trace_t::trace(true, MODULENAME, 0,
+                              "MPIR_attach_fifo symbol not found");
+        }
+      } else {
+        get_tracer()->tracer_continue(p, use_cxt);
+      }
+    }  // With MPIR Colocation service
+    else {
+      bool ptab_ready = true;
+      //
+      // Some RMs will build the Proctable on demand. If so, we may need to
+      // continue until the MPIR_Breakpoint is hit.
+      //
+      if (p.rmgr()->is_cont_on_att()) {
+        if (continue_on_attach(p, use_cxt)) {
+          ptab_ready = false;
+        }
+      }
+      // If the proctable was already built, we do not want to continue,
+      // instead we can read it right away.
+      if (ptab_ready) {
+        //
+        // Without MPIR Colocation service, you would have
+        // Proctable available on attach and you would be
+        // ready to launch daemon at this point
+        //
+        //
+        acquire_proctable(p, use_cxt);
+        ship_proctab_msg(lmonp_proctable_avail);
+        ship_resourcehandle_msg(lmonp_resourcehandle_avail, get_resid());
+        ship_rminfo_msg(lmonp_rminfo, (int)p.get_pid(false),
+                        p.rmgr()->get_resource_manager().get_rm());
+        say_fetofe_msg(lmonp_stop_at_first_attach);
+        launch_tool_daemons(p);
+        get_tracer()->tracer_continue(p, use_cxt);
+      }
+    }
 
-      {
-        self_trace_t::trace ( 
-          LEVELCHK(level2), 
-          MODULENAME,
-          0,
-	      "trap after attach event handler completed.");
-      }
-  
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "trap after attach event handler completed.");
+    }
+
 #if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-      // accum and countHandler now contain the cost of this handler which 
-      // is invoked just once per job
-      {
-        self_trace_t::trace ( 
-          true, // print always 
-          MODULENAME, 
-          0,
-          "Just continued the RM process out of the first trap"); 
-      }
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+    // accum and countHandler now contain the cost of this handler which
+    // is invoked just once per job
 #endif
 
-      set_last_seen (gettimeofdayD ());
+    {
+      self_trace_t::trace(
+          true,  // print always
+          MODULENAME, 0, "Just continued the RM process out of the first trap");
+    }
 
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+    set_last_seen(gettimeofdayD());
+
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_trap_after_exec_event
 /*!
-    handles the first fork/exec-trap event.  
+    handles the first fork/exec-trap event.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_trap_after_exec_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_trap_after_exec_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 
 #if MEASURE_TRACING_COST
-     beginTS = gettimeofdayD ();
-     {
-       self_trace_t::trace ( 
-         true, // print always 
-         MODULENAME,
-         0,
-         "The RM process has just been forked and exec'ed.");
-     }
+    beginTS = gettimeofdayD();
 #endif
 
-      bool use_cxt = true;
-      image_base_t<T_VA,elf_wrapper> *main_im, *dynloader_im;
-      breakpoint_base_t<T_VA, T_IT> *lo_bp;
-      T_VA addr_dl_start, dl_linked_addr, addr_dl_bp;
+    {
+      self_trace_t::trace(true,  // print always
+                          MODULENAME, 0,
+                          "The RM process has just been forked and exec'ed.");
+    }
 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-          MODULENAME,0,
-	  "trap after first exec event handler invoked.");
-      }
+    bool use_cxt = true;
+    image_base_t<T_VA, elf_wrapper> *main_im, *dynloader_im;
+    breakpoint_base_t<T_VA, T_IT> *lo_bp;
+    T_VA addr_dl_start, dl_linked_addr, addr_dl_bp;
 
-      main_im  = p.get_myimage();
-      if ( !main_im )
-	{
-	  self_trace_t::trace ( LEVELCHK(level1), 
-	    MODULENAME,1,
-	    "main image is null.");
-				
-	  return LAUNCHMON_FAILED;
-	}
-      
-      dynloader_im = p.get_mydynloader_image();
-      if ( !dynloader_im )
-      {
-	self_trace_t::trace ( LEVELCHK(level1), 
-	  MODULENAME,1,
-	  "dynamic loader image is null.");
-			      
-	return LAUNCHMON_FAILED;
-      }    
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "trap after first exec event handler invoked.");
+    }
 
-      main_im->set_image_base_address(0);
-      main_im->compute_reloc();
+    main_im = p.get_myimage();
+    if (!main_im) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "main image is null.");
 
-      //
-      // handle_mpir_variables method requires main image has been relocated
-      // (though this is meaningless almost all platforms
-      handle_mpir_variables(p, *main_im); 
+      return LAUNCHMON_FAILED;
+    }
 
-      //
-      // computing where the dynamic loader was linked and 
-      // registering p.loader_hidden_bp 
-      const symbol_base_t<T_VA>& dynload_sym 
-	= dynloader_im->get_a_symbol (p.get_loader_breakpoint_sym());  
+    dynloader_im = p.get_mydynloader_image();
+    if (!dynloader_im) {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "dynamic loader image is null.");
 
-      if ( (dl_linked_addr = get_auxv (p.get_pid (true)) ) == T_UNINIT_HEX)
-        {
-	  //
-	  // Corner case; we deal with a heuristics
-	  //
+      return LAUNCHMON_FAILED;
+    }
+
+    main_im->set_image_base_address(0);
+    main_im->compute_reloc();
+
+    //
+    // handle_mpir_variables method requires main image has been relocated
+    // (though this is meaningless almost all platforms
+    handle_mpir_variables(p, *main_im);
+
+    //
+    // computing where the dynamic loader was linked and
+    // registering p.loader_hidden_bp
+    const symbol_base_t<T_VA> &dynload_sym =
+        dynloader_im->get_a_symbol(p.get_loader_breakpoint_sym());
+
+    if ((dl_linked_addr = get_auxv(p.get_pid(true))) == T_UNINIT_HEX) {
+//
+// Corner case; we deal with a heuristics
+//
 #if PPC_ARCHITECTURE
-          //
-          // DHA Mar 05 2009
-	  // There're systems that do not directly 
-	  // export function symbols, and the original logic 
-	  // to determining the base linked address of the runtime 
-	  // linker maps has some problems. 
-	  // Specifically, one must know the relative function address of 
-	  // _start to compute the linked addrss, but the system 
-	  // that only allows indirection to get this function address 
-	  // won't provide that without
-	  // having to collect that info from the memory. Now,
-	  // collecting this from the mem isn't possible 
-	  // for symbols within the runtime linker until
-	  // the base mapped address for the linker is determined.
-	  // Egg-and-Chicken problem. 
-	  //
-	  // In such a system, we use a hack assuming the runtime
-	  // linker is mapped to an address aligned in some multiple pages, 
-	  // which insn't too outragous to assume. 
-	  //
-	  
-	  dl_linked_addr
-# if BIT64
-	    =  p.get_gprset(use_cxt)->get_pc() & 0xffffffffff0000;
-# else
-	    =  p.get_gprset(use_cxt)->get_pc() & 0xffff0000;
-# endif
-#else /* PPC_ARCHITECTURE */
-          //
-          // This requires the actual page size to compute this loader load
-          // address implictly. Just using the following bits for now.  
-          //
-	  dl_linked_addr
+      //
+      // DHA Mar 05 2009
+      // There're systems that do not directly
+      // export function symbols, and the original logic
+      // to determining the base linked address of the runtime
+      // linker maps has some problems.
+      // Specifically, one must know the relative function address of
+      // _start to compute the linked addrss, but the system
+      // that only allows indirection to get this function address
+      // won't provide that without
+      // having to collect that info from the memory. Now,
+      // collecting this from the mem isn't possible
+      // for symbols within the runtime linker until
+      // the base mapped address for the linker is determined.
+      // Egg-and-Chicken problem.
+      //
+      // In such a system, we use a hack assuming the runtime
+      // linker is mapped to an address aligned in some multiple pages,
+      // which insn't too outragous to assume.
+      //
+
+      dl_linked_addr
 #if BIT64
-	    =  p.get_gprset(use_cxt)->get_pc() & 0xfffffffffff000;
+          = p.get_gprset(use_cxt)->get_pc() & 0xffffffffff0000;
 #else
-	    =  p.get_gprset(use_cxt)->get_pc() & 0xfffff000;
+          = p.get_gprset(use_cxt)->get_pc() & 0xffff0000;
+#endif
+#else /* PPC_ARCHITECTURE */
+      //
+      // This requires the actual page size to compute this loader load
+      // address implictly. Just using the following bits for now.
+      //
+      dl_linked_addr
+#if BIT64
+          = p.get_gprset(use_cxt)->get_pc() & 0xfffffffffff000;
+#else
+          = p.get_gprset(use_cxt)->get_pc() & 0xfffff000;
 #endif
 #endif
-        }
-  
-      dynloader_im->set_image_base_address(dl_linked_addr);
-      dynloader_im->compute_reloc();
+    }
 
-      lo_bp = new linux_breakpoint_t();
-      addr_dl_bp = dynload_sym.get_relocated_address();
-      lo_bp->set_address_at ( addr_dl_bp );
-      
+    dynloader_im->set_image_base_address(dl_linked_addr);
+    dynloader_im->compute_reloc();
+
+    lo_bp = new linux_breakpoint_t();
+    addr_dl_bp = dynload_sym.get_relocated_address();
+    lo_bp->set_address_at(addr_dl_bp);
+
 #if PPC_ARCHITECTURE
-      lo_bp->set_use_indirection();
-      T_VA adjusted_indirect_addr; 
-      //
-      // This is A special case because the loader hasn't had
-      // a chance even to relocate its own symbols... 
-      //
-      get_tracer()->tracer_read (p,
-	addr_dl_bp,
-	&adjusted_indirect_addr,
-	sizeof(T_VA),
-	use_cxt);
+    lo_bp->set_use_indirection();
+    T_VA adjusted_indirect_addr;
+    //
+    // This is A special case because the loader hasn't had
+    // a chance even to relocate its own symbols...
+    //
+    get_tracer()->tracer_read(p, addr_dl_bp, &adjusted_indirect_addr,
+                              sizeof(T_VA), use_cxt);
 
-      lo_bp->set_indirect_address_at(adjusted_indirect_addr + dl_linked_addr);
+    lo_bp->set_indirect_address_at(adjusted_indirect_addr + dl_linked_addr);
 #endif
-      lo_bp->set();
+    lo_bp->set();
 
-      p.set_loader_hidden_bp(lo_bp);
-      get_tracer()->enable_breakpoint(p,
-				      (*p.get_loader_hidden_bp()),
-				      use_cxt );
+    p.set_loader_hidden_bp(lo_bp);
+    get_tracer()->enable_breakpoint(p, (*p.get_loader_hidden_bp()), use_cxt);
 
-      // now this process has get past the first fork/exec
-      //
-      p.set_never_trapped ( false );
+    // now this process has get past the first fork/exec
+    //
+    p.set_never_trapped(false);
 
-      get_tracer()->tracer_setoptions (p, use_cxt, -1);
+    get_tracer()->tracer_setoptions(p, use_cxt, -1);
 
-      get_tracer()->tracer_continue (p, use_cxt);
- 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "trap after first exec event handler completed.");
-      }
+    get_tracer()->tracer_continue(p, use_cxt);
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "trap after first exec event handler completed.");
+    }
 
 #if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-      // accum and countHandler now contain the cost of this handler which 
-      // is invoked just once per job
-      {
-        self_trace_t::trace ( true, // print always 
-          MODULENAME,0,
-          "Just continued the RM process out of the first trap"); 
-      }
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+    // accum and countHandler now contain the cost of this handler which
+    // is invoked just once per job
 #endif
 
-      set_last_seen (gettimeofdayD ());
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
     {
-      e.report();
-      abort();
+      self_trace_t::trace(
+          true,  // print always
+          MODULENAME, 0, "Just continued the RM process out of the first trap");
     }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-}
 
+    set_last_seen(gettimeofdayD());
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    abort();
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
+}
 
 //! PUBLIC: handle_launch_bp_event
 /*!
     The event handler for a launch breakpoint hit event.
     Most RM MPIR APAI implementations use MPIR_Breakpoint for this.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_launch_bp_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_launch_bp_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 #if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD ();
+    beginTS = gettimeofdayD();
 #endif
-      launchmon_rc_e lrc = LAUNCHMON_OK;
-      bool use_cxt = true;
-      image_base_t<T_VA,elf_wrapper> *main_im;
-      T_VA debug_state_addr;
-      int bdbg, bdbgp;
-  
-      if (!(is_bp_prologue_done(p, p.get_launch_hidden_bp()))) {
+    launchmon_rc_e lrc = LAUNCHMON_OK;
+    bool use_cxt = true;
+    image_base_t<T_VA, elf_wrapper> *main_im;
+    T_VA debug_state_addr;
+    int bdbg, bdbgp;
+
+    if (!(is_bp_prologue_done(p, p.get_launch_hidden_bp()))) {
 #if MEASURE_TRACING_COST
-        endTS = gettimeofdayD ();
-        accum += endTS - beginTS;
-	countHandler++;
-#endif
-	return LAUNCHMON_OK;
-      }
-
-#if MEASURE_TRACING_COST
-      {
-        self_trace_t::trace ( 
-          true, /* print always */
-	  MODULENAME,
-          0,
-	  "launch-breakpoint hit event handler invoked.");
-      }
-#endif
-      {
-        self_trace_t::trace ( 
-          LEVELCHK(level2),
-	  MODULENAME,
-          0,
-	  "launch-breakpoint hit event handler invoked.");
-      }
-
-      main_im  = p.get_myimage();  
-      if (!main_im)
-        {
-          self_trace_t::trace ( true, /* print always */
-	    MODULENAME,0,
-	    "main image has not been processed.");
-
-          return LAUNCHMON_FAILED;
-        }
-
-      //
-      // looking up MPIR_debug_state
-      //
-      symbol_base_t<T_VA> debug_state_var 
-	    = main_im->get_a_symbol (p.get_launch_debug_state());
-      if (!debug_state_var && p.get_myrmso_image())
-        {
-          debug_state_var 
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_debug_state());
-        }
-
-      debug_state_addr = debug_state_var.get_relocated_address(); 
-      get_tracer()->tracer_read ( p, 
-				  debug_state_addr,
-				  &bdbg,
-				  sizeof(bdbg),
-				  use_cxt );
-      symbol_base_t<T_VA> debug_state
-            = main_im->get_a_symbol (p.get_launch_being_debug());
-      if (!debug_state && p.get_myrmso_image())
-        {
-          debug_state
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
-        }
-
-#if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
+      endTS = gettimeofdayD();
       accum += endTS - beginTS;
       countHandler++;
 #endif
-      
-      //
-      // MPIR_debug_state 
-      //
-      //
-      if (!validate_mpir_state_transition(bdbg))
-        {
-	  self_trace_t::trace ( 
-            LEVELCHK(level2), 
-	    MODULENAME,0,
-	    "MPIR state transition is invalid! continue...");
+      return LAUNCHMON_OK;
+    }
 
-          //
-          // if state transition isn't valid, simply continue
-          //
-          get_tracer()->tracer_continue (p, use_cxt);
-        }
-      else
-        {
-          switch ( bdbg )
-	    {
-	    case MPIR_DEBUG_SPAWNED:
-              {
-	        //
-	        // Apparently, MPI tasks have just been spawned.
-	        //   We want to acquire RPDTAB and the resource ID, 
-	        //   and to pass those along to the FE client. 
-	        //   Subsequently, we want to launch the specified tool 
-                //   daemons before let go of the RM process.
-	        //
-	        {
-	          self_trace_t::trace ( 
-                    LEVELCHK(level2), 
-		    MODULENAME,0,
-	            "launch-breakpoint hit event handler completing with MPIR_DEBUG_SPAWNED");
-	        }
-	        acquire_proctable ( p, use_cxt );
-	        ship_proctab_msg ( lmonp_proctable_avail );
-	        ship_resourcehandle_msg ( lmonp_resourcehandle_avail, get_resid() );
-	        ship_rminfo_msg ( lmonp_rminfo, 
-		  	          (int) p.get_pid(false), 
-			          p.rmgr()->get_resource_manager().get_rm());
-	        say_fetofe_msg ( lmonp_stop_at_launch_bp_spawned );
-
-    	        launch_tool_daemons(p);
-
-                set_engine_state(bdbg);
-
-                if (get_API_mode())
-                  {
-                    p.get_thrlist()[p.get_cur_thread_ctx()]->set_event_registered ( true );
-                    // shouldn't continue this eventing thread 
-                    // if the engine is drived via API 
-                    // until all set up is done and FEN sends the "unlock" command.
-                  } 
-                else
-                  { 
-	            get_tracer()->tracer_continue (p, use_cxt);
-                  }
-	        break;
-              }
-	    case MPIR_DEBUG_ABORTING:
-              {
-	        //
-	        // Apparently, MPI tasks have just been aborted, 
-                //   either normally or abnormally.
-                //   We want to pass this along to the FE client, 
-	        //   to notify the RM launcher of the upcoming detach via 
-                //   the MPIR_being_debugged, to disinsert all breakpoints, and to 
-	        //   actually issue a detach command to the RM process.
-	        //
-                int bdbg = 0;
-                T_VA debug_state_flag = T_UNINIT_HEX;
-
-	        {
-	          self_trace_t::trace ( LEVELCHK(level2), 
-		    MODULENAME,0,
-	            "launch-breakpoint hit event handler completing with MPIR_DEBUG_ABORTING");
-                }
-
-                //
-                // disable all the hidden breakpoints. Since we don't     
-                // know if the context is slave or main thread, we have to 
-                // pass true 
-                disable_all_BPs (p, true);
-
-                //
-                // unsetting "MPIR_being_debugged."
-                //
-                //const symbol_base_t<T_VA>& being_debugged
-                //  = p.get_myimage()->get_a_symbol (p.get_launch_being_debug());
-
-                get_tracer()->tracer_write ( p,
-                                  debug_state.get_relocated_address(),
-                                  &bdbg,
-                                  sizeof(bdbg),
-                                  true );
-
-                //
-                // detach from all slave threads.
-                //
-                for ( p.thr_iter = p.get_thrlist().begin();
-                        p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-                  {
-                    if ( !(p.thr_iter->second->is_master_thread()) )
-                      {
-                        // operates on a slave thread
-                        p.make_context ( p.thr_iter->first );
-                        if (get_tracer()->status(p, true) == SDBG_TRACE_STOPPED)
-                          {
-                            get_tracer()->tracer_detach ( p, true );
-                          }
-                        p.check_and_undo_context ( p.thr_iter->first );
-                      }
-                  }
-
-                self_trace_t::trace ( 
-                  LEVELCHK(level1),
-                  MODULENAME,
-                  0,
-                  "detached from all threads of the RM process...");
-
-                //
-                // detach from the main thread
-                //
-                if (get_tracer()->status(p, false) == SDBG_TRACE_STOPPED)
-                  {
-                    get_tracer()->tracer_detach ( p, false );
-                  }
-
-                self_trace_t::trace ( 
-                  LEVELCHK(level1),
-                  MODULENAME,
-                  0,
-                  "detached from all the RM process...");
-
-                set_engine_state(bdbg);
-                say_fetofe_msg(lmonp_stop_at_launch_bp_abort);
-
- 	        //
- 	        // this return code will cause the engine to exit.
- 	        // but it should leave its children RM_daemon process
- 	        // in a running state.
- 	        //
- 	        lrc = LAUNCHMON_MPIR_DEBUG_ABORT;
-
-	        {
-	          self_trace_t::trace ( 
-                    LEVELCHK(level2),
-		    MODULENAME,0,
-	            "launch-breakpoint hit event handler "
-                    "completing with MPIR_DEBUG_ABORTING");
-	        }
-	        break; 
-	      }
-            case MPIR_NULL:
-              {
-	        {
-	          self_trace_t::trace ( 
-                    LEVELCHK(level2), 
-		    MODULENAME,0,
-	            "launch-breakpoint hit event handler "
-                    "completing with MPIR_NULL");
-	        }
-                set_engine_state(bdbg);
-	        get_tracer()->tracer_continue (p, use_cxt);
-                break;
-              }
-	    default:
-	      {
-	        {
-	          self_trace_t::trace ( LEVELCHK(level2), 
-		    MODULENAME,0,
-	            "launch-breakpoint hit event handler "
-                    "completing with unknown debug state");
-	        }
-                set_engine_state(bdbg);
-	        get_tracer()->tracer_continue (p, use_cxt);
-	        break;
-	      }
-	    }
-        }
-
-      set_last_seen (gettimeofdayD ());
-
-      return lrc;
-  }
-  catch ( symtab_exception_t e ) 
     {
-      e.report();
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "launch-breakpoint hit event handler invoked.");
+    }
+
+    main_im = p.get_myimage();
+    if (!main_im) {
+      self_trace_t::trace(true, /* print always */
+                          MODULENAME, 0, "main image has not been processed.");
+
       return LAUNCHMON_FAILED;
     }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
+
+    //
+    // looking up MPIR_debug_state
+    //
+    symbol_base_t<T_VA> debug_state_var =
+        main_im->get_a_symbol(p.get_launch_debug_state());
+    if (!debug_state_var && p.get_myrmso_image()) {
+      debug_state_var =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_debug_state());
     }
-}
 
+    debug_state_addr = debug_state_var.get_relocated_address();
+    get_tracer()->tracer_read(p, debug_state_addr, &bdbg, sizeof(bdbg),
+                              use_cxt);
+    symbol_base_t<T_VA> debug_state =
+        main_im->get_a_symbol(p.get_launch_being_debug());
+    if (!debug_state && p.get_myrmso_image()) {
+      debug_state =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
+    }
 
-//! PUBLIC: handle_detach_cmd_event 
-/*!
-    handles "detach-command" event.  
-*/
-launchmon_rc_e 
-linux_launchmon_t::handle_detach_cmd_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try
-    {
-      int bdbg = 0;
-      T_VA debug_state_flag = T_UNINIT_HEX;
+#if MEASURE_TRACING_COST
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+#endif
+
+    //
+    // MPIR_debug_state
+    //
+    //
+    if (!validate_mpir_state_transition(bdbg)) {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "MPIR state transition is invalid! continue...");
 
       //
-      // disable all the hidden breakpoints	
+      // if state transition isn't valid, simply continue
       //
-      disable_all_BPs (p, false);      
+      get_tracer()->tracer_continue(p, use_cxt);
+    } else {
+      switch (bdbg) {
+        case MPIR_DEBUG_SPAWNED: {
+          //
+          // Apparently, MPI tasks have just been spawned.
+          //   We want to acquire RPDTAB and the resource ID,
+          //   and to pass those along to the FE client.
+          //   Subsequently, we want to launch the specified tool
+          //   daemons before let go of the RM process.
+          //
+          {
+            self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                "launch-breakpoint hit event handler "
+                                "completing with MPIR_DEBUG_SPAWNED");
+          }
+          acquire_proctable(p, use_cxt);
+          ship_proctab_msg(lmonp_proctable_avail);
+          ship_resourcehandle_msg(lmonp_resourcehandle_avail, get_resid());
+          ship_rminfo_msg(lmonp_rminfo, (int)p.get_pid(false),
+                          p.rmgr()->get_resource_manager().get_rm());
+          say_fetofe_msg(lmonp_stop_at_launch_bp_spawned);
 
-      //
-      // detach from all slave threads.
-      //
-      for ( p.thr_iter = p.get_thrlist().begin(); 
-	      p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-        {
-	  if ( !(p.thr_iter->second->is_master_thread()) ) 
-            {
+          launch_tool_daemons(p);
+
+          set_engine_state(bdbg);
+
+          if (get_API_mode()) {
+            p.get_thrlist()[p.get_cur_thread_ctx()]->set_event_registered(true);
+            // shouldn't continue this eventing thread
+            // if the engine is drived via API
+            // until all set up is done and FEN sends the "unlock" command.
+          } else {
+            get_tracer()->tracer_continue(p, use_cxt);
+          }
+          break;
+        }
+        case MPIR_DEBUG_ABORTING: {
+          //
+          // Apparently, MPI tasks have just been aborted,
+          //   either normally or abnormally.
+          //   We want to pass this along to the FE client,
+          //   to notify the RM launcher of the upcoming detach via
+          //   the MPIR_being_debugged, to disinsert all breakpoints, and to
+          //   actually issue a detach command to the RM process.
+          //
+          int bdbg = 0;
+          T_VA debug_state_flag = T_UNINIT_HEX;
+
+          {
+            self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                "launch-breakpoint hit event handler "
+                                "completing with MPIR_DEBUG_ABORTING");
+          }
+
+          //
+          // disable all the hidden breakpoints. Since we don't
+          // know if the context is slave or main thread, we have to
+          // pass true
+          disable_all_BPs(p, true);
+
+          //
+          // unsetting "MPIR_being_debugged."
+          //
+          // const symbol_base_t<T_VA>& being_debugged
+          //  = p.get_myimage()->get_a_symbol (p.get_launch_being_debug());
+
+          get_tracer()->tracer_write(p, debug_state.get_relocated_address(),
+                                     &bdbg, sizeof(bdbg), true);
+
+          //
+          // detach from all slave threads.
+          //
+          for (p.thr_iter = p.get_thrlist().begin();
+               p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+            if (!(p.thr_iter->second->is_master_thread())) {
               // operates on a slave thread
-              p.make_context ( p.thr_iter->first );
-              get_tracer()->tracer_unsetoptions ( p, true, -1 );
-              get_tracer()->tracer_detach ( p, true ); 
-              p.check_and_undo_context ( p.thr_iter->first );
-	    }
-	}
-
-       self_trace_t::trace (  LEVELCHK(level1),
-         MODULENAME,
-         0,
-         "detached from all RM threads...");
-
-      //
-      // unsetting "MPIR_being_debugged."
-      //
-      symbol_base_t<T_VA> being_debugged
-        = p.get_myimage()->get_a_symbol (p.get_launch_being_debug());
-      if (!being_debugged && p.get_myrmso_image())
-        {
-          being_debugged
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
-        }
-
-
-      get_tracer()->tracer_write ( p,
-                                   being_debugged.get_relocated_address(),
-                                   &bdbg,
-                                   sizeof(bdbg),
-                                   false );
-
-      //
-      // detach from the main thread
-      //
-      // calls detach twice in case there are
-      // multiple stop event queued up into waitpid
-      get_tracer()->tracer_unsetoptions ( p, false, -1 );
-      get_tracer()->tracer_detach ( p, false );
-
-       self_trace_t::trace ( LEVELCHK(level1),
-         MODULENAME,
-         0,
-         "detached from the RM process ...");
-
-      char *bnbuf = strdup(p.get_myopts()->get_my_opt()->debugtarget.c_str());
-      std::string dt = basename(bnbuf);
-
-      switch ( p.get_reason() )
-        {
-        //
-        // say the job-done to the FE, if I can
-        //
-        case RM_BE_daemon_exited:
-          say_fetofe_msg ( lmonp_bedmon_exited );
-          break;
-        case RM_MW_daemon_exited:
-          say_fetofe_msg ( lmonp_mwdmon_exited );
-          break;
-	case RM_JOB_mpir_aborting:
-	  say_fetofe_msg ( lmonp_stop_at_launch_bp_abort );
-	  break;
-        case FE_requested_detach:
-          say_fetofe_msg ( lmonp_detach_done );	
-          break;
-        case FE_requested_shutdown_dmon:
-          p.rmgr()->graceful_rmkill(get_toollauncherpid());
-          say_fetofe_msg ( lmonp_detach_done );	
-          break;
-        case FE_disconnected:
-	  usleep (GracePeriodFEDisconnection);
-          p.rmgr()->graceful_rmkill(get_toollauncherpid());
-          break;
-        case ENGINE_dying_wsignal:
-          say_fetofe_msg (lmonp_stop_tracing);
-          break;
-        case reserved_for_rent:
-        case FE_requested_kill:
-          {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-			          MODULENAME,1,
-	    "Reason for the detach is unclear "
-            "(reserved_for_rent or FE_requested_kill)");
+              p.make_context(p.thr_iter->first);
+              if (get_tracer()->status(p, true) == SDBG_TRACE_STOPPED) {
+                get_tracer()->tracer_detach(p, true);
+              }
+              p.check_and_undo_context(p.thr_iter->first);
+            }
           }
-          break;
-        default:
+
+          self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                              "detached from all threads of the RM process...");
+
+          //
+          // detach from the main thread
+          //
+          if (get_tracer()->status(p, false) == SDBG_TRACE_STOPPED) {
+            get_tracer()->tracer_detach(p, false);
+          }
+
+          self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                              "detached from all the RM process...");
+
+          set_engine_state(bdbg);
+          say_fetofe_msg(lmonp_stop_at_launch_bp_abort);
+
+          //
+          // this return code will cause the engine to exit.
+          // but it should leave its children RM_daemon process
+          // in a running state.
+          //
+          lrc = LAUNCHMON_MPIR_DEBUG_ABORT;
+
           {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-			          MODULENAME,1,
-	    "Reason for the detach is unclear");
+            self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                "launch-breakpoint hit event handler "
+                                "completing with MPIR_DEBUG_ABORTING");
           }
           break;
         }
-
-      free(bnbuf);
-      free_engine_resources(p);
-
-      //
-      // This return code will cause the engine to exit.
-      // but it should leave its children RM_daemon process
-      // in a running state.
-      //
-      set_last_seen (gettimeofdayD ());
-
-      return LAUNCHMON_STOP_TRACE;
+        case MPIR_NULL: {
+          {
+            self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                "launch-breakpoint hit event handler "
+                                "completing with MPIR_NULL");
+          }
+          set_engine_state(bdbg);
+          get_tracer()->tracer_continue(p, use_cxt);
+          break;
+        }
+        default: {
+          {
+            self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                "launch-breakpoint hit event handler "
+                                "completing with unknown debug state");
+          }
+          set_engine_state(bdbg);
+          get_tracer()->tracer_continue(p, use_cxt);
+          break;
+        }
+      }
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
+
+    set_last_seen(gettimeofdayD());
+
+    return lrc;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
 
-
-//! PUBLIC: handle_kill_cmd_event 
+//! PUBLIC: handle_detach_cmd_event
 /*!
-    handles "kill-command event." This is an event initiated by 
-    the FE client as opposed to an event generated from the 
+    handles "detach-command" event.
+*/
+launchmon_rc_e linux_launchmon_t::handle_detach_cmd_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    int bdbg = 0;
+    T_VA debug_state_flag = T_UNINIT_HEX;
+
+    //
+    // disable all the hidden breakpoints
+    //
+    disable_all_BPs(p, false);
+
+    //
+    // detach from all slave threads.
+    //
+    for (p.thr_iter = p.get_thrlist().begin();
+         p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+      if (!(p.thr_iter->second->is_master_thread())) {
+        // operates on a slave thread
+        p.make_context(p.thr_iter->first);
+        get_tracer()->tracer_unsetoptions(p, true, -1);
+        get_tracer()->tracer_detach(p, true);
+        p.check_and_undo_context(p.thr_iter->first);
+      }
+    }
+
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                        "detached from all RM threads...");
+
+    //
+    // unsetting "MPIR_being_debugged."
+    //
+    symbol_base_t<T_VA> being_debugged =
+        p.get_myimage()->get_a_symbol(p.get_launch_being_debug());
+    if (!being_debugged && p.get_myrmso_image()) {
+      being_debugged =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
+    }
+
+    get_tracer()->tracer_write(p, being_debugged.get_relocated_address(), &bdbg,
+                               sizeof(bdbg), false);
+
+    //
+    // detach from the main thread
+    //
+    // calls detach twice in case there are
+    // multiple stop event queued up into waitpid
+    get_tracer()->tracer_unsetoptions(p, false, -1);
+    get_tracer()->tracer_detach(p, false);
+
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                        "detached from the RM process ...");
+
+    char *bnbuf = strdup(p.get_myopts()->get_my_opt()->debugtarget.c_str());
+    std::string dt = basename(bnbuf);
+
+    switch (p.get_reason()) {
+      //
+      // say the job-done to the FE, if I can
+      //
+      case RM_BE_daemon_exited:
+        say_fetofe_msg(lmonp_bedmon_exited);
+        break;
+      case RM_MW_daemon_exited:
+        say_fetofe_msg(lmonp_mwdmon_exited);
+        break;
+      case RM_JOB_mpir_aborting:
+        say_fetofe_msg(lmonp_stop_at_launch_bp_abort);
+        break;
+      case FE_requested_detach:
+        say_fetofe_msg(lmonp_detach_done);
+        break;
+      case FE_requested_shutdown_dmon:
+        p.rmgr()->graceful_rmkill(get_toollauncherpid());
+        say_fetofe_msg(lmonp_detach_done);
+        break;
+      case FE_disconnected:
+        usleep(GracePeriodFEDisconnection);
+        p.rmgr()->graceful_rmkill(get_toollauncherpid());
+        break;
+      case ENGINE_dying_wsignal:
+        say_fetofe_msg(lmonp_stop_tracing);
+        break;
+      case reserved_for_rent:
+      case FE_requested_kill: {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "Reason for the detach is unclear "
+                            "(reserved_for_rent or FE_requested_kill)");
+      } break;
+      default: {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "Reason for the detach is unclear");
+      } break;
+    }
+
+    free(bnbuf);
+    free_engine_resources(p);
+
+    //
+    // This return code will cause the engine to exit.
+    // but it should leave its children RM_daemon process
+    // in a running state.
+    //
+    set_last_seen(gettimeofdayD());
+
+    return LAUNCHMON_STOP_TRACE;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
+}
+
+//! PUBLIC: handle_kill_cmd_event
+/*!
+    handles "kill-command event." This is an event initiated by
+    the FE client as opposed to an event generated from the
     RM launcher process.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_kill_cmd_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try
-    {   
-      int bdbg = 0;
-      T_VA debug_state_flag = T_UNINIT_HEX;
- 
-      //
-      // disinserting all the breakpoints
-      //
-      disable_all_BPs (p, false);
- 
-      //
-      // detach from all the slave threads.
-      //
-      for ( p.thr_iter = p.get_thrlist().begin();
-              p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-        {
-          if ( !(p.thr_iter->second->is_master_thread()) )
-            {
-              // operates on a slave thread
-              p.make_context ( p.thr_iter->first );
-              get_tracer()->tracer_unsetoptions ( p, true, -1 );
-              get_tracer()->tracer_detach( p, true );
-              p.check_and_undo_context ( p.thr_iter->first );
-            }
-        }
+launchmon_rc_e linux_launchmon_t::handle_kill_cmd_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    int bdbg = 0;
+    T_VA debug_state_flag = T_UNINIT_HEX;
 
-       self_trace_t::trace ( LEVELCHK(level1),
-         MODULENAME,
-         0,
-         "detached from all RM threads...");
-      //
-      // unsetting MPIR_being_debugged.
-      //
-      symbol_base_t<T_VA> debug_state
-        = p.get_myimage()->get_a_symbol (p.get_launch_being_debug());
+    //
+    // disinserting all the breakpoints
+    //
+    disable_all_BPs(p, false);
 
-      if (!debug_state && p.get_myrmso_image())
-        {
-          debug_state
-            = p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
-        }
- 
-      debug_state_flag = debug_state.get_relocated_address();
-      get_tracer()->tracer_write ( p,
-        debug_state_flag,
-        &bdbg,
-        sizeof(bdbg),
-        false );
+    //
+    // detach from all the slave threads.
+    //
+    for (p.thr_iter = p.get_thrlist().begin();
+         p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+      if (!(p.thr_iter->second->is_master_thread())) {
+        // operates on a slave thread
+        p.make_context(p.thr_iter->first);
+        get_tracer()->tracer_unsetoptions(p, true, -1);
+        get_tracer()->tracer_detach(p, true);
+        p.check_and_undo_context(p.thr_iter->first);
+      }
+    }
 
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                        "detached from all RM threads...");
+    //
+    // unsetting MPIR_being_debugged.
+    //
+    symbol_base_t<T_VA> debug_state =
+        p.get_myimage()->get_a_symbol(p.get_launch_being_debug());
+
+    if (!debug_state && p.get_myrmso_image()) {
+      debug_state =
+          p.get_myrmso_image()->get_a_symbol(p.get_launch_being_debug());
+    }
+
+    debug_state_flag = debug_state.get_relocated_address();
+    get_tracer()->tracer_write(p, debug_state_flag, &bdbg, sizeof(bdbg), false);
+
+    //
+    // detach from all the main thread
+    //
+    get_tracer()->tracer_unsetoptions(p, false, -1);
+    get_tracer()->tracer_detach(p, false);
+
+    {
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                          "detached from the RM process ...");
+    }
+
+    //
+    // kill both the target RM and tool RM gracefully
+    //
+    p.rmgr()->graceful_rmkill(p.get_pid(false));
+    if (!p.rmgr()->is_coloc_sup()) {
+      int pid = get_toollauncherpid();
+      p.rmgr()->graceful_rmkill(pid);
+    }
+
+    switch (p.get_reason()) {
       //
-      // detach from all the main thread
+      // say the job-done to the FE, if I can
       //
-      get_tracer()->tracer_unsetoptions ( p, false, -1 );
-      get_tracer()->tracer_detach ( p, false );
-     
+      case RM_BE_daemon_exited:
+      case RM_MW_daemon_exited:
+      case FE_disconnected:
+      case FE_requested_shutdown_dmon:
+      case FE_requested_detach:
+      case ENGINE_dying_wsignal: {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "RM_BE_daemon_exited or "
+                            "its equivalents should not kill the job!");
+      } break;
+      case FE_requested_kill:
+        say_fetofe_msg(lmonp_kill_done);
+        break;
+      case reserved_for_rent: {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "Reason for the kill is unclear "
+                            "(reserved_for_rent!)");
+      } break;
+      default: {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "Reason for the kill is unclear (default!)");
+      } break;
+    }
+
+    free_engine_resources(p);
+
+    //
+    // this return code will cause the engine to exit.
+    // daemon should have gotten a kill command if supported
+    // at this point.
+    //
+    set_last_seen(gettimeofdayD());
+
+    return LAUNCHMON_STOP_TRACE;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
+}
+
+//! PUBLIC: handle_loader_bp_event
+/*!
+    handles the loader event. Whenever the loader notifies
+    the debugger its DSO load/unload, this handler gets
+    invoked, fetching some information (e.g. the base link map for
+    the pthread library.) Once it gleans all necessary info, it
+    stops poking the link map to optimize the perf.
+*/
+launchmon_rc_e linux_launchmon_t::handle_loader_bp_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
+
+#if MEASURE_TRACING_COST
+    beginTS = gettimeofdayD();
+#endif
+
+    bool use_cxt = true;
+
+    if (!(is_bp_prologue_done(p, p.get_loader_hidden_bp()))) {
+#if MEASURE_TRACING_COST
+      endTS = gettimeofdayD();
+      accum += endTS - beginTS;
+      countHandler++;
+#endif
+      return LAUNCHMON_OK;
+    }
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "loader event handler invoked.");
+    }
+
+    check_dependent_SOs(p);
+
+    get_tracer()->tracer_continue(p, use_cxt);
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "loader event handler completed.");
+    }
+
+#if MEASURE_TRACING_COST
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+#endif
+
+    set_last_seen(gettimeofdayD());
+
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
+}
+
+//! PUBLIC: handle_fork_event
+/*!
+    handle a process fork event
+*/
+launchmon_rc_e linux_launchmon_t::handle_newproc_forked_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
+
+#if MEASURE_TRACING_COST
+    beginTS = gettimeofdayD();
+#endif
+
+    bool use_cxt = true;
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "newproc forked event handler invoked.");
+    }
+
+    //
+    // Because the context would have been set up for the newly
+    // forked process, following process control actions will
+    // only affect the new process
+    //
+    disable_all_BPs(p, use_cxt, false);
+    get_tracer()->tracer_detach(p, use_cxt);
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "fork event handler completed.");
+    }
+
+#if MEASURE_TRACING_COST
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+#endif
+
+    set_last_seen(gettimeofdayD());
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
+}
+
+//! PUBLIC: handle_exit_event
+/*!
+    handle an exit event
+*/
+launchmon_rc_e linux_launchmon_t::handle_exit_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
+
+    launchmon_rc_e rc;
+
+#if MEASURE_TRACING_COST
+    beginTS = gettimeofdayD();
+#endif
+
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "thread exit event handler invoked.");
+    }
+
+    if (p.get_cur_thread_ctx() != p.get_master_thread_pid()) {
+      delete p.get_thrlist()[p.get_cur_thread_ctx()];
+      p.get_thrlist().erase(p.get_cur_thread_ctx());
       {
-         self_trace_t::trace ( 
-           LEVELCHK(level1),
-           MODULENAME,
-           0,
-           "detached from the RM process ...");
+        self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                            "a slave thread has exited.");
       }
 
-      //
-      // kill both the target RM and tool RM gracefully
-      //
-      p.rmgr()->graceful_rmkill(p.get_pid(false));	
-      if (!p.rmgr()->is_coloc_sup())
-        {
-          int pid = get_toollauncherpid();
-          p.rmgr()->graceful_rmkill(pid);
-        }
+      // cout << "slave thread exited: " << p.get_cur_thread_ctx() << endl;
+      rc = LAUNCHMON_OK;
+    } else {
+      {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                            "a main thread has exited.");
+      }
 
-      switch (p.get_reason())
-        {
-        //
-        // say the job-done to the FE, if I can
-        //
-        case RM_BE_daemon_exited:
-	case RM_MW_daemon_exited:
-	case FE_disconnected:
-	case FE_requested_shutdown_dmon:
-	case FE_requested_detach:
-        case ENGINE_dying_wsignal:
-          {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-			          MODULENAME,1,
-	    "RM_BE_daemon_exited or "
-            "its equivalents should not kill the job!");
-          }
-          break;
-        case FE_requested_kill:
-          say_fetofe_msg ( lmonp_kill_done );	
-          break;
-        case reserved_for_rent:
-          {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-			          MODULENAME,1,
-	    "Reason for the kill is unclear "
-            "(reserved_for_rent!)");
-          }
-          break;
-        default:
-          {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-			          MODULENAME,1,
-	    "Reason for the kill is unclear (default!)");
-          }
-          break;
-        }
+      // cout << "main thread exited: " << p.get_cur_thread_ctx() << endl;
+      //
+      // LMON API SUPPORT: a message via a pipe to the watchdog thread
+      //
+      //
+      say_fetofe_msg(lmonp_exited);
 
       free_engine_resources(p);
 
       //
       // this return code will cause the engine to exit.
-      // daemon should have gotten a kill command if supported
-      // at this point. 
+      // daemon should continue running: Enforcing D.1
+      // error handling semantics.
       //
-      set_last_seen (gettimeofdayD ());
-
-      return LAUNCHMON_STOP_TRACE;
+      rc = LAUNCHMON_MAINPROG_EXITED;
     }
-  catch ( symtab_exception_t e ) 
+
     {
-      e.report();
-      return LAUNCHMON_FAILED;
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "thread exit event handler completed.");
     }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    } 
-}
-
-
-
-//! PUBLIC: handle_loader_bp_event
-/*!
-    handles the loader event. Whenever the loader notifies 
-    the debugger its DSO load/unload, this handler gets 
-    invoked, fetching some information (e.g. the base link map for
-    the pthread library.) Once it gleans all necessary info, it 
-    stops poking the link map to optimize the perf. 
-*/
-launchmon_rc_e 
-linux_launchmon_t::handle_loader_bp_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
 
 #if MEASURE_TRACING_COST
-     beginTS = gettimeofdayD ();
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
 #endif
 
-      bool use_cxt = true;
-
-      if (!(is_bp_prologue_done(p, p.get_loader_hidden_bp()))) {
-#if MEASURE_TRACING_COST
-        endTS = gettimeofdayD ();
-        accum += endTS - beginTS;
-	countHandler++;
-#endif
-	return LAUNCHMON_OK;
-      }
-
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "loader event handler invoked.");
-      }
-
-      check_dependent_SOs(p);
-
-      get_tracer()->tracer_continue (p, use_cxt);
-
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "loader event handler completed.");
-      }
-
-#if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-#endif 
-
-      set_last_seen (gettimeofdayD ());
-
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }  
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-}
-
-
-//! PUBLIC: handle_fork_event 
-/*!
-    handle a process fork event
-*/
-launchmon_rc_e 
-linux_launchmon_t::handle_newproc_forked_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
-
-#if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD ();
-#endif
-
-      bool use_cxt = true; 
-  
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-			      MODULENAME,0,
-			      "newproc forked event handler invoked.");
-      }
-
-      //
-      // Because the context would have been set up for the newly
-      // forked process, following process control actions will
-      // only affect the new process 
-      //
-      disable_all_BPs (p, use_cxt, false);  
-      get_tracer()->tracer_detach(p, use_cxt);
-
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-			      MODULENAME,0,
-			      "fork event handler completed.");
-      }    
-
-#if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-#endif
-
-      set_last_seen (gettimeofdayD ());
-      return LAUNCHMON_OK;
+    set_last_seen(gettimeofdayD());
+    return rc;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
   }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }     
 }
 
-
-//! PUBLIC: handle_exit_event 
-/*!
-    handle an exit event
-*/
-launchmon_rc_e 
-linux_launchmon_t::handle_exit_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{  
-  try 
-    {
-      using namespace std;
-
-      launchmon_rc_e rc;
-
-#if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD ();
-#endif
- 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-          "thread exit event handler invoked.");
-      }
-
-      if (p.get_cur_thread_ctx () != p.get_master_thread_pid()) 
-	{
-          delete p.get_thrlist()[p.get_cur_thread_ctx()];
-	  p.get_thrlist().erase(p.get_cur_thread_ctx());
-	  {
-	    self_trace_t::trace ( LEVELCHK(level2), 
-	      MODULENAME,0,
-	      "a slave thread has exited.");
-	  }
-
-	  //cout << "slave thread exited: " << p.get_cur_thread_ctx() << endl;
-	  rc = LAUNCHMON_OK;
-	}
-      else 
-	{    
-
-	  {
-	    self_trace_t::trace ( LEVELCHK(level1), 
-	      MODULENAME,0,
-	      "a main thread has exited.");
-	  }
-
-	  //cout << "main thread exited: " << p.get_cur_thread_ctx() << endl;
-	  //
-	  // LMON API SUPPORT: a message via a pipe to the watchdog thread
-	  // 
-	  //
-	  say_fetofe_msg(lmonp_exited);	 
-
-          free_engine_resources(p);
-
-          //
-          // this return code will cause the engine to exit.
-          // daemon should continue running: Enforcing D.1
-          // error handling semantics.
-          //
-	  rc = LAUNCHMON_MAINPROG_EXITED;
-	}    
-
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-          "thread exit event handler completed.");
-      }
-
-#if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-#endif
-
-      set_last_seen (gettimeofdayD ());
-      return rc;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }     
-}
-
-
-//! PUBLIC: handle_term_event 
+//! PUBLIC: handle_term_event
 /*!
     handle a termination event
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_term_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
+launchmon_rc_e linux_launchmon_t::handle_term_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
   using namespace std;
 
 #if MEASURE_TRACING_COST
-  beginTS = gettimeofdayD ();
+  beginTS = gettimeofdayD();
 #endif
 
   {
-    self_trace_t::trace ( LEVELCHK(level2), 
-      MODULENAME,0,
-      "termination event handler invoked.");
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "termination event handler invoked.");
   }
 
   say_fetofe_msg(lmonp_terminated);
 
   {
-    self_trace_t::trace ( LEVELCHK(level2), 
-      MODULENAME,0,
-      "termination event handler completed.");
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "termination event handler completed.");
   }
-	
+
   cout << "main thread terminated: " << p.get_cur_thread_ctx() << endl;
 
 #if MEASURE_TRACING_COST
-  endTS = gettimeofdayD ();
+  endTS = gettimeofdayD();
   accum += endTS - beginTS;
   countHandler++;
 #endif
 
-  set_last_seen( gettimeofdayD() );
+  set_last_seen(gettimeofdayD());
 
   return LAUNCHMON_OK;
 }
 
-
 //! PUBLIC: handle_thrcreate_request
 /*!
-    handle a thread-creation event 
+    handle a thread-creation event
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_thrcreate_request ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p, int newlwpid )
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_thrcreate_request(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int newlwpid) {
+  try {
+    using namespace std;
 #if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD (); 
+    beginTS = gettimeofdayD();
 #endif
 
-      my_thrinfo_t tinfo;
-      memset(&tinfo, '\0', sizeof(tinfo));
-      tinfo.ti_lid = (lwpid_t) newlwpid;
+    my_thrinfo_t tinfo;
+    memset(&tinfo, '\0', sizeof(tinfo));
+    tinfo.ti_lid = (lwpid_t)newlwpid;
 
-      if ( p.get_thrlist().find( tinfo.ti_lid )
-           == p.get_thrlist().end() )
-        {
-          // this thread has not been seen
+    if (p.get_thrlist().find(tinfo.ti_lid) == p.get_thrlist().end()) {
+// this thread has not been seen
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE
-          thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo
-            = new linux_x86_thread_t();
+      thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo =
+          new linux_x86_thread_t();
 #elif PPC_ARCHITECTURE
-          thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo
-            = new linux_ppc_thread_t();
+      thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo =
+          new linux_ppc_thread_t();
 #elif AARCH64_ARCHITECTURE
-          thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo
-            = new linux_aarch64_thread_t();
+      thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *thrinfo =
+          new linux_aarch64_thread_t();
 #endif
-          thrinfo->copy_thread_info(tinfo);
-          // if the process doesn't contain tid of the given thread,
-          // those threads must be the new threads
-          p.get_thrlist().insert (make_pair (tinfo.ti_lid, thrinfo) );
-        }
+      thrinfo->copy_thread_info(tinfo);
+      // if the process doesn't contain tid of the given thread,
+      // those threads must be the new threads
+      p.get_thrlist().insert(make_pair(tinfo.ti_lid, thrinfo));
+    }
 
-       set_last_seen( gettimeofdayD() );
+    set_last_seen(gettimeofdayD());
 
-       return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }     
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_thrcreate_trap_event
 /*!
-    handle a thread-creation event 
+    handle a thread-creation event
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_thrcreate_trap_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_thrcreate_trap_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 #if MEASURE_TRACING_COST
-      beginTS = gettimeofdayD (); 
+    beginTS = gettimeofdayD();
 #endif
 
-      bool use_cxt = true;
-      T_WT newlwpid = -1;
+    bool use_cxt = true;
+    T_WT newlwpid = -1;
 
-      get_tracer()->tracer_get_event_msg( p, 
-                                          0, 
-                                          (void *) &newlwpid, 
-                                          true);
+    get_tracer()->tracer_get_event_msg(p, 0, (void *)&newlwpid, true);
 
-      if (newlwpid < 0) 
-        {
-          self_trace_t::trace (true, 
-          MODULENAME,1,
-          "negative thread id has been returned! Ignoring.");
-        }
-
-      //cout << "<" << newlwpid << ">" << endl;
-
-      handle_thrcreate_request(p, (int) newlwpid);
-
-      get_tracer()->tracer_continue(p, use_cxt); 
-      set_last_seen( gettimeofdayD() );
-
-      return LAUNCHMON_OK;
+    if (newlwpid < 0) {
+      self_trace_t::trace(true, MODULENAME, 1,
+                          "negative thread id has been returned! Ignoring.");
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }     
+
+    // cout << "<" << newlwpid << ">" << endl;
+
+    handle_thrcreate_request(p, (int)newlwpid);
+
+    get_tracer()->tracer_continue(p, use_cxt);
+    set_last_seen(gettimeofdayD());
+
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_newthread_trace_event
 /*!
-    handle a thread-creation event 
+    handle a thread-creation event
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_newthread_trace_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p )
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_newthread_trace_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 #if MEASURE_TRACING_COST
-     beginTS = gettimeofdayD ();
+    beginTS = gettimeofdayD();
 #endif
 
-      bool use_cxt = true;
+    bool use_cxt = true;
 
-      {
-        self_trace_t::trace ( LEVELCHK(level2),
-          MODULENAME,0,
-          "irrelevant stop event handler invoked");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler invoked");
+    }
 
-      get_tracer()->tracer_setoptions (p, use_cxt, -1);
-      p.get_thrlist()[p.get_cur_thread_ctx()]->set_traced(true);
-      //cout << "[" << p.get_cur_thread_ctx() << "]" << endl;
-      get_tracer()->tracer_continue (p, use_cxt);
+    get_tracer()->tracer_setoptions(p, use_cxt, -1);
+    p.get_thrlist()[p.get_cur_thread_ctx()]->set_traced(true);
+    // cout << "[" << p.get_cur_thread_ctx() << "]" << endl;
+    get_tracer()->tracer_continue(p, use_cxt);
 
-      {
-        self_trace_t::trace ( LEVELCHK(level2),
-          MODULENAME,0,
-          "irrelevant stop event handler completed");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler completed");
+    }
 
 #if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
 #endif
 
-      set_last_seen (gettimeofdayD ());
+    set_last_seen(gettimeofdayD());
 
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }     
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_not_interested_event
 /*!
-    If the target stopped with no apprent reason, 
+    If the target stopped with no apprent reason,
     we'd better simply kick it again.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_not_interested_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p ) 
-{
-  try 
-    {
-      using namespace std;
+launchmon_rc_e linux_launchmon_t::handle_not_interested_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p) {
+  try {
+    using namespace std;
 
 #if MEASURE_TRACING_COST
-     beginTS = gettimeofdayD (); 
+    beginTS = gettimeofdayD();
 #endif
 
-      bool use_cxt = true;  
+    bool use_cxt = true;
 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "irrelevant stop event handler invoked");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler invoked");
+    }
 
-      get_tracer()->tracer_continue (p, use_cxt);
+    get_tracer()->tracer_continue(p, use_cxt);
 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "irrelevant stop event handler completed");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler completed");
+    }
 
 #if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
-#endif     
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
+#endif
 
-     set_last_seen (gettimeofdayD ());
+    set_last_seen(gettimeofdayD());
 
-     return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
-
 
 //! PUBLIC: handle_relay_signal_event
 /*!
-    If the target stopped with no apprent reason, 
+    If the target stopped with no apprent reason,
     we'd better simply kick it again.
 */
-launchmon_rc_e 
-linux_launchmon_t::handle_relay_signal_event ( 
-                 process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p, int sig) 
-{
-  try 
-    {
-      using namespace std;
-      int what_to_send = SIGCONT;
+launchmon_rc_e linux_launchmon_t::handle_relay_signal_event(
+    process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int sig) {
+  try {
+    using namespace std;
+    int what_to_send = SIGCONT;
 #if MEASURE_TRACING_COST
-     beginTS = gettimeofdayD (); 
+    beginTS = gettimeofdayD();
 #endif
 
-      bool use_cxt = true;  
+    bool use_cxt = true;
 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "irrelevant stop event handler invoked");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler invoked");
+    }
 
-      if ( sig != SIGSTOP )
-	what_to_send = sig;
+    if (sig != SIGSTOP) what_to_send = sig;
 
-      get_tracer()->tracer_setoptions (p, true, -1);
-      get_tracer()->tracer_deliver_signal (p, what_to_send, use_cxt);
+    get_tracer()->tracer_setoptions(p, true, -1);
+    get_tracer()->tracer_deliver_signal(p, what_to_send, use_cxt);
 
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,0,
-	  "irrelevant stop event handler completed");
-      }
+    {
+      self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                          "irrelevant stop event handler completed");
+    }
 
 #if MEASURE_TRACING_COST
-      endTS = gettimeofdayD ();
-      accum += endTS - beginTS;
-      countHandler++;
+    endTS = gettimeofdayD();
+    accum += endTS - beginTS;
+    countHandler++;
 #endif
 
-     set_last_seen (gettimeofdayD ());
-     return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return LAUNCHMON_FAILED;
-    }
+    set_last_seen(gettimeofdayD());
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return LAUNCHMON_FAILED;
+  }
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_launchmon.hxx
+++ b/launchmon/src/linux/sdbg_linux_launchmon.hxx
@@ -1,196 +1,174 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_launchmon.hxx,v 1.9.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jul 22 2015 ADG: Fix for on demand proctable
- *        Oct 01 2010 DHA: Refactor handling of mpir variables setup to 
+ *        Oct 01 2010 DHA: Refactor handling of mpir variables setup to
  *                         handle_mpir_variables.
- *        Sep 24 2008 DHA: Added handle_daemon_exit_event for 
+ *        Sep 24 2008 DHA: Added handle_daemon_exit_event for
  *                         better error handling
  *        Jul 03 2006 DHA: Added self tracing support
  *        Jun 08 2006 DHA: Added attach-to-a-running job support.
  *                         handle_attach_event method
  *        Mar 30 2006 DHA: Added exception handling support
  *        Jan 12 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_LINUX_LAUNCHMON_HXX
 #define SDBG_LINUX_LAUNCHMON_HXX 1
 
 #include <vector>
-#include "sdbg_base_launchmon.hxx"
-#include "sdbg_linux_std.hxx"
-#include "sdbg_linux_mach.hxx"
 #include "lmon_api/lmon_proctab.h"
-
+#include "sdbg_base_launchmon.hxx"
+#include "sdbg_linux_mach.hxx"
+#include "sdbg_linux_std.hxx"
 
 //! class linux_launchmon_t<>
 /*!
     implements launchmon algorithm
 */
-class linux_launchmon_t : public launchmon_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
+class linux_launchmon_t
+    : public launchmon_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
+  linux_launchmon_t();
+  virtual ~linux_launchmon_t();
 
-public:
-  linux_launchmon_t ( );
-  virtual ~linux_launchmon_t ( );
-
-  
   ////////////////////////////////////////////////////////////
   //
   //  Public Interfaces:
   //
   //
-  virtual launchmon_rc_e init ( opts_args_t *opt );
+  virtual launchmon_rc_e init(opts_args_t *opt);
 
-  virtual launchmon_event_e decipher_an_event ( 
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, 
-		const debug_event_t &e );
+  virtual launchmon_event_e decipher_an_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, const debug_event_t &e);
 
-  virtual 
-  launchmon_rc_e handle_attach_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_attach_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_launch_bp_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
-  
-  virtual 
-  launchmon_rc_e handle_detach_cmd_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_launch_bp_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_kill_cmd_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_detach_cmd_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_trap_after_exec_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_kill_cmd_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_trap_after_attach_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_trap_after_exec_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_loader_bp_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
-  
-  virtual 
-  launchmon_rc_e handle_exit_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_trap_after_attach_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_term_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
-  
-  virtual 
-  launchmon_rc_e handle_thrcreate_request
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int newlwpid );
+  virtual launchmon_rc_e handle_loader_bp_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_thrcreate_trap_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_exit_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_newthread_trace_event 
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
-  
-  virtual 
-  launchmon_rc_e handle_newproc_forked_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_term_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  virtual 
-  launchmon_rc_e handle_not_interested_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  virtual launchmon_rc_e handle_thrcreate_request(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int newlwpid);
 
-  virtual 
-  launchmon_rc_e handle_relay_signal_event
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int sig);
+  virtual launchmon_rc_e handle_thrcreate_trap_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-private:
+  virtual launchmon_rc_e handle_newthread_trace_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
+  virtual launchmon_rc_e handle_newproc_forked_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
+
+  virtual launchmon_rc_e handle_not_interested_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
+
+  virtual launchmon_rc_e handle_relay_signal_event(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, int sig);
+
+ private:
   ////////////////////////////////////////////////////////////
   //
   //  Private Methods:
   //
   //
-  linux_launchmon_t (const linux_launchmon_t& l );
+  linux_launchmon_t(const linux_launchmon_t &l);
 
-  launchmon_rc_e handle_bp_prologue
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p,
-		   breakpoint_base_t<T_VA,T_IT> *bp );
+  launchmon_rc_e handle_bp_prologue(
+      process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+      breakpoint_base_t<T_VA, T_IT> *bp);
 
-  bool is_bp_prologue_done
-                 ( process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>& p,
-		   breakpoint_base_t<T_VA,T_IT> *bp );
+  bool is_bp_prologue_done(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                           breakpoint_base_t<T_VA, T_IT> *bp);
 
-  bool disable_all_BPs (
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, 
-                bool use_context,
-                bool change_state=true );
+  bool disable_all_BPs(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                       bool use_context, bool change_state = true);
 
-  bool enable_all_BPs ( 
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, 
-                bool use_context,
-                bool change_state=true );
+  bool enable_all_BPs(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                      bool use_context, bool change_state = true);
 
-  bool check_dependent_SOs ( 
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  bool check_dependent_SOs(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  bool continue_on_attach (
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool );
+  bool continue_on_attach(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                          bool);
 
-  bool acquire_proctable ( 
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p, bool );
-  
-  bool launch_tool_daemons ( 
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p );
+  bool acquire_proctable(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                         bool);
 
-  bool handle_mpir_variables (
-                process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
-                image_base_t<T_VA,elf_wrapper> &i);
+  bool launch_tool_daemons(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  launchmon_rc_e init_API (opts_args_t *);
+  bool handle_mpir_variables(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p,
+                             image_base_t<T_VA, elf_wrapper> &i);
+
+  launchmon_rc_e init_API(opts_args_t *);
 
   void free_engine_resources(process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> &p);
 
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().launchmon_module_trace.verbosity_level >= level); }
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().launchmon_module_trace.verbosity_level >=
+            level);
+  }
 
   ////////////////////////////////////////////////////////////
-  //  
+  //
   // Private Data:
   //
   //
 
   // For self tracing
   //
-  std::string MODULENAME; 
-
+  std::string MODULENAME;
 };
 
-#endif // SDBG_LINUX_LAUNCHMON_HXX
+#endif  // SDBG_LINUX_LAUNCHMON_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_mach.cxx
+++ b/launchmon/src/linux/sdbg_linux_mach.cxx
@@ -1,29 +1,31 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_mach.cxx,v 1.3.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
  * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
  *
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
  *        May 02 2018 KMD/ADG: Added aarch64 support
@@ -46,10 +48,9 @@
 
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_mach_impl.hxx"
+#include "sdbg_linux_mach.hxx"
 #include "sdbg_linux_symtab.hxx"
 #include "sdbg_linux_symtab_impl.hxx"
-#include "sdbg_linux_mach.hxx"
-
 
 extern "C" {
 #include <thread_db.h>
@@ -68,8 +69,7 @@ extern "C" {
     Default constructor.
 */
 linux_x86_gpr_set_t::linux_x86_gpr_set_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   // This part of the code may be difficult to read. It was trial and error
   //   to detemine what registers are writable and what are not.
   //
@@ -84,7 +84,7 @@ linux_x86_gpr_set_t::linux_x86_gpr_set_t()
   gpr_writable_mask |= (1 << 4);
   gpr_writable_mask |= (1 << 5);
   gpr_writable_mask |= (1 << 6);
-  gpr_writable_mask |= (1 << 12); // eip (program counter) is writable
+  gpr_writable_mask |= (1 << 12);  // eip (program counter) is writable
 
 #elif X86_64_ARCHITECTURE
 
@@ -102,23 +102,20 @@ linux_x86_gpr_set_t::linux_x86_gpr_set_t()
   gpr_writable_mask |= (1 << 11);
   gpr_writable_mask |= (1 << 12);
 
-  gpr_writable_mask |= (1 << 16); // rip (program counter) is writable
+  gpr_writable_mask |= (1 << 16);  // rip (program counter) is writable
 
 #endif /* X86_64_ARCHITECTURE */
 
   set_user_offset(0);
   set_writable_mask(gpr_writable_mask);
 
-} // linux_x86_gpr_set_t
-
+}  // linux_x86_gpr_set_t
 
 //! PUBLIC: linux_x86_gpr_set_t
 /*!
     get_pc
 */
-const T_VA
-linux_x86_gpr_set_t::get_pc() const
-{
+const T_VA linux_x86_gpr_set_t::get_pc() const {
   T_GRS gpr = get_native_rs();
 
 #ifdef X86_ARCHITECTURE
@@ -128,14 +125,11 @@ linux_x86_gpr_set_t::get_pc() const
 #endif
 }
 
-
 //! PUBLIC: linux_x86_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_x86_gpr_set_t::get_ret_addr() const
-{
+const T_VA linux_x86_gpr_set_t::get_ret_addr() const {
   //
   // We need to keep track of the "return address"
   // because that address can result from a single-step
@@ -153,14 +147,11 @@ linux_x86_gpr_set_t::get_ret_addr() const
   return T_UNINIT_HEX;
 }
 
-
 //! PUBLIC: linux_x86_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_x86_gpr_set_t::get_memloc_for_ret_addr() const
-{
+const T_VA linux_x86_gpr_set_t::get_memloc_for_ret_addr() const {
   //
   // We need to keep track of the "return address"
   // because that address can result from a single-step
@@ -181,24 +172,19 @@ linux_x86_gpr_set_t::get_memloc_for_ret_addr() const
 #endif
 }
 
-
 //! PUBLIC: linux_x86_gpr_set_t
 /*!
   set_pc method doesn't actually write value into tho PC register
   but into its corresponding data strucuture. The user of this method
   must ensure writing this back into the register.
 */
-void
-linux_x86_gpr_set_t::set_pc(T_VA addr)
-{
-
+void linux_x86_gpr_set_t::set_pc(T_VA addr) {
 #ifdef X86_ARCHITECTURE
   rs.eip = addr;
 #elif X86_64_ARCHITECTURE
   rs.rip = addr;
 #endif
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -211,15 +197,11 @@ linux_x86_gpr_set_t::set_pc(T_VA addr)
     Default constructor.
 */
 linux_x86_fpr_set_t::linux_x86_fpr_set_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   unsigned int fpr_writable_mask = 0xffffff80;
-  set_user_offset(sizeof(T_GRS)+sizeof(int));
+  set_user_offset(sizeof(T_GRS) + sizeof(int));
   set_writable_mask(fpr_writable_mask);
-
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -232,25 +214,18 @@ linux_x86_fpr_set_t::linux_x86_fpr_set_t()
     Default constructor.
 */
 linux_x86_thread_t::linux_x86_thread_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   set_gprset(new linux_x86_gpr_set_t());
   set_fprset(new linux_x86_fpr_set_t());
 }
 
-
-linux_x86_thread_t::~linux_x86_thread_t()
-{
-
-}
+linux_x86_thread_t::~linux_x86_thread_t() {}
 
 //! PUBLIC: linux_x86_thread_t
 /*!
     accessors
 */
-pid_t
-linux_x86_thread_t::thr2pid()
-{
+pid_t linux_x86_thread_t::thr2pid() {
   //
   // ti_lid is defined by the pthread debug library.
   // It contains the lightweight process ID (lwp) that
@@ -261,12 +236,11 @@ linux_x86_thread_t::thr2pid()
   // thr2pid is a misnomer, it should rather be thr2lwp.
   //
 
-  if ( is_master_thread ())
-    return (pid_t) get_master_pid ();
+  if (is_master_thread())
+    return (pid_t)get_master_pid();
   else
-    return (pid_t) get_thread_info().ti_lid;
+    return (pid_t)get_thread_info().ti_lid;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -278,59 +252,47 @@ linux_x86_thread_t::thr2pid()
 /*!
     Default constructor.
 */
-linux_x86_process_t::linux_x86_process_t ( )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-
-}
-
+linux_x86_process_t::linux_x86_process_t()
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {}
 
 //! PUBLIC: linux_x86_process_t
 /*!
      A constructor.
 */
-linux_x86_process_t::linux_x86_process_t (
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_x86_process_t::linux_x86_process_t(const std::string& mi,
+                                         const std::string& md,
+                                         const std::string& mt,
+                                         const std::string& mc)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   basic_init(mi, md, mt, mc);
 }
-
 
 //! PUBLIC: linux_x86_process_t
 /*!
     A constructor.
 */
-linux_x86_process_t::linux_x86_process_t (
-                 const pid_t& pid )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_x86_process_t::linux_x86_process_t(const pid_t& pid)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
-  linux_x86_thread_t* master_thread = new linux_x86_thread_t ();
-  master_thread->set_master_thread (true);
-  master_thread->set_master_pid (pid);
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  linux_x86_thread_t* master_thread = new linux_x86_thread_t();
+  master_thread->set_master_thread(true);
+  master_thread->set_master_pid(pid);
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // TODO: I need to be able to fetch image information
   // using pid to push it into basic_init.
   //
-
 }
-
 
 //! PUBLIC: linux_x86_process_t
 /*!
     A constructor: this is the currently recommended constructor
 */
-linux_x86_process_t::linux_x86_process_t (
-                 const pid_t &pid, const std::string &mi )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_x86_process_t::linux_x86_process_t(const pid_t& pid,
+                                         const std::string& mi)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   //
@@ -342,8 +304,7 @@ linux_x86_process_t::linux_x86_process_t (
   //
   // default lwp state is LMON_RM_CREATED
   //
-  linux_x86_thread_t *master_thread
-    = new linux_x86_thread_t();
+  linux_x86_thread_t* master_thread = new linux_x86_thread_t();
 
   //
   // indicating this represents the main thread
@@ -363,25 +324,21 @@ linux_x86_process_t::linux_x86_process_t (
   //
   // now is the time to initialize my images!
   //
-  if (!basic_init(mi))
-    {
-      throw (machine_exception_t("fail to initialize a process"));
-    }
+  if (!basic_init(mi)) {
+    throw(machine_exception_t("fail to initialize a process"));
+  }
 }
-
 
 //! PUBLIC: linux_x86_process_t
 /*!
     A constructor. This will be deprecated soon
 */
-linux_x86_process_t::linux_x86_process_t (
-                 const pid_t& pid,
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_x86_process_t::linux_x86_process_t(const pid_t& pid,
+                                         const std::string& mi,
+                                         const std::string& md,
+                                         const std::string& mt,
+                                         const std::string& mc)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   // Once pid is in place, we assume that at least
@@ -392,37 +349,33 @@ linux_x86_process_t::linux_x86_process_t (
 
   get_thrlist().insert(make_pair((int)pid, master_thread));
   basic_init(mi, md, mt, mc);
-} // linux_x86_process_t
-
+}  // linux_x86_process_t
 
 //! PRIVATE: linux_x86_process_t
 /*!
     launcher_symbols_init
 */
-void
-linux_x86_process_t::launcher_symbols_init()
-{
+void linux_x86_process_t::launcher_symbols_init() {
   //
   // symbols relevant to daemon launching
   //
-  set_launch_breakpoint_sym (LAUNCH_BREAKPOINT);
-  set_launch_being_debug (LAUNCH_BEING_DEBUG);
-  set_launch_debug_state (LAUNCH_DEBUG_STATE);
-  set_launch_debug_gate (LAUNCH_DEBUG_GATE);
-  set_launch_proctable (LAUNCH_PROCTABLE);
-  set_launch_proctable_size (LAUNCH_PROCTABLE_SIZE);
-  set_launch_acquired_premain (LAUNCH_ACQUIRED_PREMAIN);
-  set_launch_exec_path (LAUNCH_EXEC_PATH);
-  set_launch_server_args (LAUNCH_SERVER_ARGS);
-  set_launch_attach_fifo (LAUNCH_ATTACH_FIFO);
+  set_launch_breakpoint_sym(LAUNCH_BREAKPOINT);
+  set_launch_being_debug(LAUNCH_BEING_DEBUG);
+  set_launch_debug_state(LAUNCH_DEBUG_STATE);
+  set_launch_debug_gate(LAUNCH_DEBUG_GATE);
+  set_launch_proctable(LAUNCH_PROCTABLE);
+  set_launch_proctable_size(LAUNCH_PROCTABLE_SIZE);
+  set_launch_acquired_premain(LAUNCH_ACQUIRED_PREMAIN);
+  set_launch_exec_path(LAUNCH_EXEC_PATH);
+  set_launch_server_args(LAUNCH_SERVER_ARGS);
+  set_launch_attach_fifo(LAUNCH_ATTACH_FIFO);
   set_loader_breakpoint_sym(LOADER_BP_SYM);
   set_loader_r_debug_sym(LOADER_R_DEBUG);
   set_loader_start_sym(LOADER_START);
-  //set_libc_iden(LIBC_IDEN);
+  // set_libc_iden(LIBC_IDEN);
 
   set_resource_handler_sym(RESOURCE_HANDLER_SYM);
 }
-
 
 //! PUBLIC: linux_x86_process_t
 /*!
@@ -433,69 +386,60 @@ linux_x86_process_t::launcher_symbols_init()
     we only parse out images that matter to the daemon launching
     interface.
 */
-bool
-linux_x86_process_t::basic_init (const std::string &mi)
-{
+bool linux_x86_process_t::basic_init(const std::string& mi) {
   struct stat pathchk;
-
 
   //
   // make sure paths exist
   //
-  if ( stat( mi.c_str(), &pathchk ) != 0 )
-    {
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path: %s", mi.c_str () );
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path: %s",
+                        mi.c_str());
 
-      return false;
-    }
+    return false;
+  }
 
   //
   // image object representing the main RM launcher
   // details are filled in proctected_init down in the base layer
   //
-  set_myimage (new linux_image_t<T_VA>(mi));
+  set_myimage(new linux_image_t<T_VA>(mi));
 
   //
   // image object representing the dynamic linker
   // details are filled in proctected_init down in the base layer
   //
-  set_mydynloader_image (new linux_image_t<T_VA>());
+  set_mydynloader_image(new linux_image_t<T_VA>());
 
   //
   // image object representing the POSIX thread library
   // details are filled in dynamically at SO load
   //
-  set_mythread_lib_image (new linux_image_t<T_VA>());
+  set_mythread_lib_image(new linux_image_t<T_VA>());
 
   //
   // image object representing the LIBC library
   // details are filled in dynamically at SO load
   //
-  set_mylibc_image (new linux_image_t<T_VA>());
+  set_mylibc_image(new linux_image_t<T_VA>());
 
   //
   // image object representing a RM SO library
   // details are filled in dynamically at SO load.
   //
-  set_myrmso_image (new linux_image_t<T_VA>());
+  set_myrmso_image(new linux_image_t<T_VA>());
 
-  if (!protected_init(mi))
-    {
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed");
+  if (!protected_init(mi)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed");
 
-      return false;
-    }
+    return false;
+  }
 
   launcher_symbols_init();
 
   return true;
 }
 
-
 //! PUBLIC: linux_x86_process_t
 /*!
     Method that initializes static matters including
@@ -505,55 +449,41 @@ linux_x86_process_t::basic_init (const std::string &mi)
     we only parse out images that matter to the daemon launching
     interface.
 */
-bool
-linux_x86_process_t::basic_init (
-                 const std::string& mi,
-     const std::string& md,
-     const std::string& mt,
-     const std::string& mc )
-{
+bool linux_x86_process_t::basic_init(const std::string& mi,
+                                     const std::string& md,
+                                     const std::string& mt,
+                                     const std::string& mc) {
   struct stat pathchk;
 
   // make sure paths exist
   //
-  if ( stat( mi.c_str(), &pathchk ) != 0 )
-    {
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path: %s", mi.c_str ());
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path: %s",
+                        mi.c_str());
 
-      return false;
-    }
+    return false;
+  }
 
-  if ( stat( md.c_str(), &pathchk ) != 0 )
-    {
+  if (stat(md.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path: %s",
+                        md.c_str());
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path: %s", md.c_str ());
+    return false;
+  }
 
-      return false;
-    }
+  if (stat(mt.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path: %s",
+                        mt.c_str());
 
-  if ( stat( mt.c_str(), &pathchk ) != 0 )
-    {
+    return false;
+  }
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path: %s", mt.c_str ());
+  if (stat(mc.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path: %s",
+                        mc.c_str());
 
-      return false;
-    }
-
-  if ( stat( mc.c_str(), &pathchk ) != 0 )
-    {
-
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path: %s", mc.c_str ());
-
-      return false;
-    }
+    return false;
+  }
 
   //
   // image object representing the main RM launcher
@@ -577,25 +507,20 @@ linux_x86_process_t::basic_init (
   // image object representing the LIBC library
   // details are filled in proctected_init down in the base layer
   //
-  set_mylibc_image( new linux_image_t<T_VA>(mc));
+  set_mylibc_image(new linux_image_t<T_VA>(mc));
 
-  if (!protected_init(mi, md, mt, mc))
-    {
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed");
+  if (!protected_init(mi, md, mt, mc)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed");
 
-      return false;
-    }
+    return false;
+  }
 
   launcher_symbols_init();
 
   return true;
 }
 
-
 #elif PPC_ARCHITECTURE
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -607,9 +532,8 @@ linux_x86_process_t::basic_init (
 /*!
     Default constructor.
 */
-linux_ppc_gpr_set_t::linux_ppc_gpr_set_t ()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_ppc_gpr_set_t::linux_ppc_gpr_set_t()
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   // This part of the code may be difficult to read. It was trial and error
   //   to detemine what registers are writable and what are not.
   // Mar 11 2008 DHA
@@ -619,40 +543,33 @@ linux_ppc_gpr_set_t::linux_ppc_gpr_set_t ()
   unsigned int gpr_writable_mask = 0;
   int i;
 
-  for ( i=0; i < 32; ++i )
-    {
-      gpr_writable_mask |= (1 << i);
-    }
+  for (i = 0; i < 32; ++i) {
+    gpr_writable_mask |= (1 << i);
+  }
 
-  set_user_offset (0);
-  set_writable_mask (gpr_writable_mask);
+  set_user_offset(0);
+  set_writable_mask(gpr_writable_mask);
 
-} // linux_ppc_gpr_set_t
-
+}  // linux_ppc_gpr_set_t
 
 //! PUBLIC: linux_ppc_gpr_set_t
 /*!
     get_pc
 */
-const T_VA
-linux_ppc_gpr_set_t::get_pc () const
-{
+const T_VA linux_ppc_gpr_set_t::get_pc() const {
   //
   // T_GRP for PowerPC is pt_reg in which nip is defined.
   //
-  T_GRS gpr = get_native_rs ();
+  T_GRS gpr = get_native_rs();
 
   return gpr.nip;
 }
-
 
 //! PUBLIC: linux_x86_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_ppc_gpr_set_t::get_ret_addr() const
-{
+const T_VA linux_ppc_gpr_set_t::get_ret_addr() const {
   //
   // We need to keep track of the "return address"
   // because that address can result from a single-step
@@ -667,19 +584,16 @@ linux_ppc_gpr_set_t::get_ret_addr() const
   // moot point for our purpose though.) The struct member
   // representing the LR is "link."
   //
-  T_GRS gpr = get_native_rs ();
+  T_GRS gpr = get_native_rs();
 
   return gpr.link;
 }
-
 
 //! PUBLIC: linux_ppc_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_ppc_gpr_set_t::get_memloc_for_ret_addr () const
-{
+const T_VA linux_ppc_gpr_set_t::get_memloc_for_ret_addr() const {
   //
   // We need to keep track of the "return address"
   // because that address can result from a single-step
@@ -694,19 +608,13 @@ linux_ppc_gpr_set_t::get_memloc_for_ret_addr () const
   return T_UNINIT_HEX;
 }
 
-
 //! PUBLIC: linux_ppc_gpr_set_t
 /*!
   set_pc method doesn't actually write value into tho PC register
   but into its corresponding data strucuture. The user of this method
   must ensure writing this back into the register.
 */
-void
-linux_ppc_gpr_set_t::set_pc (T_VA addr)
-{
-  rs.nip = addr;
-}
-
+void linux_ppc_gpr_set_t::set_pc(T_VA addr) { rs.nip = addr; }
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -719,23 +627,22 @@ linux_ppc_gpr_set_t::set_pc (T_VA addr)
     Default constructor.
 */
 linux_ppc_fpr_set_t::linux_ppc_fpr_set_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-  //
-  // asm-ppc/ptrace.h defines PT_FPR0 with 48
-  // The offset into the USER area that allows a tool to fetch
-  // floating point registers begins with PT_FPR0 (48)
-  // end with PT_FPR0 + 2*31 (which is PT_FPR31). The following
-  // in the USER area is PT_FPSCR but again this is a moot
-  // point for this project.
-  //
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
+//
+// asm-ppc/ptrace.h defines PT_FPR0 with 48
+// The offset into the USER area that allows a tool to fetch
+// floating point registers begins with PT_FPR0 (48)
+// end with PT_FPR0 + 2*31 (which is PT_FPR31). The following
+// in the USER area is PT_FPSCR but again this is a moot
+// point for this project.
+//
 
 #ifndef PT_FPR0
 #define PT_FPR0 48
 #endif
 
   unsigned int fpr_writable_mask = 0xffffffff;
-  set_user_offset (PT_FPR0);
+  set_user_offset(PT_FPR0);
   set_writable_mask(fpr_writable_mask);
 }
 
@@ -750,25 +657,18 @@ linux_ppc_fpr_set_t::linux_ppc_fpr_set_t()
     Default constructor.
 */
 linux_ppc_thread_t::linux_ppc_thread_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-  set_gprset (new linux_ppc_gpr_set_t());
-  set_fprset (new linux_ppc_fpr_set_t());
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
+  set_gprset(new linux_ppc_gpr_set_t());
+  set_fprset(new linux_ppc_fpr_set_t());
 }
 
-
-linux_ppc_thread_t::~linux_ppc_thread_t()
-{
-
-}
+linux_ppc_thread_t::~linux_ppc_thread_t() {}
 
 //! PUBLIC: linux_ppc_thread_t
 /*!
     accessors
 */
-pid_t
-linux_ppc_thread_t::thr2pid()
-{
+pid_t linux_ppc_thread_t::thr2pid() {
   //
   // ti_lid is defined by the pthread debug library.
   // It contains the lightweight process ID (lwp) that
@@ -779,12 +679,11 @@ linux_ppc_thread_t::thr2pid()
   // thr2pid is a misnomer, it should rather be thr2lwp.
   //
 
-  if ( is_master_thread ())
-    return (pid_t) get_master_pid ();
+  if (is_master_thread())
+    return (pid_t)get_master_pid();
   else
-    return (pid_t) get_thread_info().ti_lid;
+    return (pid_t)get_thread_info().ti_lid;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -796,73 +695,61 @@ linux_ppc_thread_t::thr2pid()
 /*!
     Default constructor.
 */
-linux_ppc_process_t::linux_ppc_process_t ( )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-
-}
-
+linux_ppc_process_t::linux_ppc_process_t()
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {}
 
 //! PUBLIC: linux_ppc_process_t
 /*!
      A constructor.
 */
-linux_ppc_process_t::linux_ppc_process_t (
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-{
-  basic_init (mi, md, mt, mc);
-} // linux_ppc_process_t
-
+linux_ppc_process_t::linux_ppc_process_t(const std::string& mi,
+                                         const std::string& md,
+                                         const std::string& mt,
+                                         const std::string& mc) {
+  basic_init(mi, md, mt, mc);
+}  // linux_ppc_process_t
 
 //! PUBLIC: linux_ppc_process_t
 /*!
     A constructor.
 */
-linux_ppc_process_t::linux_ppc_process_t (
-                 const pid_t& pid )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_ppc_process_t::linux_ppc_process_t(const pid_t& pid)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   //
   // default lwp state is LMON_RM_CREATED
   //
-  linux_ppc_thread_t* master_thread
-    = new linux_ppc_thread_t ();
+  linux_ppc_thread_t* master_thread = new linux_ppc_thread_t();
 
   //
   // indicating this represents the main thread
   //
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
   //
   // pid is lwp pid
   //
-  master_thread->set_master_pid (pid);
+  master_thread->set_master_pid(pid);
 
   //
   // update the thread list
   //
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // TODO: I need to be able to fetch image information
   // using pid to push it into basic_init.
   //
-} // linux_ppc_process_t
-
+}  // linux_ppc_process_t
 
 //! PUBLIC: linux_ppc_process_t
 /*!
     A constructor: this is the currently recommended constructor
 */
-linux_ppc_process_t::linux_ppc_process_t (
-                 const pid_t& pid, const std::string& mi )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_ppc_process_t::linux_ppc_process_t(const pid_t& pid,
+                                         const std::string& mi)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   //
@@ -873,208 +760,169 @@ linux_ppc_process_t::linux_ppc_process_t (
   //
   // default lwp state is LMON_RM_CREATED
   //
-  linux_ppc_thread_t *master_thread
-    = new linux_ppc_thread_t();
+  linux_ppc_thread_t* master_thread = new linux_ppc_thread_t();
 
   //
   // indicating this represents the main thread
   //
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
   //
   // pid is lwp pid
   //
-  master_thread->set_master_pid (pid);
+  master_thread->set_master_pid(pid);
 
   //
   // update the thread list
   //
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // now is the time to initialize my image!
   //
   if (!basic_init(mi)) {
-    throw (machine_exception_t("fail to initialize a process"));
+    throw(machine_exception_t("fail to initialize a process"));
   }
-} // linux_ppc_process_t
-
+}  // linux_ppc_process_t
 
 //! PUBLIC: linux_ppc_process_t
 /*!
     A constructor.
 */
-linux_ppc_process_t::linux_ppc_process_t (
-                 const pid_t& pid,
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_ppc_process_t::linux_ppc_process_t(const pid_t& pid,
+                                         const std::string& mi,
+                                         const std::string& md,
+                                         const std::string& mt,
+                                         const std::string& mc)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   //
   // Once pid is in place, at least the main thread has already
   // come into existence
   //
-  linux_ppc_thread_t *master_thread
-    = new linux_ppc_thread_t();
+  linux_ppc_thread_t* master_thread = new linux_ppc_thread_t();
 
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
-  master_thread->set_master_pid (pid);
+  master_thread->set_master_pid(pid);
 
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // now is the time to initialize my image!
   //
   if (!basic_init(mi)) {
-    throw (machine_exception_t("fail to initialize a process"));
+    throw(machine_exception_t("fail to initialize a process"));
   }
-} // linux_ppc_process_t
-
+}  // linux_ppc_process_t
 
 //! PRIVATE: linux_ppc_process_t
 /*!
     launcher_symbols_init
 */
-void
-linux_ppc_process_t::launcher_symbols_init()
-{
+void linux_ppc_process_t::launcher_symbols_init() {
   //
   // symbols relevant to daemon launching
   //
-  set_launch_breakpoint_sym (LAUNCH_BREAKPOINT);
-  set_launch_being_debug (LAUNCH_BEING_DEBUG);
-  set_launch_debug_state (LAUNCH_DEBUG_STATE);
-  set_launch_debug_gate (LAUNCH_DEBUG_GATE);
-  set_launch_proctable (LAUNCH_PROCTABLE);
-  set_launch_proctable_size (LAUNCH_PROCTABLE_SIZE);
-  set_launch_acquired_premain (LAUNCH_ACQUIRED_PREMAIN);
-  set_launch_exec_path (LAUNCH_EXEC_PATH);
-  set_launch_server_args (LAUNCH_SERVER_ARGS);
-  set_launch_attach_fifo (LAUNCH_ATTACH_FIFO);
+  set_launch_breakpoint_sym(LAUNCH_BREAKPOINT);
+  set_launch_being_debug(LAUNCH_BEING_DEBUG);
+  set_launch_debug_state(LAUNCH_DEBUG_STATE);
+  set_launch_debug_gate(LAUNCH_DEBUG_GATE);
+  set_launch_proctable(LAUNCH_PROCTABLE);
+  set_launch_proctable_size(LAUNCH_PROCTABLE_SIZE);
+  set_launch_acquired_premain(LAUNCH_ACQUIRED_PREMAIN);
+  set_launch_exec_path(LAUNCH_EXEC_PATH);
+  set_launch_server_args(LAUNCH_SERVER_ARGS);
+  set_launch_attach_fifo(LAUNCH_ATTACH_FIFO);
   set_loader_breakpoint_sym(LOADER_BP_SYM);
   set_loader_r_debug_sym(LOADER_R_DEBUG);
   set_loader_start_sym(LOADER_START);
   set_resource_handler_sym(RESOURCE_HANDLER_SYM);
 }
 
-
 //! PUBLIC: linux_ppc_process_t
 /*!
     basic_init
 */
-bool
-linux_ppc_process_t::basic_init (
-                 const std::string& mi )
-{
+bool linux_ppc_process_t::basic_init(const std::string& mi) {
   struct stat pathchk;
 
   //
   // make sure paths exist
   //
-  if ( stat( mi.c_str(), &pathchk ) != 0 )
-    {
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mi.c_str());
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mi.c_str ());
+    return false;
+  }
 
-      return false;
-    }
+  set_myimage(new linux_image_t<T_VA>(mi));
+  set_mydynloader_image(new linux_image_t<T_VA>());
+  set_mythread_lib_image(new linux_image_t<T_VA>());
+  set_mylibc_image(new linux_image_t<T_VA>());
+  set_myrmso_image(new linux_image_t<T_VA>());
 
-  set_myimage (new linux_image_t<T_VA>(mi));
-  set_mydynloader_image (new linux_image_t<T_VA>());
-  set_mythread_lib_image (new linux_image_t<T_VA>());
-  set_mylibc_image (new linux_image_t<T_VA>());
-  set_myrmso_image (new linux_image_t<T_VA>());
+  if (!protected_init(mi)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed.");
 
-  if (!protected_init(mi))
-    {
-
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed." );
-
-      return false;
-    }
+    return false;
+  }
 
   launcher_symbols_init();
 
   return true;
 }
 
-
 //! PUBLIC: linux_ppc_process_t
 /*!
     basic_init
 */
-bool
-linux_ppc_process_t::basic_init (
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-{
+bool linux_ppc_process_t::basic_init(const std::string& mi,
+                                     const std::string& md,
+                                     const std::string& mt,
+                                     const std::string& mc) {
   struct stat pathchk;
 
   //
   // make sure paths exist
   //
-  if ( stat( mi.c_str(), &pathchk ) != 0 )
-    {
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mi.c_str());
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mi.c_str ());
+    return false;
+  }
+  if (stat(md.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        md.c_str());
 
-      return false;
-    }
-  if ( stat( md.c_str(), &pathchk ) != 0 )
-    {
+    return false;
+  }
+  if (stat(mt.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mt.c_str());
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", md.c_str ());
+    return false;
+  }
+  if (stat(mc.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mc.c_str());
 
-      return false;
-    }
-  if ( stat( mt.c_str(), &pathchk ) != 0 )
-    {
+    return false;
+  }
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mt.c_str ());
+  set_myimage(new linux_image_t<T_VA>(mi));
+  set_mydynloader_image(new linux_image_t<T_VA>(md));
+  set_mythread_lib_image(new linux_image_t<T_VA>(mt));
+  set_mylibc_image(new linux_image_t<T_VA>(mc));
 
-      return false;
-    }
-  if ( stat( mc.c_str(), &pathchk ) != 0 )
-    {
+  if (!protected_init(mi, md, mt, mc)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed.");
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mc.c_str ());
-
-      return false;
-    }
-
-  set_myimage (new linux_image_t<T_VA>(mi));
-  set_mydynloader_image (new linux_image_t<T_VA>(md));
-  set_mythread_lib_image (new linux_image_t<T_VA>(mt));
-  set_mylibc_image (new linux_image_t<T_VA>(mc));
-
-  if (!protected_init(mi, md, mt, mc))
-    {
-
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed." );
-
-      return false;
-    }
+    return false;
+  }
 
   launcher_symbols_init();
 
@@ -1083,60 +931,51 @@ linux_ppc_process_t::basic_init (
 
 #elif AARCH64_ARCHITECTURE
 
-
 ////////////////////////////////////////////////////////////////////
 //
 // PUBLIC INTERFACES (class linux_aarch64_gpr_set_t)
 //
 //
- 
+
 //! PUBLIC: linux_aarch64_gpr_set_t
 /*!
     Default constructor.
 */
-linux_aarch64_gpr_set_t::linux_aarch64_gpr_set_t ()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_aarch64_gpr_set_t::linux_aarch64_gpr_set_t()
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   // This part of the code may be difficult to read. It was trial and error
   //   to detemine what registers are writable and what are not.
   // Mar 11 2008 DHA
   // If somebody has ABI documentation that describes all of these,
-  // let me know.  
+  // let me know.
   //
   unsigned int gpr_writable_mask = 0;
   int i;
 
-  for ( i=0; i <= 30; ++i ) 
-    {
-      gpr_writable_mask |= (1 << i);
-    }
+  for (i = 0; i <= 30; ++i) {
+    gpr_writable_mask |= (1 << i);
+  }
 
-  set_user_offset (0);
-  set_writable_mask (gpr_writable_mask);
- 
-} // linux_aarch64_gpr_set_t
- 
- 
+  set_user_offset(0);
+  set_writable_mask(gpr_writable_mask);
+
+}  // linux_aarch64_gpr_set_t
+
 //! PUBLIC: linux_aarch64_gpr_set_t
 /*!
     get_pc
 */
-const T_VA
-linux_aarch64_gpr_set_t::get_pc () const
-{
-  T_GRS gpr = get_native_rs ();
- 
-  return gpr.pc; 
+const T_VA linux_aarch64_gpr_set_t::get_pc() const {
+  T_GRS gpr = get_native_rs();
+
+  return gpr.pc;
 }
- 
 
 //! PUBLIC: linux_aarch64_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_aarch64_gpr_set_t::get_ret_addr() const
-{
+const T_VA linux_aarch64_gpr_set_t::get_ret_addr() const {
   //
   // We need to keep track of the "return address"
   // because that address can result from a single-step
@@ -1151,63 +990,52 @@ linux_aarch64_gpr_set_t::get_ret_addr() const
   // TODO: This is not always true if the LR is spilled to the
   // stack to make room for more GP registers. How to determine
   // this?
-  T_GRS gpr = get_native_rs ();
- 
+  T_GRS gpr = get_native_rs();
+
   return gpr.regs[30];
 }
- 
 
 //! PUBLIC: linux_aarch64_gpr_set_t
 /*!
     get_memloc_for_ret_addr
 */
-const T_VA
-linux_aarch64_gpr_set_t::get_memloc_for_ret_addr () const
-{
+const T_VA linux_aarch64_gpr_set_t::get_memloc_for_ret_addr() const {
   //
   // We need to keep track of the "return address"
-  // because that address can result from a single-step 
-  // needed for a breakpoint operation. 
+  // because that address can result from a single-step
+  // needed for a breakpoint operation.
   // Essentially, we need to be able to indentify all possible
   // reasons for a process stop event; otherwise, our
-  // process state transition will cause a BAD thing. 
+  // process state transition will cause a BAD thing.
   //
   // In this architecture, this information is kepted in
-  // the register set. We simply return T_UNINIT_HEX. 
- 
+  // the register set. We simply return T_UNINIT_HEX.
+
   return T_UNINIT_HEX;
 }
- 
- 
+
 //! PUBLIC: linux_aarch64_gpr_set_t
 /*!
   set_pc method doesn't actually write value into tho PC register
   but into its corresponding data strucuture. The user of this method
-  must ensure writing this back into the register. 
+  must ensure writing this back into the register.
 */
-void
-linux_aarch64_gpr_set_t::set_pc (T_VA addr)
-{
-  rs.pc = addr;
-}
- 
- 
+void linux_aarch64_gpr_set_t::set_pc(T_VA addr) { rs.pc = addr; }
+
 ////////////////////////////////////////////////////////////////////
 //
 // PUBLIC INTERFACES (class linux_aarch64_fpr_set_t)
 //
 //
- 
+
 //! PUBLIC: linux_aarch64_fpr_set_t
 /*!
     Default constructor.
 */
 linux_aarch64_fpr_set_t::linux_aarch64_fpr_set_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   unsigned int fpr_writable_mask = 0xffffffff;
-  set_user_offset (sizeof(T_GRS)+sizeof(int));
+  set_user_offset(sizeof(T_GRS) + sizeof(int));
   set_writable_mask(fpr_writable_mask);
 }
 
@@ -1216,341 +1044,286 @@ linux_aarch64_fpr_set_t::linux_aarch64_fpr_set_t()
 // PUBLIC INTERFACES (class linux_aarch64_thread_t)
 //
 //
- 
+
 //! PUBLIC: linux_aarch64_thread_t
 /*!
     Default constructor.
 */
 linux_aarch64_thread_t::linux_aarch64_thread_t()
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-  set_gprset (new linux_aarch64_gpr_set_t());
-  set_fprset (new linux_aarch64_fpr_set_t());
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
+  set_gprset(new linux_aarch64_gpr_set_t());
+  set_fprset(new linux_aarch64_fpr_set_t());
 }
- 
- 
-linux_aarch64_thread_t::~linux_aarch64_thread_t()
-{
 
-}
- 
+linux_aarch64_thread_t::~linux_aarch64_thread_t() {}
+
 //! PUBLIC: linux_aarch64_thread_t
 /*!
     accessors
 */
-pid_t
-linux_aarch64_thread_t::thr2pid()
-{
+pid_t linux_aarch64_thread_t::thr2pid() {
   //
-  // ti_lid is defined by the pthread debug library.  
-  // It contains the lightweight process ID (lwp) that 
+  // ti_lid is defined by the pthread debug library.
+  // It contains the lightweight process ID (lwp) that
   // the kernel can understand. For example, passing this
-  // information into the ptrace system call, the kernel 
+  // information into the ptrace system call, the kernel
   // should operate on the thread.
   //
-  // thr2pid is a misnomer, it should rather be thr2lwp. 
+  // thr2pid is a misnomer, it should rather be thr2lwp.
   //
 
-  if ( is_master_thread ())
-    return (pid_t) get_master_pid ();
+  if (is_master_thread())
+    return (pid_t)get_master_pid();
   else
-    return (pid_t) get_thread_info().ti_lid;
+    return (pid_t)get_thread_info().ti_lid;
 }
- 
- 
+
 ////////////////////////////////////////////////////////////////////
 //
 // PUBLIC INTERFACES (class linux_aarch64_process_t)
 //
 //
- 
+
 //! PUBLIC: linux_aarch64_process_t
 /*!
     Default constructor.
 */
-linux_aarch64_process_t::linux_aarch64_process_t ( )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
-  
-}
- 
- 
+linux_aarch64_process_t::linux_aarch64_process_t()
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {}
+
 //! PUBLIC: linux_aarch64_process_t
 /*!
      A constructor.
 */
-linux_aarch64_process_t::linux_aarch64_process_t ( 
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-{
-  basic_init (mi, md, mt, mc);
-} // linux_aarch64_process_t
- 
- 
+linux_aarch64_process_t::linux_aarch64_process_t(const std::string& mi,
+                                                 const std::string& md,
+                                                 const std::string& mt,
+                                                 const std::string& mc) {
+  basic_init(mi, md, mt, mc);
+}  // linux_aarch64_process_t
+
 //! PUBLIC: linux_aarch64_process_t
 /*!
     A constructor.
 */
-linux_aarch64_process_t::linux_aarch64_process_t ( 
-                 const pid_t& pid )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_aarch64_process_t::linux_aarch64_process_t(const pid_t& pid)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
 
   //
   // default lwp state is LMON_RM_CREATED
   //
-  linux_aarch64_thread_t* master_thread 
-    = new linux_aarch64_thread_t ();
+  linux_aarch64_thread_t* master_thread = new linux_aarch64_thread_t();
 
   //
-  // indicating this represents the main thread 
+  // indicating this represents the main thread
   //
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
   //
-  // pid is lwp pid 
+  // pid is lwp pid
   //
-  master_thread->set_master_pid (pid);
+  master_thread->set_master_pid(pid);
 
   //
   // update the thread list
   //
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
-  // TODO: I need to be able to fetch image information 
-  // using pid to push it into basic_init.   
+  // TODO: I need to be able to fetch image information
+  // using pid to push it into basic_init.
   //
-} // linux_aarch64_process_t
- 
- 
+}  // linux_aarch64_process_t
+
 //! PUBLIC: linux_aarch64_process_t
 /*!
     A constructor: this is the currently recommended constructor
 */
-linux_aarch64_process_t::linux_aarch64_process_t (
-                 const pid_t& pid, const std::string& mi )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_aarch64_process_t::linux_aarch64_process_t(const pid_t& pid,
+                                                 const std::string& mi)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
- 
+
   //
-  // Once pid is in place, at least the main thread has already 
+  // Once pid is in place, at least the main thread has already
   // come into existence
   //
 
   //
   // default lwp state is LMON_RM_CREATED
   //
-  linux_aarch64_thread_t *master_thread 
-    = new linux_aarch64_thread_t();
+  linux_aarch64_thread_t* master_thread = new linux_aarch64_thread_t();
 
   //
-  // indicating this represents the main thread 
+  // indicating this represents the main thread
   //
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
   //
-  // pid is lwp pid 
+  // pid is lwp pid
   //
-  master_thread->set_master_pid (pid);
+  master_thread->set_master_pid(pid);
 
   //
   // update the thread list
   //
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // now is the time to initialize my image!
   //
   if (!basic_init(mi)) {
-    throw (machine_exception_t("fail to initialize a process"));
+    throw(machine_exception_t("fail to initialize a process"));
   }
-} // linux_aarch64_process_t
- 
- 
+}  // linux_aarch64_process_t
+
 //! PUBLIC: linux_aarch64_process_t
 /*!
     A constructor.
 */
-linux_aarch64_process_t::linux_aarch64_process_t ( 
-                 const pid_t& pid,
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-   : MODULENAME (self_trace_t::self_trace().machine_module_trace.module_name)
-{
+linux_aarch64_process_t::linux_aarch64_process_t(const pid_t& pid,
+                                                 const std::string& mi,
+                                                 const std::string& md,
+                                                 const std::string& mt,
+                                                 const std::string& mc)
+    : MODULENAME(self_trace_t::self_trace().machine_module_trace.module_name) {
   using namespace std;
- 
+
   //
-  // Once pid is in place, at least the main thread has already 
+  // Once pid is in place, at least the main thread has already
   // come into existence
   //
-  linux_aarch64_thread_t *master_thread 
-    = new linux_aarch64_thread_t();
+  linux_aarch64_thread_t* master_thread = new linux_aarch64_thread_t();
 
-  master_thread->set_master_thread (true);
+  master_thread->set_master_thread(true);
 
-  master_thread->set_master_pid (pid);
- 
-  get_thrlist().insert (make_pair((int)pid, master_thread));
+  master_thread->set_master_pid(pid);
+
+  get_thrlist().insert(make_pair((int)pid, master_thread));
 
   //
   // now is the time to initialize my image!
   //
   if (!basic_init(mi)) {
-    throw (machine_exception_t("fail to initialize a process"));
+    throw(machine_exception_t("fail to initialize a process"));
   }
-} // linux_aarch64_process_t
- 
- 
+}  // linux_aarch64_process_t
+
 //! PRIVATE: linux_aarch64_process_t
 /*!
     launcher_symbols_init
 */
-void
-linux_aarch64_process_t::launcher_symbols_init()
-{
+void linux_aarch64_process_t::launcher_symbols_init() {
   //
   // symbols relevant to daemon launching
   //
-  set_launch_breakpoint_sym (LAUNCH_BREAKPOINT);
-  set_launch_being_debug (LAUNCH_BEING_DEBUG);
-  set_launch_debug_state (LAUNCH_DEBUG_STATE);
-  set_launch_debug_gate (LAUNCH_DEBUG_GATE);
-  set_launch_proctable (LAUNCH_PROCTABLE);
-  set_launch_proctable_size (LAUNCH_PROCTABLE_SIZE);
-  set_launch_acquired_premain (LAUNCH_ACQUIRED_PREMAIN);
-  set_launch_exec_path (LAUNCH_EXEC_PATH);
-  set_launch_server_args (LAUNCH_SERVER_ARGS);
-  set_launch_attach_fifo (LAUNCH_ATTACH_FIFO);
+  set_launch_breakpoint_sym(LAUNCH_BREAKPOINT);
+  set_launch_being_debug(LAUNCH_BEING_DEBUG);
+  set_launch_debug_state(LAUNCH_DEBUG_STATE);
+  set_launch_debug_gate(LAUNCH_DEBUG_GATE);
+  set_launch_proctable(LAUNCH_PROCTABLE);
+  set_launch_proctable_size(LAUNCH_PROCTABLE_SIZE);
+  set_launch_acquired_premain(LAUNCH_ACQUIRED_PREMAIN);
+  set_launch_exec_path(LAUNCH_EXEC_PATH);
+  set_launch_server_args(LAUNCH_SERVER_ARGS);
+  set_launch_attach_fifo(LAUNCH_ATTACH_FIFO);
   set_loader_breakpoint_sym(LOADER_BP_SYM);
   set_loader_r_debug_sym(LOADER_R_DEBUG);
   set_loader_start_sym(LOADER_START);
   set_resource_handler_sym(RESOURCE_HANDLER_SYM);
 }
 
+//! PUBLIC: linux_aarch64_process_t
+/*!
+    basic_init
+*/
+bool linux_aarch64_process_t::basic_init(const std::string& mi) {
+  struct stat pathchk;
+
+  //
+  // make sure paths exist
+  //
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mi.c_str());
+
+    return false;
+  }
+
+  set_myimage(new linux_image_t<T_VA>(mi));
+  set_mydynloader_image(new linux_image_t<T_VA>());
+  set_mythread_lib_image(new linux_image_t<T_VA>());
+  set_mylibc_image(new linux_image_t<T_VA>());
+  set_myrmso_image(new linux_image_t<T_VA>());
+
+  if (!protected_init(mi)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed.");
+
+    return false;
+  }
+
+  launcher_symbols_init();
+
+  return true;
+}
 
 //! PUBLIC: linux_aarch64_process_t
 /*!
     basic_init
 */
-bool
-linux_aarch64_process_t::basic_init (
-                 const std::string& mi )
-{
+bool linux_aarch64_process_t::basic_init(const std::string& mi,
+                                         const std::string& md,
+                                         const std::string& mt,
+                                         const std::string& mc) {
   struct stat pathchk;
- 
-  //  
-  // make sure paths exist
-  //
-  if ( stat( mi.c_str(), &pathchk ) != 0 ) 
-    {
 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mi.c_str ());
-  
-      return false;
-    }
-  
-  set_myimage (new linux_image_t<T_VA>(mi));
-  set_mydynloader_image (new linux_image_t<T_VA>());
-  set_mythread_lib_image (new linux_image_t<T_VA>());
-  set_mylibc_image (new linux_image_t<T_VA>());
-  set_myrmso_image (new linux_image_t<T_VA>());
-
-  if (!protected_init(mi)) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed." );
-  
-      return false;
-    }
-   
-  launcher_symbols_init();
- 
-  return true;
-}
- 
- 
-//! PUBLIC: linux_aarch64_process_t
-/*!
-    basic_init
-*/
-bool
-linux_aarch64_process_t::basic_init (
-                 const std::string& mi,
-                 const std::string& md,
-                 const std::string& mt,
-                 const std::string& mc )
-{
-  struct stat pathchk;
-   
   //
   // make sure paths exist
   //
-  if ( stat( mi.c_str(), &pathchk ) != 0 ) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mi.c_str ());
+  if (stat(mi.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mi.c_str());
 
-      return false;
-    }
-  if ( stat( md.c_str(), &pathchk ) != 0 ) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", md.c_str ());
+    return false;
+  }
+  if (stat(md.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        md.c_str());
 
-      return false;
-    }
-  if ( stat( mt.c_str(), &pathchk ) != 0 ) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mt.c_str ());
+    return false;
+  }
+  if (stat(mt.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mt.c_str());
 
-      return false;
-    }
-  if ( stat( mc.c_str(), &pathchk ) != 0 ) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: invalid path %s", mc.c_str ());
- 
-      return false;
-    }
-   
-  set_myimage (new linux_image_t<T_VA>(mi));
-  set_mydynloader_image (new linux_image_t<T_VA>(md));
-  set_mythread_lib_image (new linux_image_t<T_VA>(mt));
-  set_mylibc_image (new linux_image_t<T_VA>(mc));
- 
-  if (!protected_init(mi, md, mt, mc)) 
-    {
- 
-      self_trace_t::trace ( 1,
-            MODULENAME,1,
-            "Machine: protected_init failed." );
- 
-      return false;
-    }
+    return false;
+  }
+  if (stat(mc.c_str(), &pathchk) != 0) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: invalid path %s",
+                        mc.c_str());
+
+    return false;
+  }
+
+  set_myimage(new linux_image_t<T_VA>(mi));
+  set_mydynloader_image(new linux_image_t<T_VA>(md));
+  set_mythread_lib_image(new linux_image_t<T_VA>(mt));
+  set_mylibc_image(new linux_image_t<T_VA>(mc));
+
+  if (!protected_init(mi, md, mt, mc)) {
+    self_trace_t::trace(1, MODULENAME, 1, "Machine: protected_init failed.");
+
+    return false;
+  }
 
   launcher_symbols_init();
- 
+
   return true;
 }
 
-#endif // AARCH64_ARCHITECTURE
+#endif  // AARCH64_ARCHITECTURE
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_mach.hxx
+++ b/launchmon/src/linux/sdbg_linux_mach.hxx
@@ -1,27 +1,28 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_mach.hxx,v 1.3.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
  * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
  *
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
@@ -43,11 +44,10 @@ extern "C" {
 }
 
 #include <string>
-#include "sdbg_std.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_linux_std.hxx"
 #include "sdbg_linux_symtab.hxx"
-
+#include "sdbg_std.hxx"
 
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE
 
@@ -162,25 +162,23 @@ extern "C" {
 
  */
 
-class linux_x86_gpr_set_t
-  : public register_set_base_t<T_GRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_x86_gpr_set_t : public register_set_base_t<T_GRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_x86_gpr_set_t  ();
-  virtual ~linux_x86_gpr_set_t () { }
+  linux_x86_gpr_set_t();
+  virtual ~linux_x86_gpr_set_t() {}
 
-  virtual void set_pc  (T_VA addr);
-  virtual T_VA const get_pc () const;
+  virtual void set_pc(T_VA addr);
+  virtual T_VA const get_pc() const;
   virtual T_VA const get_ret_addr() const;
   virtual T_VA const get_memloc_for_ret_addr() const;
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
@@ -273,36 +271,29 @@ private:
     };
 
 */
-class linux_x86_fpr_set_t
-  : public register_set_base_t<T_FRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_x86_fpr_set_t : public register_set_base_t<T_FRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_x86_fpr_set_t ();
-  virtual ~linux_x86_fpr_set_t() { }
+  linux_x86_fpr_set_t();
+  virtual ~linux_x86_fpr_set_t() {}
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //! class linux_x86_thread_t:
 /*!
     linux_x86_thread_t is linux x86 and x86-64 implementation of thread_base_t
     class. The constructor sets register model.
 */
-class linux_x86_thread_t
-  : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+class linux_x86_thread_t : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
   linux_x86_thread_t();
@@ -312,14 +303,14 @@ public:
   // which the kernel understands
   virtual pid_t thr2pid();
 
-
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //! linux_x86_process_t:
 /*!
@@ -327,44 +318,35 @@ private:
   class. The constructor sets register model.
 */
 class linux_x86_process_t
-  : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+    : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
-  linux_x86_process_t ();
-  linux_x86_process_t ( const std::string& mi,
-      const std::string& md,
-      const std::string& mt,
-      const std::string& mc );
-  linux_x86_process_t ( const pid_t& pid,
-      const std::string& mi,
-      const std::string& md,
-      const std::string& mt,
-            const std::string& mc );
-  linux_x86_process_t ( const pid_t& pid,
-      const std::string& mi );
+  linux_x86_process_t();
+  linux_x86_process_t(const std::string& mi, const std::string& md,
+                      const std::string& mt, const std::string& mc);
+  linux_x86_process_t(const pid_t& pid, const std::string& mi,
+                      const std::string& md, const std::string& mt,
+                      const std::string& mc);
+  linux_x86_process_t(const pid_t& pid, const std::string& mi);
 
-  explicit linux_x86_process_t ( const pid_t& pid );
-  ~linux_x86_process_t() { }
+  explicit linux_x86_process_t(const pid_t& pid);
+  ~linux_x86_process_t() {}
 
-protected:
-  bool basic_init ( const std::string& mi,
-        const std::string& md,
-        const std::string& mt,
-        const std::string& mc );
+ protected:
+  bool basic_init(const std::string& mi, const std::string& md,
+                  const std::string& mt, const std::string& mc);
 
-  bool basic_init ( const std::string& mi );
+  bool basic_init(const std::string& mi);
 
-private:
+ private:
   void launcher_symbols_init();
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
-
 };
 
 // data structure needed by proc service layer
@@ -402,30 +384,26 @@ struct ps_prochandle {
     General purpose register set resides at the zero offset.
 */
 
-class linux_aarch64_gpr_set_t
-  : public register_set_base_t<T_GRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_aarch64_gpr_set_t : public register_set_base_t<T_GRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_aarch64_gpr_set_t  ();
-  virtual ~linux_aarch64_gpr_set_t () { }
+  linux_aarch64_gpr_set_t();
+  virtual ~linux_aarch64_gpr_set_t() {}
 
-  virtual void set_pc  (T_VA addr);
-  virtual T_VA const get_pc () const;
+  virtual void set_pc(T_VA addr);
+  virtual T_VA const get_pc() const;
   virtual T_VA const get_ret_addr() const;
   virtual T_VA const get_memloc_for_ret_addr() const;
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
-
 
 //! linux_aarch64_fpr_set_t
 /*!
@@ -453,24 +431,21 @@ private:
 
     General purpose register set resides at the zero offset.
 */
-class linux_aarch64_fpr_set_t
-  : public register_set_base_t<T_FRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_aarch64_fpr_set_t : public register_set_base_t<T_FRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_aarch64_fpr_set_t ();
-  virtual ~linux_aarch64_fpr_set_t() { }
+  linux_aarch64_fpr_set_t();
+  virtual ~linux_aarch64_fpr_set_t() {}
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //! class linux_aarch64_thread_t:
 /*!
@@ -478,11 +453,8 @@ private:
     class. The constructor sets register model.
 */
 class linux_aarch64_thread_t
-  : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+    : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
   linux_aarch64_thread_t();
@@ -492,14 +464,14 @@ public:
   // which the kernel understands
   virtual pid_t thr2pid();
 
-
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //! linux_aarch64_process_t:
 /*!
@@ -507,44 +479,35 @@ private:
   class. The constructor sets register model.
 */
 class linux_aarch64_process_t
-  : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+    : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
-  linux_aarch64_process_t ();
-  linux_aarch64_process_t ( const std::string& mi,
-      const std::string& md,
-      const std::string& mt,
-      const std::string& mc );
-  linux_aarch64_process_t ( const pid_t& pid,
-      const std::string& mi,
-      const std::string& md,
-      const std::string& mt,
-            const std::string& mc );
-  linux_aarch64_process_t ( const pid_t& pid,
-      const std::string& mi );
+  linux_aarch64_process_t();
+  linux_aarch64_process_t(const std::string& mi, const std::string& md,
+                          const std::string& mt, const std::string& mc);
+  linux_aarch64_process_t(const pid_t& pid, const std::string& mi,
+                          const std::string& md, const std::string& mt,
+                          const std::string& mc);
+  linux_aarch64_process_t(const pid_t& pid, const std::string& mi);
 
-  explicit linux_aarch64_process_t ( const pid_t& pid );
-  ~linux_aarch64_process_t() { }
+  explicit linux_aarch64_process_t(const pid_t& pid);
+  ~linux_aarch64_process_t() {}
 
-protected:
-  bool basic_init ( const std::string& mi,
-        const std::string& md,
-        const std::string& mt,
-        const std::string& mc );
+ protected:
+  bool basic_init(const std::string& mi, const std::string& md,
+                  const std::string& mt, const std::string& mc);
 
-  bool basic_init ( const std::string& mi );
+  bool basic_init(const std::string& mi);
 
-private:
+ private:
   void launcher_symbols_init();
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
-
 };
 
 // data structure needed by proc service layer
@@ -611,25 +574,23 @@ struct ps_prochandle {
   and PT_FPSCR (PT_FPR0 + 2*32 + 1)
  */
 
-class linux_ppc_gpr_set_t
-  : public register_set_base_t<T_GRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_ppc_gpr_set_t : public register_set_base_t<T_GRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_ppc_gpr_set_t  ();
-  virtual ~linux_ppc_gpr_set_t () { }
+  linux_ppc_gpr_set_t();
+  virtual ~linux_ppc_gpr_set_t() {}
 
-  virtual void set_pc  (T_VA addr);
-  virtual T_VA const get_pc () const;
+  virtual void set_pc(T_VA addr);
+  virtual T_VA const get_pc() const;
   virtual T_VA const get_ret_addr() const;
   virtual T_VA const get_memloc_for_ret_addr() const;
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
@@ -689,36 +650,29 @@ private:
   Each FP reg occupies 2 slots in this space. PT_FPR31 (PT_FPR0 + 2*31)
   and PT_FPSCR (PT_FPR0 + 2*32 + 1)
 */
-class linux_ppc_fpr_set_t
-  : public register_set_base_t<T_FRS, T_VA, T_WT>
-{
-
-public:
-
+class linux_ppc_fpr_set_t : public register_set_base_t<T_FRS, T_VA, T_WT> {
+ public:
   // constructors and destructor
   //
-  linux_ppc_fpr_set_t ();
-  virtual ~linux_ppc_fpr_set_t() { }
+  linux_ppc_fpr_set_t();
+  virtual ~linux_ppc_fpr_set_t() {}
 
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //! linux_ppc_thread_t:
 /*!
     linux_ppc_thread_t is the linux ppc implementation of thread_base_t
     class. The constructor sets the register model.
 */
-class linux_ppc_thread_t
-  : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+class linux_ppc_thread_t : public thread_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
   linux_ppc_thread_t();
@@ -728,14 +682,14 @@ public:
   // which the kernel understand.
   virtual pid_t thr2pid();
 
-
-private:
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
-
 
 //!
 /*!
@@ -743,41 +697,33 @@ private:
   class. The constructor sets the register model.
 */
 class linux_ppc_process_t
-  : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>
-{
-
-public:
-
+    : public process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> {
+ public:
   // constructors and destructor
   //
-  linux_ppc_process_t ();
-  linux_ppc_process_t ( const std::string& mi,
-                        const std::string& md,
-                        const std::string& mt,
-                        const std::string& mc );
-  linux_ppc_process_t ( const pid_t& pid,
-                        const std::string& mi,
-                        const std::string& md,
-                        const std::string& mt,
-                        const std::string& mc );
-  linux_ppc_process_t ( const pid_t& pid,
-                        const std::string& mi );
+  linux_ppc_process_t();
+  linux_ppc_process_t(const std::string& mi, const std::string& md,
+                      const std::string& mt, const std::string& mc);
+  linux_ppc_process_t(const pid_t& pid, const std::string& mi,
+                      const std::string& md, const std::string& mt,
+                      const std::string& mc);
+  linux_ppc_process_t(const pid_t& pid, const std::string& mi);
 
-  explicit linux_ppc_process_t ( const pid_t& pid );
-  ~linux_ppc_process_t() { }
+  explicit linux_ppc_process_t(const pid_t& pid);
+  ~linux_ppc_process_t() {}
 
-protected:
-  bool basic_init ( const std::string& mi,
-                    const std::string& md,
-                    const std::string& mt,
-                    const std::string& mc );
+ protected:
+  bool basic_init(const std::string& mi, const std::string& md,
+                  const std::string& mt, const std::string& mc);
 
-  bool basic_init ( const std::string& mi );
+  bool basic_init(const std::string& mi);
 
-private:
+ private:
   void launcher_symbols_init();
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
 
   std::string MODULENAME;
 };
@@ -785,8 +731,12 @@ private:
 // data structure needed by proc service layer
 //
 struct ps_prochandle {
-  process_base_t<SDBG_LINUX_DFLT_INSTANTIATION> *p;
+  process_base_t<SDBG_LINUX_DFLT_INSTANTIATION>* p;
 };
 
-#endif // ARCHITECTURES
-#endif // SDBG_LINUX_MACH_HXX
+#endif  // ARCHITECTURES
+#endif  // SDBG_LINUX_MACH_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_ptracer.hxx
+++ b/launchmon/src/linux/sdbg_linux_ptracer.hxx
@@ -1,29 +1,30 @@
-/*                                                       
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_ptracer.hxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
+/*
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jul 31 2012 DHA: Added setoptions/setunoptions
@@ -34,8 +35,8 @@
  *        Aug 16 2007 DHA: backtrace support for linux tracer exception
  *        Jul 03 2006 DHA: Added self tracing support
  *        Mar 30 2006 DHA: Added exception handling support
- *        Jan 10 2006 DHA: Created file.          
- */ 
+ *        Jan 10 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_LINUX_PTRACER_HXX
 #define SDBG_LINUX_PTRACER_HXX 1
@@ -45,24 +46,24 @@ extern "C" {
 //
 // W/R on a system that has
 //
-# ifndef PTRACE_SETOPTIONS
-#  define PTRACE_SETOPTIONS       0x4200
-# endif
-# ifndef PTRACE_GETEVENTMSG
-#  define PTRACE_GETEVENTMSG      0x4201
-# endif
-# ifndef PTRACE_O_TRACEFORK
-#  define PTRACE_O_TRACEFORK      0x00000002
-# endif
-# ifndef PTRACE_O_TRACEVFORK
-#  define PTRACE_O_TRACEVFORK     0x00000004
-# endif
-# ifndef PTRACE_O_TRACECLONE
-#  define PTRACE_O_TRACECLONE     0x00000008
-# endif
-# ifndef PTRACE_EVENT_CLONE
-#  define PTRACE_EVENT_CLONE      3
-# endif
+#ifndef PTRACE_SETOPTIONS
+#define PTRACE_SETOPTIONS 0x4200
+#endif
+#ifndef PTRACE_GETEVENTMSG
+#define PTRACE_GETEVENTMSG 0x4201
+#endif
+#ifndef PTRACE_O_TRACEFORK
+#define PTRACE_O_TRACEFORK 0x00000002
+#endif
+#ifndef PTRACE_O_TRACEVFORK
+#define PTRACE_O_TRACEVFORK 0x00000004
+#endif
+#ifndef PTRACE_O_TRACECLONE
+#define PTRACE_O_TRACECLONE 0x00000008
+#endif
+#ifndef PTRACE_EVENT_CLONE
+#define PTRACE_EVENT_CLONE 3
+#endif
 }
 
 #include "sdbg_base_tracer.hxx"
@@ -70,180 +71,166 @@ extern "C" {
 
 const int LINUX_TRACER_EVENT_CLONE = PTRACE_EVENT_CLONE;
 
-
 //! class linux_tracer_exception_t : public tracer_exception_t
 /*!
- 
+
 
 */
-class linux_tracer_exception_t : public tracer_exception_t 
-{
+class linux_tracer_exception_t : public tracer_exception_t {
+ public:
+  linux_tracer_exception_t() {}
+  linux_tracer_exception_t(const char *m, tracer_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_TRACER_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+    get_backtrace();
+  }
+  linux_tracer_exception_t(const std::string &m, tracer_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_TRACER_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+    get_backtrace();
+  }
 
-public:
-
-  linux_tracer_exception_t ()                          { }
-  linux_tracer_exception_t ( const char* m, tracer_error_e e)
-                     { set_message (m);
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_TRACER_ERROR" ) );
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ );
-                       get_backtrace(); 
-                      }
-  linux_tracer_exception_t( const std::string& m, tracer_error_e e)
-                     { set_message (m);
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_TRACER_ERROR" ) );
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ );
-                       get_backtrace();
-                      }
-
-  virtual ~linux_tracer_exception_t()                  { }
-  bool get_backtrace () 
-                     {
-		       std::string mybt;
-		       bool rc = glic_backtrace_wrapper(mybt);
-		       set_bt(mybt);		       
-		       return rc;
-                     }
+  virtual ~linux_tracer_exception_t() {}
+  bool get_backtrace() {
+    std::string mybt;
+    bool rc = glic_backtrace_wrapper(mybt);
+    set_bt(mybt);
+    return rc;
+  }
 };
-
 
 //! class linux_ptracer_t
 /*!
-    Linux ptrace implementation of trace_base_t. 
+    Linux ptrace implementation of trace_base_t.
 
     It provides a reference ptrace implementation using
     ptrace interface on Linux/X86 system. If you have
-    a ptrace variant whose semantics are slightly 
+    a ptrace variant whose semantics are slightly
     different from Linux's, you should override the
     corresponding methods by deriving your class from
     linux_ptrace_t class.
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-class linux_ptracer_t : public tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>
-{
-
-public:
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+class linux_ptracer_t : public tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> {
+ public:
   linux_ptracer_t();
   linux_ptracer_t(const linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM> &p);
   virtual ~linux_ptracer_t() {}
 
- 
   ////////////////////////////////////////////////////////////
   //
   //  Interfaces
   //
-  virtual tracer_error_e tracer_setregs    
-  ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);    
+  virtual tracer_error_e tracer_setregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_getregs   
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_getregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_setfpregs 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);      
+  virtual tracer_error_e tracer_setfpregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_getfpregs 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_getfpregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_read       
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-      VA addr, void* buf, int size, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_read(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_read_string
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, void* buf, int size, bool use_cxt )
-    throw (linux_tracer_exception_t);
+  virtual tracer_error_e tracer_read_string(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_get_event_msg
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, void* buf, bool use_cxt )
-    throw (tracer_exception_t);   
+  virtual tracer_error_e tracer_get_event_msg(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf,
+      bool use_cxt) throw(tracer_exception_t);
 
-  virtual tracer_error_e tracer_write      
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, const void* buf, int size, bool use_cxt )	
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_write(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, const void *buf,
+      int size, bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_continue   
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_continue(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_deliver_signal
-  ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig, bool use_cxt )
-    throw (linux_tracer_exception_t);  
+  virtual tracer_error_e tracer_deliver_signal(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_stop
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt );
+  virtual tracer_error_e tracer_stop(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                                     bool use_cxt);
 
-  virtual tracer_error_e tracer_kill    
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_kill(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_singlestep 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e tracer_singlestep(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_syscall  
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (linux_tracer_exception_t);    
+  virtual tracer_error_e tracer_syscall(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_detach  
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt );
+  virtual tracer_error_e tracer_detach(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt);
 
-  virtual tracer_error_e tracer_setoptions
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt, pid_t newtid=-1)
-    throw (linux_tracer_exception_t);
+  virtual tracer_error_e tracer_setoptions(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid = -1) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_unsetoptions
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt, pid_t newtid )
-    throw (linux_tracer_exception_t);
+  virtual tracer_error_e tracer_unsetoptions(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_attach  
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt, pid_t newtid=-1)
-    throw (linux_tracer_exception_t);
-  
-  virtual tracer_error_e status
-    (  process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt );
+  virtual tracer_error_e tracer_attach(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid = -1) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e tracer_trace_me   ()
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e status(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                                bool use_cxt);
 
-  virtual tracer_error_e enable_breakpoint 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      breakpoint_base_t<VA, IT>& bp, bool use_cxt, bool change_state=true )
-    throw (linux_tracer_exception_t);
+  virtual tracer_error_e tracer_trace_me() throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e disable_breakpoint 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-      breakpoint_base_t<VA, IT>& bp, bool use_cxt, bool change_state=true )
-    throw (linux_tracer_exception_t);
+  virtual tracer_error_e enable_breakpoint(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
+      bool use_cxt, bool change_state = true) throw(linux_tracer_exception_t);
 
-  virtual tracer_error_e convert_error_code(int err)
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e disable_breakpoint(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
+      bool use_cxt, bool change_state = true) throw(linux_tracer_exception_t);
 
-  tracer_error_e baretracer ( int __tag, pid_t __p, VA __addr, WT* __wd)
-    throw (linux_tracer_exception_t);   
+  virtual tracer_error_e convert_error_code(int err) throw(
+      linux_tracer_exception_t);
 
-private:
-  
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >= level); }
+  tracer_error_e baretracer(int __tag, pid_t __p, VA __addr,
+                            WT *__wd) throw(linux_tracer_exception_t);
 
-  long Pptrace ( __ptrace_request request, 
-		 pid_t pid, 
-		 void *addr, 
-		 void *data);
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().tracer_module_trace.verbosity_level >=
+            level);
+  }
+
+  long Pptrace(__ptrace_request request, pid_t pid, void *addr, void *data);
 
   // For self tracing
   //
-  std::string MODULENAME; 
+  std::string MODULENAME;
 };
 
-#endif // SDBG_LINUX_PTRACER_HXX
+#endif  // SDBG_LINUX_PTRACER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_std.hxx
+++ b/launchmon/src/linux/sdbg_linux_std.hxx
@@ -1,29 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_std.hxx,v 1.5.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May  02 2018 KMD: Added aarch64 support
@@ -33,11 +34,11 @@
  *        Mar  06 2008 DHA: Deprecate GLUESYM support
  *        Mar  11 2008 DHA: Added PowerPC support (BlueGene FEN)
  *        Feb  09 2008 DHA: Added LLNS Copyright
- *        Aug  15 2007 DHA: Change C macroes to C++ style: const char * const 
+ *        Aug  15 2007 DHA: Change C macroes to C++ style: const char * const
  *        Jan  09 2006 DHA: Linux X86-64 support
  *        Mar  22 2006 DHA: Created file.
  *
- */ 
+ */
 
 #ifndef SDBG_LINUX_STD_HXX
 #define SDBG_LINUX_STD_HXX 1
@@ -48,101 +49,101 @@ extern "C" {
 #include <stddef.h>
 }
 
-#include <string>
 #include <cxxabi.h> /* picking up demangling service */
+#include <string>
 
 //! LAUNCH_BREAKPOINT:
 /*!
     Symbol for the dummy function that gets invoked
     by the RM to notify state changes of the target job
 */
-const char * const LAUNCH_BREAKPOINT        = "MPIR_Breakpoint";
+const char *const LAUNCH_BREAKPOINT = "MPIR_Breakpoint";
 
 //! LAUNCH_BEING_DEBUG:
 /*!
     Symbol that tells the RM whether it is traced or not
 */
-const char * const LAUNCH_BEING_DEBUG       = "MPIR_being_debugged";
+const char *const LAUNCH_BEING_DEBUG = "MPIR_being_debugged";
 
 //! LAUNCH_DEBUG_STATE:
 /*!
     Symbol that tells the engine the state of the job when
     LAUNCH_BREAKPOINT is called
 */
-const char * const LAUNCH_DEBUG_STATE       = "MPIR_debug_state";
+const char *const LAUNCH_DEBUG_STATE = "MPIR_debug_state";
 
 //! LAUNCH_DEBUG_GATE:
 /*!
     Symbol to tells the job to gate the starting of the job
 */
-const char * const LAUNCH_DEBUG_GATE        = "MPIR_debug_gate";
+const char *const LAUNCH_DEBUG_GATE = "MPIR_debug_gate";
 
 //! LAUNCH_PROCTABLE:
 /*!
     Symbol that holds an array of MPI process table
 */
-const char * const LAUNCH_PROCTABLE         = "MPIR_proctable";
+const char *const LAUNCH_PROCTABLE = "MPIR_proctable";
 
 //! LAUNCH_PROCTABLE:
 /*!
     Symbol that holds the size of LAUNCH_PROCTABLE
 */
-const char * const LAUNCH_PROCTABLE_SIZE    = "MPIR_proctable_size";
+const char *const LAUNCH_PROCTABLE_SIZE = "MPIR_proctable_size";
 
 //! LAUNCH_ACQUIRED_PREMAIN:
 /*!
-    Symbol that tells whether a debugger can force the main 
+    Symbol that tells whether a debugger can force the main
     for the first attach point
 */
-const char * const LAUNCH_ACQUIRED_PREMAIN  = "MPIR_acquired_pre_main";
+const char *const LAUNCH_ACQUIRED_PREMAIN = "MPIR_acquired_pre_main";
 
 //! LAUNCH_EXEC_PATH:
 /*!
     Symbol that provides the tool daemon exectuable path to the RM
 */
-const char * const LAUNCH_EXEC_PATH         = "MPIR_executable_path";
+const char *const LAUNCH_EXEC_PATH = "MPIR_executable_path";
 
 //! LAUNCH_SERVER_ARGS:
 /*!
     Symbol that provides the tool daemons with their arguments
 */
-const char * const LAUNCH_SERVER_ARGS       = "MPIR_server_arguments";
+const char *const LAUNCH_SERVER_ARGS = "MPIR_server_arguments";
 
 //! LAUNCH_ATTACH_FIFO:
 /*!
     Symbol that provides the tool daemons with their arguments
 */
-const char * const LAUNCH_ATTACH_FIFO       = "MPIR_attach_fifo";
+const char *const LAUNCH_ATTACH_FIFO = "MPIR_attach_fifo";
 
 //! LOADER_BP_SYM:
 /*!
-    Symbol within the dynamic linker, which gets invoked on shared library 
+    Symbol within the dynamic linker, which gets invoked on shared library
     load
 */
-const char * const LOADER_BP_SYM            = "_dl_debug_state";
+const char *const LOADER_BP_SYM = "_dl_debug_state";
 
 //! LOADER_R_DEBUG:
 /*!
     Symbol within the dynamic linker, which holds the current link map
 */
-const char * const LOADER_R_DEBUG           = "_r_debug";
+const char *const LOADER_R_DEBUG = "_r_debug";
 
 //! LOADER_START:
 /*!
     Symbol within the dynamic linker, which is the first function to be
     called after exec
 */
-const char * const LOADER_START             = "_start";
-const char * const LIBC_IDEN                = "libc.";
-const char * const LIBPTHREAD_IDEN          = "libpthread."; 
-const char * const RESOURCE_HANDLER_SYM     = "totalview_jobid";
-const char * const ERRMSG_PTRACE            = " error returned from ptrace ";
-const char * const ERRMSG_KILL              = " error returned from kill ";
-const char * const LIBTHREAD_DB             = "libthread_db.so.1";
+const char *const LOADER_START = "_start";
+const char *const LIBC_IDEN = "libc.";
+const char *const LIBPTHREAD_IDEN = "libpthread.";
+const char *const RESOURCE_HANDLER_SYM = "totalview_jobid";
+const char *const ERRMSG_PTRACE = " error returned from ptrace ";
+const char *const ERRMSG_KILL = " error returned from kill ";
+const char *const LIBTHREAD_DB = "libthread_db.so.1";
 
-const int MAX_LIB_PATH                      = 128;
-const int MAX_STRING_SIZE                   = 1024;
-const int BPCHAINMAX                        = 128;
+const int MAX_LIB_PATH = 128;
+const int MAX_STRING_SIZE = 1024;
+const int BPCHAINMAX = 128;
 
 //! my_thrinfo_t
 /*! new thread-specific data structure that is far simpler
@@ -152,9 +153,7 @@ struct my_thrinfo_t {
   pid_t ti_lid;
 };
 
-inline 
-bool glic_backtrace_wrapper (std::string &bt)
-{
+inline bool glic_backtrace_wrapper(std::string &bt) {
   using namespace std;
   void *StFrameArray[BPCHAINMAX] = {0};
   char **stacksymbols, **ssUsed;
@@ -162,71 +161,66 @@ bool glic_backtrace_wrapper (std::string &bt)
   int i;
   string mybt;
 
-  if ( (size = backtrace (StFrameArray, BPCHAINMAX)) <= 0 )
-    {
-      return false;
-    }
+  if ((size = backtrace(StFrameArray, BPCHAINMAX)) <= 0) {
+    return false;
+  }
 
-  size = (size > BPCHAINMAX) ? BPCHAINMAX: size;
-  stacksymbols = backtrace_symbols (StFrameArray, BPCHAINMAX);
+  size = (size > BPCHAINMAX) ? BPCHAINMAX : size;
+  stacksymbols = backtrace_symbols(StFrameArray, BPCHAINMAX);
 
   /* demangle support */
-  char **demangleStSyms = (char **) malloc (size * sizeof(char *));
-  size_t dnSize; 
-  if (!demangleStSyms) 
+  char **demangleStSyms = (char **)malloc(size * sizeof(char *));
+  size_t dnSize;
+  if (!demangleStSyms)
     ssUsed = stacksymbols;
-  else 
-    {
-      int i;
-      string delims("()+[]");
-      /* starting from 2 to remove two top stack frames */
-      for (i=2; i < size; ++i) 
-	{
-	  char *demangledName;
-	  int status;
-	  string targetStr (stacksymbols[i]);
-	  string binName, funcName, newStr;
-	  string::size_type begIdx, endIdx;
-	  
-	  begIdx = targetStr.find_first_not_of (delims); 	
-	  endIdx = targetStr.find_first_of (delims, begIdx);
-	  if ( (begIdx == string::npos) || (endIdx == string::npos) ) 
-	    binName = "BinaryNameNA";
-	  else
-	    {
-	      binName = targetStr.substr(begIdx, endIdx-begIdx);
-	      char *bn = strdup (binName.c_str());
-	      binName = basename(bn);
-	      free(bn);
-	    }
-	  
-	  begIdx = targetStr.find_first_not_of (delims, endIdx);
-	  endIdx = targetStr.find_first_of (delims, begIdx);
-	  if ( (begIdx == string::npos) || (endIdx == string::npos) ) 
-	    funcName = "FuncNameNA";
-	  else
-	    {
-	      funcName = targetStr.substr(begIdx, endIdx-begIdx);
-	      
-	      demangledName = abi::__cxa_demangle (funcName.c_str(), NULL, NULL, &status);
-	      if ( status < 0 )
-		newStr = binName + ": " + funcName;
-	      else
-		newStr = binName + ": " + demangledName;
-	      demangleStSyms[i] = strdup (newStr.c_str());
-	    }
-	}
-      ssUsed = demangleStSyms;
+  else {
+    int i;
+    string delims("()+[]");
+    /* starting from 2 to remove two top stack frames */
+    for (i = 2; i < size; ++i) {
+      char *demangledName;
+      int status;
+      string targetStr(stacksymbols[i]);
+      string binName, funcName, newStr;
+      string::size_type begIdx, endIdx;
+
+      begIdx = targetStr.find_first_not_of(delims);
+      endIdx = targetStr.find_first_of(delims, begIdx);
+      if ((begIdx == string::npos) || (endIdx == string::npos))
+        binName = "BinaryNameNA";
+      else {
+        binName = targetStr.substr(begIdx, endIdx - begIdx);
+        char *bn = strdup(binName.c_str());
+        binName = basename(bn);
+        free(bn);
+      }
+
+      begIdx = targetStr.find_first_not_of(delims, endIdx);
+      endIdx = targetStr.find_first_of(delims, begIdx);
+      if ((begIdx == string::npos) || (endIdx == string::npos))
+        funcName = "FuncNameNA";
+      else {
+        funcName = targetStr.substr(begIdx, endIdx - begIdx);
+
+        demangledName =
+            abi::__cxa_demangle(funcName.c_str(), NULL, NULL, &status);
+        if (status < 0)
+          newStr = binName + ": " + funcName;
+        else
+          newStr = binName + ": " + demangledName;
+        demangleStSyms[i] = strdup(newStr.c_str());
+      }
     }
+    ssUsed = demangleStSyms;
+  }
   /* ssUsed = stacksymbols;*/
 
-  bt = "BACKTRACE: \n";  
-  /* starting from 2 to remove two top stack frames */  
-  for( i=2 ; i < size ; ++i)
-    {
-      bt += ssUsed[i]; 
-      bt += "\n";
-    }
+  bt = "BACKTRACE: \n";
+  /* starting from 2 to remove two top stack frames */
+  for (i = 2; i < size; ++i) {
+    bt += ssUsed[i];
+    bt += "\n";
+  }
 
   return true;
 }
@@ -235,189 +229,172 @@ bool glic_backtrace_wrapper (std::string &bt)
 // various levels of linux. This sets the appropriate struct based on
 // configure checks.
 #if X86_ARCHITECTURE || X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
-  #if defined(HAVE_STRUCT_USER_REGS_STRUCT)
-    #define SDBG_LINUX_REGS_STRUCT struct user_regs_struct
-  #elif defined(HAVE_STRUCT_USER_PT_REGS)
-    #define SDBG_LINUX_REGS_STRUCT struct user_pt_regs
-  #else
-    #error Missing required definition from <sys/user.h> for cpu registers!
-  #endif
-  #if defined(HAVE_STRUCT_USER_FPREGS_STRUCT)
-    #define SDBG_LINUX_FPREGS_STRUCT struct user_fpregs_struct
-  #elif defined(HAVE_STRUCT_USER_FPSIMD_STRUCT)
-    #define SDBG_LINUX_FPREGS_STRUCT struct user_fpsimd_struct
-  #elif defined(HAVE_STRUCT_USER_FPSIMD_STATE)
-    #define SDBG_LINUX_FPREGS_STRUCT struct user_fpsimd_state
-  #else
-    #error Missing required definition from <sys/user.h> for floating point registers!
-  #endif
+#if defined(HAVE_STRUCT_USER_REGS_STRUCT)
+#define SDBG_LINUX_REGS_STRUCT struct user_regs_struct
+#elif defined(HAVE_STRUCT_USER_PT_REGS)
+#define SDBG_LINUX_REGS_STRUCT struct user_pt_regs
+#else
+#error Missing required definition from <sys/user.h> for cpu registers!
+#endif
+#if defined(HAVE_STRUCT_USER_FPREGS_STRUCT)
+#define SDBG_LINUX_FPREGS_STRUCT struct user_fpregs_struct
+#elif defined(HAVE_STRUCT_USER_FPSIMD_STRUCT)
+#define SDBG_LINUX_FPREGS_STRUCT struct user_fpsimd_struct
+#elif defined(HAVE_STRUCT_USER_FPSIMD_STATE)
+#define SDBG_LINUX_FPREGS_STRUCT struct user_fpsimd_state
+#else
+#error Missing required definition from <sys/user.h> for floating point registers!
+#endif
 #endif
 
 #if X86_ARCHITECTURE
 
-  // 
-  // 
-  // insert linux X86 architecture macros here ...
-  //
-  //
-  //
+//
+//
+// insert linux X86 architecture macros here ...
+//
+//
+//
 
-  typedef u_int32_t                             T_VA;
-  typedef u_int32_t                             T_WT;
-  //
-  // For the purpose of what we are doing, the fixed-length
-  // T_IT is fine to represent an instruction
-  //
-  typedef u_int32_t                             T_IT;
-  typedef SDBG_LINUX_REGS_STRUCT                T_GRS;
-  typedef SDBG_LINUX_FPREGS_STRUCT              T_FRS;
+typedef u_int32_t T_VA;
+typedef u_int32_t T_WT;
+//
+// For the purpose of what we are doing, the fixed-length
+// T_IT is fine to represent an instruction
+//
+typedef u_int32_t T_IT;
+typedef SDBG_LINUX_REGS_STRUCT T_GRS;
+typedef SDBG_LINUX_FPREGS_STRUCT T_FRS;
 
-  const T_IT T_TRAP_INSTRUCTION               = 0x000000cc;
-  const T_IT T_BLEND_MASK                     = 0xffffff00;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeef;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeef;
+const T_IT T_TRAP_INSTRUCTION = 0x000000cc;
+const T_IT T_BLEND_MASK = 0xffffff00;
+const T_IT IT_UNINIT_HEX = 0xdeadbeef;
+const T_VA T_UNINIT_HEX = 0xdeadbeef;
 
-#define SDBG_LINUX_DFLT_INSTANTIATION T_VA, \
-                                      T_WT, \
-                                      T_IT, \
-                                      T_GRS,\
-                                      T_FRS,\
-                                      my_thrinfo_t,\
-                                      elf_wrapper
+#define SDBG_LINUX_DFLT_INSTANTIATION \
+  T_VA, T_WT, T_IT, T_GRS, T_FRS, my_thrinfo_t, elf_wrapper
 
 #elif X86_64_ARCHITECTURE
 
-  // 
-  // 
-  // insert linux X86-64 architecture macros here ...
-  //
-  //
-  //
+//
+//
+// insert linux X86-64 architecture macros here ...
+//
+//
+//
 
-# if BIT64
-  //
-  // if the target is 64 bit, use the following
-  //
-  typedef u_int64_t                             T_VA;
-  typedef u_int64_t                             T_WT;
-  typedef u_int64_t                             T_IT;
-  typedef SDBG_LINUX_REGS_STRUCT                T_GRS;
-  typedef SDBG_LINUX_FPREGS_STRUCT              T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0x00000000000000cc;
-  const T_IT T_BLEND_MASK                     = 0xffffffffffffff00;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeefdeadbeefULL;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeefdeadbeef;
-# else
-  //
-  // if the target is 32 bit, use the following
-  //
-  typedef u_int32_t                             T_VA;
-  typedef u_int32_t                             T_WT;
-  typedef u_int32_t                             T_IT;
-  typedef SDBG_LINUX_REGS_STRUCT                T_GRS;
-  typedef SDBG_LINUX_FPREGS_STRUCT              T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0x000000cc;
-  const T_IT T_BLEND_MASK                     = 0xffffff00;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeef;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeef;
-# endif // BIT64
+#if BIT64
+//
+// if the target is 64 bit, use the following
+//
+typedef u_int64_t T_VA;
+typedef u_int64_t T_WT;
+typedef u_int64_t T_IT;
+typedef SDBG_LINUX_REGS_STRUCT T_GRS;
+typedef SDBG_LINUX_FPREGS_STRUCT T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0x00000000000000cc;
+const T_IT T_BLEND_MASK = 0xffffffffffffff00;
+const T_IT IT_UNINIT_HEX = 0xdeadbeefdeadbeefULL;
+const T_VA T_UNINIT_HEX = 0xdeadbeefdeadbeef;
+#else
+//
+// if the target is 32 bit, use the following
+//
+typedef u_int32_t T_VA;
+typedef u_int32_t T_WT;
+typedef u_int32_t T_IT;
+typedef SDBG_LINUX_REGS_STRUCT T_GRS;
+typedef SDBG_LINUX_FPREGS_STRUCT T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0x000000cc;
+const T_IT T_BLEND_MASK = 0xffffff00;
+const T_IT IT_UNINIT_HEX = 0xdeadbeef;
+const T_VA T_UNINIT_HEX = 0xdeadbeef;
+#endif  // BIT64
 
-#define SDBG_LINUX_DFLT_INSTANTIATION T_VA, \
-                                      T_WT, \
-                                      T_IT, \
-                                      T_GRS,\
-                                      T_FRS,\
-                                      my_thrinfo_t,\
-                                      elf_wrapper
+#define SDBG_LINUX_DFLT_INSTANTIATION \
+  T_VA, T_WT, T_IT, T_GRS, T_FRS, my_thrinfo_t, elf_wrapper
 
 #elif AARCH64_ARCHITECTURE
 
-  // 
-  // 
-  // insert linux AARCH64 architecture macros here ...
-  //
-  //
-  //
+//
+//
+// insert linux AARCH64 architecture macros here ...
+//
+//
+//
 
-# if BIT64
-  //
-  // if the target is 64 bit, use the following
-  //
-  typedef u_int64_t                             T_VA;
-  typedef u_int64_t                             T_WT;
-  typedef u_int32_t                             T_IT;
-  typedef SDBG_LINUX_REGS_STRUCT                T_GRS;
-  typedef SDBG_LINUX_FPREGS_STRUCT              T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0x00000000d4200000;
-  const T_IT T_BLEND_MASK                     = 0xffffffff00000000;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeefdeadbeefULL;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeefdeadbeef;
-# else
-  // 32 bit arm is untested...
-  #error 32-bit target is not supported for the ARM architecture
-  //
-  // if the target is 32 bit, use the following
-  //
-  typedef u_int32_t                             T_VA;
-  typedef u_int32_t                             T_WT;
-  typedef u_int32_t                             T_IT;
-  typedef SDBG_LINUX_REGS_STRUCT                T_GRS;
-  typedef SDBG_LINUX_FPREGS_STRUCT              T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0xd4200000;
-  const T_IT T_BLEND_MASK                     = 0x00000000;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeef;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeef;
-# endif // BIT64
+#if BIT64
+//
+// if the target is 64 bit, use the following
+//
+typedef u_int64_t T_VA;
+typedef u_int64_t T_WT;
+typedef u_int32_t T_IT;
+typedef SDBG_LINUX_REGS_STRUCT T_GRS;
+typedef SDBG_LINUX_FPREGS_STRUCT T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0x00000000d4200000;
+const T_IT T_BLEND_MASK = 0xffffffff00000000;
+const T_IT IT_UNINIT_HEX = 0xdeadbeefdeadbeefULL;
+const T_VA T_UNINIT_HEX = 0xdeadbeefdeadbeef;
+#else
+// 32 bit arm is untested...
+#error 32-bit target is not supported for the ARM architecture
+//
+// if the target is 32 bit, use the following
+//
+typedef u_int32_t T_VA;
+typedef u_int32_t T_WT;
+typedef u_int32_t T_IT;
+typedef SDBG_LINUX_REGS_STRUCT T_GRS;
+typedef SDBG_LINUX_FPREGS_STRUCT T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0xd4200000;
+const T_IT T_BLEND_MASK = 0x00000000;
+const T_IT IT_UNINIT_HEX = 0xdeadbeef;
+const T_VA T_UNINIT_HEX = 0xdeadbeef;
+#endif  // BIT64
 
-#define SDBG_LINUX_DFLT_INSTANTIATION T_VA, \
-                                      T_WT, \
-                                      T_IT, \
-                                      T_GRS,\
-                                      T_FRS,\
-                                      my_thrinfo_t,\
-                                      elf_wrapper
-
+#define SDBG_LINUX_DFLT_INSTANTIATION \
+  T_VA, T_WT, T_IT, T_GRS, T_FRS, my_thrinfo_t, elf_wrapper
 
 #elif PPC_ARCHITECTURE
 
-  // 
-  // 
-  // Insert linux ppc architecture macroes here ...
-  // BlueGene FEN architecture is covered here.
-  //
-  //
+//
+//
+// Insert linux ppc architecture macroes here ...
+// BlueGene FEN architecture is covered here.
+//
+//
 
-# if BIT64
-  //
-  // if the target is 64 bit, use the following
-  //
-  typedef u_int64_t                             T_VA;
-  typedef u_int64_t                             T_WT;
-  typedef u_int32_t                             T_IT;
-  typedef struct pt_regs                        T_GRS;
-  typedef struct pt_regs                        T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0x7d821008;
-  const T_IT T_BLEND_MASK                     = 0x00000000;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeef;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeefdeadbeefULL;
-# else
-  typedef u_int32_t                             T_VA;
-  typedef u_int32_t                             T_WT;
-  typedef u_int32_t                             T_IT;
-  typedef struct pt_regs                        T_GRS;
-  typedef struct pt_regs                        T_FRS;
-  const T_IT T_TRAP_INSTRUCTION               = 0x7d821008;
-  const T_IT T_BLEND_MASK                     = 0x00000000;
-  const T_IT IT_UNINIT_HEX                    = 0xdeadbeef;
-  const T_VA T_UNINIT_HEX                     = 0xdeadbeef;
-# endif // BIT64
+#if BIT64
+//
+// if the target is 64 bit, use the following
+//
+typedef u_int64_t T_VA;
+typedef u_int64_t T_WT;
+typedef u_int32_t T_IT;
+typedef struct pt_regs T_GRS;
+typedef struct pt_regs T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0x7d821008;
+const T_IT T_BLEND_MASK = 0x00000000;
+const T_IT IT_UNINIT_HEX = 0xdeadbeef;
+const T_VA T_UNINIT_HEX = 0xdeadbeefdeadbeefULL;
+#else
+typedef u_int32_t T_VA;
+typedef u_int32_t T_WT;
+typedef u_int32_t T_IT;
+typedef struct pt_regs T_GRS;
+typedef struct pt_regs T_FRS;
+const T_IT T_TRAP_INSTRUCTION = 0x7d821008;
+const T_IT T_BLEND_MASK = 0x00000000;
+const T_IT IT_UNINIT_HEX = 0xdeadbeef;
+const T_VA T_UNINIT_HEX = 0xdeadbeef;
+#endif  // BIT64
 
-#define SDBG_LINUX_DFLT_INSTANTIATION T_VA, \
-                                      T_WT, \
-                                      T_IT, \
-                                      T_GRS,\
-                                      T_FRS,\
-                                      my_thrinfo_t,\
-                                      elf_wrapper
-#endif // ARCHITECTURES
-#endif // SDBG_LINUX_STD_HXX
+#define SDBG_LINUX_DFLT_INSTANTIATION \
+  T_VA, T_WT, T_IT, T_GRS, T_FRS, my_thrinfo_t, elf_wrapper
+#endif  // ARCHITECTURES
+#endif  // SDBG_LINUX_STD_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_symtab.hxx
+++ b/launchmon/src/linux/sdbg_linux_symtab.hxx
@@ -1,137 +1,130 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_symtab.hxx,v 1.3.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
- *        Oct 27 2010 DHA: Added is_defined, is_globally_visible, 
+ *        Oct 27 2010 DHA: Added is_defined, is_globally_visible,
  *                         is_locally_visible virtual methods.
- *        Oct 26 2010 DHA: Added support for symbol visibility 
+ *        Oct 26 2010 DHA: Added support for symbol visibility
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Mar 30 2006 DHA: Added exception handling support
  *        Mar 16 2006 DHA: The file is created so that
- *                         I can extract out linux specific 
+ *                         I can extract out linux specific
  *                         implementation from base symbol table
- *                         class. Linux only supports ELF file 
+ *                         class. Linux only supports ELF file
  *                         format and DWARF debug info format.
  *
- */ 
+ */
 
 #ifndef SDBG_LINUX_SYMTAB_HXX
 #define SDBG_LINUX_SYMTAB_HXX 1
 
-
-#include "sdbg_std.hxx"
 #include "sdbg_base_symtab.hxx"
+#include "sdbg_std.hxx"
 
 extern "C" {
 #if HAVE_LIBELF_H
-# include LOCATION_OF_LIBELFHEADER
+#include LOCATION_OF_LIBELFHEADER
 #else
-# error libelf.h is required
+#error libelf.h is required
 #endif
 }
 
 #define LINUX_SYMTAB_TEMPLATELIST typename VA
-#define LINUX_SYMTAB_TEMPLPARAM   VA
-#define LINUX_IMAGE_TEMPLATELIST  typename VA
-#define LINUX_IMAGE_TEMPLPARAM    VA
+#define LINUX_SYMTAB_TEMPLPARAM VA
+#define LINUX_IMAGE_TEMPLATELIST typename VA
+#define LINUX_IMAGE_TEMPLPARAM VA
 
-enum LMON_ELF_visibility 
-  { elf_sym_local, 
-    elf_sym_global, 
-    elf_sym_weak, 
-    elf_sym_procspecific, 
-    elf_sym_none 
-  };
-
+enum LMON_ELF_visibility {
+  elf_sym_local,
+  elf_sym_global,
+  elf_sym_weak,
+  elf_sym_procspecific,
+  elf_sym_none
+};
 
 //! class linkage_symbol_t<>
 /*!
-  
+
 */
 template <LINUX_SYMTAB_TEMPLATELIST>
-class linkage_symbol_t 
-	: public symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>
-{
-public:
+class linkage_symbol_t : public symbol_base_t<LINUX_SYMTAB_TEMPLPARAM> {
+ public:
   //
   // constructosr & destructor
   //
-  linkage_symbol_t ();
-  linkage_symbol_t ( const linkage_symbol_t& l );  
-  linkage_symbol_t ( const std::string& n, 
-		     const std::string& ln,
-		     const VA ra, 
-		     const VA rla);
-  virtual ~linkage_symbol_t() { }
+  linkage_symbol_t();
+  linkage_symbol_t(const linkage_symbol_t& l);
+  linkage_symbol_t(const std::string& n, const std::string& ln, const VA ra,
+                   const VA rla);
+  virtual ~linkage_symbol_t() {}
 
   //
   // accessors
   //
-  void set_name (const std::string& n); 
-  void set_base_lib_name (const std::string& bln);
-  void set_binding (const std::string& b);
-  void set_visibility (const std::string& v);
-  void set_type (const std::string& t);
-  const std::string& get_name () const;
+  void set_name(const std::string& n);
+  void set_base_lib_name(const std::string& bln);
+  void set_binding(const std::string& b);
+  void set_visibility(const std::string& v);
+  void set_type(const std::string& t);
+  const std::string& get_name() const;
   const std::string& get_base_lib_name() const;
-  const std::string get_binding () const;
-  const std::string get_visibility () const;
-  const std::string get_type () const;
+  const std::string get_binding() const;
+  const std::string get_visibility() const;
+  const std::string get_type() const;
   const VA& get_raw_address() const;
   const VA& get_relocated_address() const;
 
-  virtual bool is_defined() const; 
-  virtual bool is_globally_visible() const; 
-  virtual bool is_locally_visible() const; 
+  virtual bool is_defined() const;
+  virtual bool is_globally_visible() const;
+  virtual bool is_locally_visible() const;
 
-  define_gset(bool,defined)
-  define_gset(LMON_ELF_visibility,vis) 
+  define_gset(bool, defined) define_gset(LMON_ELF_visibility, vis)
 
-  //
-  // debug methods
-  //
-  void print_me () const;
+      //
+      // debug methods
+      //
+      void print_me() const;
 
-private:
+ private:
   bool defined;
   LMON_ELF_visibility vis;
   std::string visibility;
-  std::string binding; 
+  std::string binding;
   std::string type;
 };
 
-
 //!
 /*! elf_wrapper
-  
+
 */
-class elf_wrapper
-{
-public:
+class elf_wrapper {
+ public:
   //
   // constructors & destructor
   //
@@ -145,77 +138,78 @@ public:
   //
   void set_exec(const std::string& e) { exec = e; }
   const std::string& get_exec() const { return exec; }
-  void set_elf_handler(Elf* e)        { elf_handler = e; }
-  Elf* get_elf_handler()              { return elf_handler; }
-  
+  void set_elf_handler(Elf* e) { elf_handler = e; }
+  Elf* get_elf_handler() { return elf_handler; }
+
   symtab_error_e init(std::string& lib);
   symtab_error_e init() throw(symtab_exception_t);
-  symtab_error_e finalize();  
+  symtab_error_e finalize();
 
-private:
-  std::string exec;  
+ private:
+  std::string exec;
   int fd;
   Elf* elf_handler;
 };
-
 
 //!
 /*! linux_image_t<>
 
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-class linux_image_t 
-  : public image_base_t<VA,elf_wrapper>
-{
-public:
+class linux_image_t : public image_base_t<VA, elf_wrapper> {
+ public:
   //
   // constructors & destructor
   //
-  linux_image_t ();
-  linux_image_t ( const std::string &lib );
-  linux_image_t ( const image_base_t<VA,elf_wrapper>& im );
-  virtual ~linux_image_t ();
+  linux_image_t();
+  linux_image_t(const std::string& lib);
+  linux_image_t(const image_base_t<VA, elf_wrapper>& im);
+  virtual ~linux_image_t();
 
   //
-  // accessors: had to overload them because of 
-  //  "there are no arguments to `method' that 
-  // depend on a template parameter, so a declaration of 
+  // accessors: had to overload them because of
+  //  "there are no arguments to `method' that
+  // depend on a template parameter, so a declaration of
   // `method' must be available G++ warning
-  void set_base_image_name ( std::string& n );
-  void set_path ( std::string& n );
-  void set_image_base_address ( VA ba );
-  void set_native_exec_handler ( elf_wrapper* h ); 
+  void set_base_image_name(std::string& n);
+  void set_path(std::string& n);
+  void set_image_base_address(VA ba);
+  void set_native_exec_handler(elf_wrapper* h);
 
   const std::string& get_base_image_name() const;
   const std::string& get_path() const;
-  const VA& get_image_base_address() const;    
-  elf_wrapper* get_native_exec_handler();  
+  const VA& get_image_base_address() const;
+  elf_wrapper* get_native_exec_handler();
   std::map<std::string, symbol_base_t<VA>*, ltstr>& get_linkage_symtab();
 
-  virtual symtab_error_e init() 
-    throw ( symtab_exception_t );
-  virtual symtab_error_e read_linkage_symbols()
-    throw ( symtab_exception_t );
-  virtual symtab_error_e fetch_DSO_info (std::string&,bool&) 
-    throw ( symtab_exception_t );
+  virtual symtab_error_e init() throw(symtab_exception_t);
+  virtual symtab_error_e read_linkage_symbols() throw(symtab_exception_t);
+  virtual symtab_error_e fetch_DSO_info(std::string&,
+                                        bool&) throw(symtab_exception_t);
   // virtual symtab_error_e read_debug_symbols() = 0;
-  //   throw ( symtab_exception_t ) = 0; 
+  //   throw ( symtab_exception_t ) = 0;
 
   //
   // Some Util methods.
   //
-  virtual LMON_ELF_visibility resolve_binding ( int code ) const;
-  virtual void decode_binding ( int code, std::string &s ) const;
-  virtual void decode_visibility ( int code, std::string &s ) const;
-  virtual void decode_type ( int code, std::string &s ) const;
-  
-private:
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().symtab_module_trace.verbosity_level >= level); }
-  
+  virtual LMON_ELF_visibility resolve_binding(int code) const;
+  virtual void decode_binding(int code, std::string& s) const;
+  virtual void decode_visibility(int code, std::string& s) const;
+  virtual void decode_type(int code, std::string& s) const;
+
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().symtab_module_trace.verbosity_level >=
+            level);
+  }
+
   // For self tracing
   //
   std::string MODULENAME;
 };
 
-#endif // SDBG_LINUX_SYMTAB_HXX
+#endif  // SDBG_LINUX_SYMTAB_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_linux_symtab_impl.hxx
+++ b/launchmon/src/linux/sdbg_linux_symtab_impl.hxx
@@ -1,40 +1,42 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_linux_symtab_impl.hxx,v 1.4.4.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
- *        Oct 27 2010 DHA: Added is_defined, is_globally_visible, 
+ *        Oct 27 2010 DHA: Added is_defined, is_globally_visible,
  *                         is_locally_visible virtual methods.
  *        Dec 20 2009 DHA: Fixed a bug that arose when Mark's patch
- *                         was folded in.  
- *        Mar 06 2009 DHA: Folded in Mark O'Connor's patch that 
- *                         allows use of dynamic symbol table 
- *                         in the absence of reguar linkage symbol 
+ *                         was folded in.
+ *        Mar 06 2009 DHA: Folded in Mark O'Connor's patch that
+ *                         allows use of dynamic symbol table
+ *                         in the absence of reguar linkage symbol
  *                         table.
- *                         Changed fetch_DSO_info such that it 
+ *                         Changed fetch_DSO_info such that it
  *                         only cares about the runtime linker SO.
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jan 09 2006 DHA: Linux X86/64 support
@@ -42,12 +44,12 @@
  *        Mar 30 2006 DHA: Added exception handling support
  *        Mar 16 2006 DHA: The file is created so that
  *                         linux specific components could be
- *                         extracted out from the base symbol 
- *                         table class. Note that LINUX only 
- *                         supports ELF as the file format and 
+ *                         extracted out from the base symbol
+ *                         table class. Note that LINUX only
+ *                         supports ELF as the file format and
  *                         DWARF as the debug info format.
  *
- */ 
+ */
 
 #ifndef SDBG_LINUX_SYMTAB_IMPL_HXX
 #define SDBG_LINUX_SYMTAB_IMPL_HXX 1
@@ -58,22 +60,21 @@
 #error This source file requires a LINUX OS
 #endif
 
-#include <vector>
-#include <string>
 #include <iostream>
+#include <string>
+#include <vector>
 
 extern "C" {
-#include <libgen.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
 #include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 }
 
 #include "sdbg_linux_std.hxx"
 #include "sdbg_linux_symtab.hxx"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -81,196 +82,144 @@ extern "C" {
 //
 //
 
-
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  linkage_symbol_t<> constructors
-      
-    
+
+
 */
 template <LINUX_SYMTAB_TEMPLATELIST>
 linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::linkage_symbol_t()
-  : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>()
-{ 
+    : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>() {
   defined = false;
   vis = elf_sym_none;
   visibility = SYMTAB_UNINIT_STRING;
-  binding = SYMTAB_UNINIT_STRING; 
+  binding = SYMTAB_UNINIT_STRING;
   type = SYMTAB_UNINIT_STRING;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::linkage_symbol_t 
-(const linkage_symbol_t& l) 
-  : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>(l)
-{ 
+linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::linkage_symbol_t(
+    const linkage_symbol_t& l)
+    : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>(l) {
   defined = l.defined;
   vis = l.vis;
   visibility = l.visibility;
   binding = l.binding;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::linkage_symbol_t 
-(const std::string& n, const std::string& ln, 
- const VA ra, const VA rla)
-  : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>(n,ln,ra,rla)
-{
+linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::linkage_symbol_t(
+    const std::string& n, const std::string& ln, const VA ra, const VA rla)
+    : symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>(n, ln, ra, rla) {
   defined = false;
   vis = elf_sym_none;
   visibility = SYMTAB_UNINIT_STRING;
-  binding = SYMTAB_UNINIT_STRING; 
+  binding = SYMTAB_UNINIT_STRING;
   type = SYMTAB_UNINIT_STRING;
 }
-  
 
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  linkage_symbol_t<> accessors
 
 */
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_name 
-(const std::string& n) 
-{ 
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_name(const std::string& n) {
   symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::set_name(n);
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_base_lib_name 
-(const std::string& bln) 
-{ 
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_base_lib_name(
+    const std::string& bln) {
   symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::set_base_lib_name(bln);
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_binding 
-(const std::string& b) 
-{ 
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_binding(
+    const std::string& b) {
   binding = b;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_visibility 
-(const std::string& v) 
-{ 
-  visibility = v; 
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_visibility(
+    const std::string& v) {
+  visibility = v;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_type 
-(const std::string& t) 
-{ 
-  type = t; 
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::set_type(const std::string& t) {
+  type = t;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const std::string& 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_name () const 
-{
-  return ( symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::
-	   get_name()); 
+const std::string& linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_name() const {
+  return (symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::get_name());
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const std::string& 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_base_lib_name() const 
-{ 
-  return ( symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::
-	   get_base_lib_name()); 
+const std::string&
+linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_base_lib_name() const {
+  return (symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::get_base_lib_name());
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const VA&
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_raw_address() const 
-{ 
-  return ( symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::
-	   get_raw_address()); 
+const VA& linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_raw_address() const {
+  return (symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::get_raw_address());
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const VA& 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_relocated_address() const 
-{ 
-  return  ( symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::
-	    get_relocated_address()); 
+const VA& linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_relocated_address()
+    const {
+  return (symbol_base_t<LINUX_SYMTAB_TEMPLPARAM>::get_relocated_address());
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const std::string
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_binding () const 
-{
-  return binding; 
+const std::string linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_binding()
+    const {
+  return binding;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const std::string
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_visibility () const
-{ 
-  return visibility; 
+const std::string linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_visibility()
+    const {
+  return visibility;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-const std::string
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_type () const 
-{ 
+const std::string linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::get_type() const {
   return type;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-bool 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_defined() const
-{
-  return defined;  
+bool linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_defined() const {
+  return defined;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-bool 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_globally_visible() const
-{
-  return (vis == elf_sym_global)? true : false;
+bool linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_globally_visible() const {
+  return (vis == elf_sym_global) ? true : false;
 }
 
-
 template <LINUX_SYMTAB_TEMPLATELIST>
-bool 
-linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_locally_visible() const
-{
-  return (vis == elf_sym_local)? true : false;
+bool linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::is_locally_visible() const {
+  return (vis == elf_sym_local) ? true : false;
 }
-
 
 // PUBLIC: linkage_symbol_t<>::print_me()
 /*!
-    Method allows this class to print its data; chiefly 
+    Method allows this class to print its data; chiefly
     for debugging purpose.
 */
 template <LINUX_SYMTAB_TEMPLATELIST>
-void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::print_me () const
-{
+void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::print_me() const {
   using namespace std;
 
   cout << " ---- Symbol Info --- " << endl;
   cout << "Sym Name:   " << get_name() << endl;
-  cout << "Value:       0x" << (int) get_raw_address() << endl;
-  cout << "Type:       " << type << endl;	
-  cout << "Binding:    " << binding << endl;	
-  cout << "Visibility: " << visibility << endl;		
+  cout << "Value:       0x" << (int)get_raw_address() << endl;
+  cout << "Type:       " << type << endl;
+  cout << "Binding:    " << binding << endl;
+  cout << "Visibility: " << visibility << endl;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -278,122 +227,97 @@ void linkage_symbol_t<LINUX_SYMTAB_TEMPLPARAM>::print_me () const
 //
 //
 
-
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  elf_wrapper<BASE_SYMTAB_TYPES> constructors
-      
-    
+
+
 */
-elf_wrapper::elf_wrapper() : elf_handler(NULL)
-{
-  exec = SYMTAB_UNINIT_STRING;    
+elf_wrapper::elf_wrapper() : elf_handler(NULL) { exec = SYMTAB_UNINIT_STRING; }
+
+elf_wrapper::elf_wrapper(const std::string& ex) : elf_handler(NULL) {
+  exec = ex;
 }
 
-elf_wrapper::elf_wrapper(const std::string& ex) 
-  : elf_handler(NULL)
-{
-  exec = ex;  
-}
-
-elf_wrapper::elf_wrapper(const elf_wrapper& elfw) 
-  : elf_handler(NULL)
-{
+elf_wrapper::elf_wrapper(const elf_wrapper& elfw) : elf_handler(NULL) {
   exec = elfw.exec;
   elf_handler = elfw.elf_handler;
 }
 
-elf_wrapper::~elf_wrapper()
-{
-  if (elf_handler)
-    finalize(); 
+elf_wrapper::~elf_wrapper() {
+  if (elf_handler) finalize();
 }
 
-
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  elf_wrapper::init()
-      
-    
+
+
 */
-symtab_error_e elf_wrapper::init()
-throw(symtab_exception_t)
-{
+symtab_error_e elf_wrapper::init() throw(symtab_exception_t) {
   using namespace std;
 
   string e;
   string func = "[elf_wrapper::init]";
   Elf_Kind kind;
-  Elf *arf;
+  Elf* arf;
 
-  if ( elf_version(EV_CURRENT) == EV_NONE ) 
-    {
-      e = func + " elf_version failed";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if (elf_version(EV_CURRENT) == EV_NONE) {
+    e = func + " elf_version failed";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  if ( ( fd = open (exec.c_str(), O_RDONLY)) == -1 ) 
-    {
-      e = func + " couldn't open executable " + exec;
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if ((fd = open(exec.c_str(), O_RDONLY)) == -1) {
+    e = func + " couldn't open executable " + exec;
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  if ( ( arf = elf_begin (fd, ELF_C_READ, NULL)) == NULL ) 
-    {
-      e = func + " elf_begin failed ";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if ((arf = elf_begin(fd, ELF_C_READ, NULL)) == NULL) {
+    e = func + " elf_begin failed ";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  if ( ( kind = elf_kind (arf)) != ELF_K_ELF )
-    {
-      e = func + " elf_kind failed ";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if ((kind = elf_kind(arf)) != ELF_K_ELF) {
+    e = func + " elf_kind failed ";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  if ( ( elf_handler = elf_begin (fd, ELF_C_READ, arf)) == NULL )
-    {
-      e = func + " elf_begin failed ";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if ((elf_handler = elf_begin(fd, ELF_C_READ, arf)) == NULL) {
+    e = func + " elf_begin failed ";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
   return SDBG_SYMTAB_OK;
 }
 
-
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  elf_wrapper::init(std::string& lib)
 
 
 */
-symtab_error_e
-elf_wrapper::init ( std::string& lib )
-{
+symtab_error_e elf_wrapper::init(std::string& lib) {
   exec = lib;
-  return (init());  
+  return (init());
 }
-
 
 //!  PUBLIC:
 /*!  elf_wrapper<>::finalize()
-      
-    
-*/
-symtab_error_e elf_wrapper::finalize ()
-{
-  symtab_error_e rc = SDBG_SYMTAB_OK;
-  
-  if (elf_handler) {   
 
-    if ( elf_end(elf_handler) < 0 ) {
+
+*/
+symtab_error_e elf_wrapper::finalize() {
+  symtab_error_e rc = SDBG_SYMTAB_OK;
+
+  if (elf_handler) {
+    if (elf_end(elf_handler) < 0) {
       rc = SDBG_SYMTAB_FAILED;
     }
     elf_handler = NULL;
-    if ( close(fd) < 0 ) {
+    if (close(fd) < 0) {
       rc = SDBG_SYMTAB_FAILED;
     }
   }
-  
+
   return rc;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -401,75 +325,61 @@ symtab_error_e elf_wrapper::finalize ()
 //
 //
 
-
-//!  PUBLIC: 
+//!  PUBLIC:
 /*!  linux_image_t<> constructors
 
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t ()
-  : image_base_t<LINUX_IMAGE_TEMPLPARAM,elf_wrapper>()
-{
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t()
+    : image_base_t<LINUX_IMAGE_TEMPLPARAM, elf_wrapper>() {
   MODULENAME = self_trace_t::self_trace().symtab_module_trace.module_name;
 }
 
-
 template <LINUX_IMAGE_TEMPLATELIST>
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t 
-(const std::string& lib) 
-  : image_base_t<LINUX_IMAGE_TEMPLPARAM,elf_wrapper>(lib)
-{
-  MODULENAME = self_trace_t::self_trace().self_trace().symtab_module_trace.module_name;
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t(const std::string& lib)
+    : image_base_t<LINUX_IMAGE_TEMPLPARAM, elf_wrapper>(lib) {
+  MODULENAME =
+      self_trace_t::self_trace().self_trace().symtab_module_trace.module_name;
 }
 
 template <LINUX_IMAGE_TEMPLATELIST>
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t 
-(const image_base_t<VA,elf_wrapper>& im)
-  : image_base_t<LINUX_IMAGE_TEMPLPARAM,elf_wrapper>(im)
-{
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::linux_image_t(
+    const image_base_t<VA, elf_wrapper>& im)
+    : image_base_t<LINUX_IMAGE_TEMPLPARAM, elf_wrapper>(im) {
   MODULENAME = im.MODULENAME;
 }
 
 template <LINUX_IMAGE_TEMPLATELIST>
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::~linux_image_t ()
-{
-
-}
-
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::~linux_image_t() {}
 
 //! PUBLIC: init
 /*!
-  
+
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::init()
-throw(symtab_exception_t)
-{
+symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::init() throw(
+    symtab_exception_t) {
   using namespace std;
 
   elf_wrapper* elfw;
-  string e;  
+  string e;
   string func = "[linux_image_t::init]";
 
-  if (get_base_image_name() == SYMTAB_UNINIT_STRING) 
-    {
-      e = func + 
-	" Attempt to call init before setting the base image name. ";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if (get_base_image_name() == SYMTAB_UNINIT_STRING) {
+    e = func + " Attempt to call init before setting the base image name. ";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  elfw = new elf_wrapper(get_path());  
+  elfw = new elf_wrapper(get_path());
 
-  if (elfw->init() != SDBG_SYMTAB_OK) 
-    {
-      e = func + " ELF library init failed.";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-    }
+  if (elfw->init() != SDBG_SYMTAB_OK) {
+    e = func + " ELF library init failed.";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
   set_native_exec_handler(elfw);
 
   return SDBG_SYMTAB_OK;
 }
-
 
 //! PUBLIC: read_linkage_symbols
 /*!
@@ -477,133 +387,113 @@ throw(symtab_exception_t)
     Elf handler.
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-symtab_error_e 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::read_linkage_symbols ()
-throw(symtab_exception_t)
-{
+symtab_error_e
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::read_linkage_symbols() throw(
+    symtab_exception_t) {
   using namespace std;
 
-  string e;  
+  string e;
   string func = "[linux_image_t::read_linkage_symbols]";
-#if BIT64 
-  Elf64_Shdr *shdr = NULL;
-  Elf64_Shdr *shdrdyn = NULL;
+#if BIT64
+  Elf64_Shdr* shdr = NULL;
+  Elf64_Shdr* shdrdyn = NULL;
   Elf64_Sym *first_sym, *last_sym;
 #else
-  Elf32_Shdr *shdr = NULL;
-  Elf32_Shdr *shdrdyn = NULL;
+  Elf32_Shdr* shdr = NULL;
+  Elf32_Shdr* shdrdyn = NULL;
   Elf32_Sym *first_sym, *last_sym;
 #endif
-  Elf_Data *elf_data = NULL;
-  Elf_Scn *symtab_sect=0;
-  Elf_Scn *sect=0;
-  Elf_Scn *dynsym_sect=0;
+  Elf_Data* elf_data = NULL;
+  Elf_Scn* symtab_sect = 0;
+  Elf_Scn* sect = 0;
+  Elf_Scn* dynsym_sect = 0;
 
-  Elf *elf_h = get_native_exec_handler()->get_elf_handler();
+  Elf* elf_h = get_native_exec_handler()->get_elf_handler();
 
   {
-    self_trace_t::trace ( LEVELCHK(level2), 
-			  MODULENAME, 0, 
-			  "reading linkage symbol table for image[=%s]",
-			  get_base_image_name().c_str());    
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "reading linkage symbol table for image[=%s]",
+                        get_base_image_name().c_str());
   }
- 
-  while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) 
-    {
-#if BIT64 
-      if ( (shdr = elf64_getshdr (sect) ) != NULL )
+
+  while ((sect = elf_nextscn(elf_h, sect)) != NULL) {
+#if BIT64
+    if ((shdr = elf64_getshdr(sect)) != NULL)
 #else
-      if ( (shdr = elf32_getshdr (sect) ) != NULL ) 
+    if ((shdr = elf32_getshdr(sect)) != NULL)
 #endif
-	{
-	  if ( shdr->sh_type == SHT_SYMTAB ) 
-	    {
-	      symtab_sect = sect;
-	      break;
-	    }
-	  else if ( shdr->sh_type == SHT_DYNSYM )
-            {
-	      dynsym_sect = sect;
-              shdrdyn = shdr;
-            }
-	}
-    }
-
-  if (!symtab_sect)
     {
-      if ( dynsym_sect && shdrdyn)
-        {
-          symtab_sect = dynsym_sect;
-          shdr = shdrdyn;
-        } 
-      else 
-        {
-          e = func 
-          + " No symbol table section is found in "
-          + get_base_image_name()
-          + " ";
-          throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
-        }
+      if (shdr->sh_type == SHT_SYMTAB) {
+        symtab_sect = sect;
+        break;
+      } else if (shdr->sh_type == SHT_DYNSYM) {
+        dynsym_sect = sect;
+        shdrdyn = shdr;
+      }
     }
+  }
 
-  if ( ( ( elf_data = elf_getdata ( symtab_sect, elf_data )) == NULL) 
-       || elf_data->d_size == 0 ) 
-    {
-      e = func + " ELF data are not valid.";
+  if (!symtab_sect) {
+    if (dynsym_sect && shdrdyn) {
+      symtab_sect = dynsym_sect;
+      shdr = shdrdyn;
+    } else {
+      e = func + " No symbol table section is found in " +
+          get_base_image_name() + " ";
       throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
     }
+  }
 
-#if BIT64 
-  first_sym = (Elf64_Sym*) elf_data->d_buf;
-  last_sym = (Elf64_Sym*) ( (char *) elf_data->d_buf + elf_data->d_size );
+  if (((elf_data = elf_getdata(symtab_sect, elf_data)) == NULL) ||
+      elf_data->d_size == 0) {
+    e = func + " ELF data are not valid.";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
+
+#if BIT64
+  first_sym = (Elf64_Sym*)elf_data->d_buf;
+  last_sym = (Elf64_Sym*)((char*)elf_data->d_buf + elf_data->d_size);
 #else
-  first_sym = (Elf32_Sym*) elf_data->d_buf;
-  last_sym = (Elf32_Sym *) ( (char*)(elf_data->d_buf) + elf_data->d_size ); 
+  first_sym = (Elf32_Sym*)elf_data->d_buf;
+  last_sym = (Elf32_Sym*)((char*)(elf_data->d_buf) + elf_data->d_size);
 #endif
 
-  while ( first_sym < last_sym ) 
-    { 
-      //
-      // Some memory checkers complain symname is leaked, but 
-      // we can't simply free it because it is unclear if it's safe
-      char* symname = elf_strptr(elf_h, 
-				 shdr->sh_link, 
-				 (size_t) first_sym->st_name); 
+  while (first_sym < last_sym) {
+    //
+    // Some memory checkers complain symname is leaked, but
+    // we can't simply free it because it is unclear if it's safe
+    char* symname =
+        elf_strptr(elf_h, shdr->sh_link, (size_t)first_sym->st_name);
 
-      if ( symname != 0 && (strcmp(symname, "") != 0) 
-	   && (first_sym->st_value 
-	       != 0)) 
-	{
-	  const string ssym(symname);
+    if (symname != 0 && (strcmp(symname, "") != 0) &&
+        (first_sym->st_value != 0)) {
+      const string ssym(symname);
 
-	  linkage_symbol_t<VA>* a_linksym 
-	    =  new linkage_symbol_t<VA>( ssym,
-		     get_base_image_name(),
-		     (const VA) first_sym->st_value,
-		     (const VA) SYMTAB_UNINIT_ADDR);
+      linkage_symbol_t<VA>* a_linksym = new linkage_symbol_t<VA>(
+          ssym, get_base_image_name(), (const VA)first_sym->st_value,
+          (const VA)SYMTAB_UNINIT_ADDR);
 
-          string tmp; 
-          decode_binding(first_sym->st_info, tmp);
-	  a_linksym->set_binding(tmp);	  
-          a_linksym->set_vis(resolve_binding(first_sym->st_info));
-          decode_visibility(first_sym->st_other, tmp);
-	  a_linksym->set_visibility(tmp);
-          decode_type(first_sym->st_info, tmp); 
-	  a_linksym->set_type(tmp);
-          a_linksym->set_defined((first_sym->st_shndx != SHN_UNDEF)? true : false);
+      string tmp;
+      decode_binding(first_sym->st_info, tmp);
+      a_linksym->set_binding(tmp);
+      a_linksym->set_vis(resolve_binding(first_sym->st_info));
+      decode_visibility(first_sym->st_other, tmp);
+      a_linksym->set_visibility(tmp);
+      decode_type(first_sym->st_info, tmp);
+      a_linksym->set_type(tmp);
+      a_linksym->set_defined((first_sym->st_shndx != SHN_UNDEF) ? true : false);
 
-	  string keystr(symname);
+      string keystr(symname);
 
-	  get_linkage_symtab().insert(make_pair(keystr, 
-						(symbol_base_t<VA>*) a_linksym));
-	}
+      get_linkage_symtab().insert(
+          make_pair(keystr, (symbol_base_t<VA>*)a_linksym));
+    }
 
-      first_sym++;
-    } 
-  
+    first_sym++;
+  }
+
   return SDBG_SYMTAB_OK;
 }
-
 
 //! PUBLIC: fetch_DSO_info
 /*!
@@ -611,213 +501,185 @@ throw(symtab_exception_t)
 */
 
 template <LINUX_IMAGE_TEMPLATELIST>
-symtab_error_e 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::fetch_DSO_info
-( std::string &where_is_interpreter, bool &found_interp )
-  throw(symtab_exception_t)
-{
+symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::fetch_DSO_info(
+    std::string& where_is_interpreter,
+    bool& found_interp) throw(symtab_exception_t) {
   using namespace std;
 
   string e;
   string func = "[linux_image_t::fetch_DSO_info]";
-#if BIT64 
-  Elf64_Shdr *shdr = NULL;
+#if BIT64
+  Elf64_Shdr* shdr = NULL;
 #else
-  Elf32_Shdr *shdr = NULL;
+  Elf32_Shdr* shdr = NULL;
 #endif
-  Elf_Data *elf_data = NULL;
-  Elf_Data *elf_data_dso = NULL;
-  Elf_Data *interp_sect = NULL;
-  char *strtab = NULL;
-  char *sh_strtab = NULL;
+  Elf_Data* elf_data = NULL;
+  Elf_Data* elf_data_dso = NULL;
+  Elf_Data* interp_sect = NULL;
+  char* strtab = NULL;
+  char* sh_strtab = NULL;
   int strtab_size;
   int sh_strtab_size;
   Elf_Scn* sect;
-#if BIT64 
-  Elf64_Dyn *first_dso;
+#if BIT64
+  Elf64_Dyn* first_dso;
 #else
-  Elf32_Dyn *first_dso;
+  Elf32_Dyn* first_dso;
 #endif
   int sz;
 
   sect = 0;
   Elf* elf_h = get_native_exec_handler()->get_elf_handler();
- 
-  while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) 
-    {  
-#if BIT64 
-      if ( (shdr = elf64_getshdr (sect) ) != NULL )
+
+  while ((sect = elf_nextscn(elf_h, sect)) != NULL) {
+#if BIT64
+    if ((shdr = elf64_getshdr(sect)) != NULL)
 #else
-      if ( (shdr = elf32_getshdr (sect) ) != NULL ) 
+    if ((shdr = elf32_getshdr(sect)) != NULL)
 #endif
-	{
-	  if ( shdr->sh_type == SHT_STRTAB ) 
-	    {
-	      elf_data = 0;
-
-	      if ( ( ( elf_data = elf_getdata ( sect, elf_data )) == NULL) 
-		   || elf_data->d_size == 0 ) 
-		{
-		  e = func + " ELF data are not valid.";
-		  throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);       
-		}
-
-	      if (shdr->sh_addr != 0 ) 
-		{
-		  // Section header string table's sh_addr is 0
-		  // it seems the only mechanism where it differs from
-		  // general string table section.	  	
-		  strtab =  (char*) elf_data->d_buf;
-		  strtab_size = elf_data->d_size;
-		} 
-	      else {
-		if ( strcmp(".shstrtab", 
-			    ((char*)elf_data->d_buf) + shdr->sh_name) == 0) 
-		  {	    
-		    sh_strtab =  (char*) elf_data->d_buf;
-		    sh_strtab_size = elf_data->d_size;
-		  }
-	      }
-	    }
-	}
-    } // while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) 
-
-  if (!sh_strtab) 
     {
-      e = func + " No section header string table.";
-      throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);  
+      if (shdr->sh_type == SHT_STRTAB) {
+        elf_data = 0;
+
+        if (((elf_data = elf_getdata(sect, elf_data)) == NULL) ||
+            elf_data->d_size == 0) {
+          e = func + " ELF data are not valid.";
+          throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+        }
+
+        if (shdr->sh_addr != 0) {
+          // Section header string table's sh_addr is 0
+          // it seems the only mechanism where it differs from
+          // general string table section.
+          strtab = (char*)elf_data->d_buf;
+          strtab_size = elf_data->d_size;
+        } else {
+          if (strcmp(".shstrtab", ((char*)elf_data->d_buf) + shdr->sh_name) ==
+              0) {
+            sh_strtab = (char*)elf_data->d_buf;
+            sh_strtab_size = elf_data->d_size;
+          }
+        }
+      }
     }
-  
-   while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) 
-     {
-#if BIT64 
-       if ( (shdr = elf64_getshdr (sect)) == NULL )
-         continue;
+  }  // while ( (sect = elf_nextscn(elf_h, sect)) != NULL )
+
+  if (!sh_strtab) {
+    e = func + " No section header string table.";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
+
+  while ((sect = elf_nextscn(elf_h, sect)) != NULL) {
+#if BIT64
+    if ((shdr = elf64_getshdr(sect)) == NULL) continue;
 #else
-       if ( (shdr = elf32_getshdr (sect)) == NULL )
-         continue;
+    if ((shdr = elf32_getshdr(sect)) == NULL) continue;
 #endif
 
-       switch ( shdr->sh_type ) 
-	 {
-	 case SHT_PROGBITS:
-           {
-	     if ( strcmp(".interp", sh_strtab + shdr->sh_name) == 0 ) 
-	       {
-	         elf_data = 0;
-	         if ( ( ( elf_data = elf_getdata ( sect, elf_data )) == NULL) 
-		      || elf_data->d_size == 0 ) 
-		   {
-		     e = func + " ELF data are not valid.";
-		     throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);       
-		   }
+    switch (shdr->sh_type) {
+      case SHT_PROGBITS: {
+        if (strcmp(".interp", sh_strtab + shdr->sh_name) == 0) {
+          elf_data = 0;
+          if (((elf_data = elf_getdata(sect, elf_data)) == NULL) ||
+              elf_data->d_size == 0) {
+            e = func + " ELF data are not valid.";
+            throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+          }
 
-	         interp_sect = elf_data;
-	         where_is_interpreter = (char*) interp_sect->d_buf;
+          interp_sect = elf_data;
+          where_is_interpreter = (char*)interp_sect->d_buf;
 
-	         struct stat fchk_buf;	   
+          struct stat fchk_buf;
 
-	         if (lstat(where_is_interpreter.c_str(), &fchk_buf) != 0) 
-		   {
-		     e = func + " interpreter path ("
-		       + where_is_interpreter + ") is invalid.";
-		     throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);  
-		   }
+          if (lstat(where_is_interpreter.c_str(), &fchk_buf) != 0) {
+            e = func + " interpreter path (" + where_is_interpreter +
+                ") is invalid.";
+            throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+          }
 
-	         if (!S_ISLNK(fchk_buf.st_mode) && S_ISREG(fchk_buf.st_mode)) 		 
-		   found_interp = true;	     		
-	         else if (S_ISLNK(fchk_buf.st_mode)) 
-		   {	     
-		     char realpath[PATH_MAX];
-		     char tmpath[PATH_MAX];
-		     int cnt;
+          if (!S_ISLNK(fchk_buf.st_mode) && S_ISREG(fchk_buf.st_mode))
+            found_interp = true;
+          else if (S_ISLNK(fchk_buf.st_mode)) {
+            char realpath[PATH_MAX];
+            char tmpath[PATH_MAX];
+            int cnt;
 
-		     strcpy(tmpath, where_is_interpreter.c_str());    	     
-		   
-		     while (S_ISLNK(fchk_buf.st_mode)) 
-		       {	     
-		         if ( (cnt = readlink(tmpath, realpath, PATH_MAX)) == -1 ) 
-			   {
-			     e = func + " readlink failed ";
-			     throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);  
-			   }
-		       
-		         realpath[cnt] = '\0';	       
-		         if (realpath[0] == '/') 
-			   strcpy(tmpath, realpath);
-		         else
-			   sprintf(tmpath, "%s/%s", dirname(tmpath), realpath); 
+            strcpy(tmpath, where_is_interpreter.c_str());
 
-		         if (lstat(tmpath, &fchk_buf) != 0) 
-			   {
-			     e = func + " interpreter path (" + tmpath 
-			       + ") is invalid.";
-			     throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);  
-			   }
-		       } 
-		   
-		     if (S_ISREG(fchk_buf.st_mode)) {		     
-		       where_is_interpreter = tmpath;
-		       found_interp = true;
+            while (S_ISLNK(fchk_buf.st_mode)) {
+              if ((cnt = readlink(tmpath, realpath, PATH_MAX)) == -1) {
+                e = func + " readlink failed ";
+                throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+              }
 
-		       {
-			   self_trace_t::trace ( LEVELCHK(level2), 
-		             MODULENAME, 0, 
-			     "interpreter found in .interp section [%s]",
-			     where_is_interpreter.c_str());
-		       }
-		     } 
-		   
-		   } // else if (S_ISLNK(buf)) {
-	       } // if ( strcmp(".interp", 	    
-	     break;
-	   }
-	 default:
-           //
-           // Expand cases when you need to do more with other ELF sections
-           //
-	   break;
-	 }
+              realpath[cnt] = '\0';
+              if (realpath[0] == '/')
+                strcpy(tmpath, realpath);
+              else
+                sprintf(tmpath, "%s/%s", dirname(tmpath), realpath);
 
-     } // while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) {   
+              if (lstat(tmpath, &fchk_buf) != 0) {
+                e = func + " interpreter path (" + tmpath + ") is invalid.";
+                throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+              }
+            }
 
-  if ( !strtab ) 
-    {
-      e = func + " No string table section is found. ";
-      return SDBG_SYMTAB_FAILED;
-    }  
+            if (S_ISREG(fchk_buf.st_mode)) {
+              where_is_interpreter = tmpath;
+              found_interp = true;
 
-  if ( !elf_data_dso ) 
-    {
-      e = func + " No DSO section is found. ";
-      return SDBG_SYMTAB_FAILED;
+              {
+                self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                                    "interpreter found in .interp section [%s]",
+                                    where_is_interpreter.c_str());
+              }
+            }
+
+          }  // else if (S_ISLNK(buf)) {
+        }    // if ( strcmp(".interp",
+        break;
+      }
+      default:
+        //
+        // Expand cases when you need to do more with other ELF sections
+        //
+        break;
     }
-  if (!interp_sect) 
-    {
-      e = func + " No interpreter found. ";
-      return SDBG_SYMTAB_FAILED;
-    }
-    
+
+  }  // while ( (sect = elf_nextscn(elf_h, sect)) != NULL ) {
+
+  if (!strtab) {
+    e = func + " No string table section is found. ";
+    return SDBG_SYMTAB_FAILED;
+  }
+
+  if (!elf_data_dso) {
+    e = func + " No DSO section is found. ";
+    return SDBG_SYMTAB_FAILED;
+  }
+  if (!interp_sect) {
+    e = func + " No interpreter found. ";
+    return SDBG_SYMTAB_FAILED;
+  }
+
   return SDBG_SYMTAB_OK;
 }
 
-
 //! PROTECTED: linux_image_t<VA>::decode_type --
-/*!   
+/*!
     Determines the symbol type
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-void 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_type(int code, std::string &ret_string) const
-{
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_type(
+    int code, std::string& ret_string) const {
   using namespace std;
 
-#if BIT64 
-  switch(ELF64_ST_TYPE(code))
+#if BIT64
+  switch (ELF64_ST_TYPE(code))
 #else
-  switch(ELF32_ST_TYPE(code))
+  switch (ELF32_ST_TYPE(code))
 #endif
-    {
+  {
 
     case STT_NOTYPE:
       ret_string = string("Symbol type is unspecified");
@@ -867,71 +729,65 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_type(int code, std::string &ret_st
       ret_string = string("End of processor-specific");
       break;
 
-    default:    
+    default:
       ret_string = string(SYMTAB_UNINIT_STRING);
       break;
-    }
+  }
 }
-
 
 //! PROTECTED: image_t<VA>::resolve_binding --
 /*!
     Determines the symbol binding information
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-LMON_ELF_visibility 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::resolve_binding(int code) const
-{
+LMON_ELF_visibility linux_image_t<LINUX_IMAGE_TEMPLPARAM>::resolve_binding(
+    int code) const {
   LMON_ELF_visibility rc = elf_sym_none;
 
 #if BIT64
-  switch(ELF64_ST_BIND(code))
+  switch (ELF64_ST_BIND(code))
 #else
-  switch(ELF32_ST_BIND(code))
+  switch (ELF32_ST_BIND(code))
 #endif
-    {
+  {
     case STB_LOCAL:
-       rc = elf_sym_local;
-       break;
+      rc = elf_sym_local;
+      break;
 
     case STB_GLOBAL:
-       rc = elf_sym_global;
-       break;
+      rc = elf_sym_global;
+      break;
 
     case STB_WEAK:
-       rc = elf_sym_weak;
-       break;
+      rc = elf_sym_weak;
+      break;
 
     default:
       break;
-    }
+  }
 
-  if ( (rc == elf_sym_none) 
-       && ( (code <= STB_HIPROC) && (code >= STB_LOPROC) ))
-    {
-      rc = elf_sym_procspecific;
-    }
+  if ((rc == elf_sym_none) && ((code <= STB_HIPROC) && (code >= STB_LOPROC))) {
+    rc = elf_sym_procspecific;
+  }
 
   return rc;
 }
-
 
 //! PROTECTED: image_t<VA>::decode_binding --
 /*!
     Determines the symbol binding information
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-void
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_binding(int code, std::string &ret_string) const
-{  
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_binding(
+    int code, std::string& ret_string) const {
   using namespace std;
 
 #if BIT64
-  switch(ELF64_ST_BIND(code))
+  switch (ELF64_ST_BIND(code))
 #else
-  switch(ELF32_ST_BIND(code))
+  switch (ELF32_ST_BIND(code))
 #endif
-    {
+  {
 
     case STB_LOCAL:
       ret_string = "Local symbol";
@@ -960,7 +816,7 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_binding(int code, std::string &ret
     case STB_LOPROC:
       ret_string = "Start of processor-specific";
       break;
-      
+
     case STB_HIPROC:
       ret_string = "End of processor-specific ";
       break;
@@ -968,26 +824,24 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_binding(int code, std::string &ret
     default:
       ret_string = SYMTAB_UNINIT_STRING;
       break;
-    }
+  }
 }
-
 
 //! PROTECTED: image_t<VA>::decode_visibility --
 /*!
     Determines the symbol visibility information
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-void
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_visibility (int code, std::string &ret_string) const
-{
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_visibility(
+    int code, std::string& ret_string) const {
   using namespace std;
- 
-#if BIT64 
-  switch(ELF64_ST_VISIBILITY(code))
+
+#if BIT64
+  switch (ELF64_ST_VISIBILITY(code))
 #else
-  switch(ELF32_ST_VISIBILITY(code))
+  switch (ELF32_ST_VISIBILITY(code))
 #endif
-    {
+  {
     case STV_DEFAULT:
       ret_string = "Default symbol visibility rules";
       break;
@@ -995,11 +849,11 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_visibility (int code, std::string 
     case STV_INTERNAL:
       ret_string = "Processor specific hidden class";
       break;
-      
+
     case STV_HIDDEN:
       ret_string = "Sym unavailable in other modules";
       break;
-      
+
     case STV_PROTECTED:
       ret_string = "Not preemptible, not exported";
       break;
@@ -1007,84 +861,60 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::decode_visibility (int code, std::string 
     default:
       ret_string = SYMTAB_UNINIT_STRING;
       break;
-    }
+  }
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-void
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_image_base_address(VA ba)
-{
-  image_base_t<VA,elf_wrapper>::set_image_base_address(ba); 
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_image_base_address(VA ba) {
+  image_base_t<VA, elf_wrapper>::set_image_base_address(ba);
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-const VA&
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_image_base_address() const
-{
-  return (image_base_t<VA,elf_wrapper>::get_image_base_address());
+const VA& linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_image_base_address()
+    const {
+  return (image_base_t<VA, elf_wrapper>::get_image_base_address());
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_base_image_name
-(std::string& n)
-{
-  image_base_t<VA,elf_wrapper>::set_base_image_name(n);
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_base_image_name(
+    std::string& n) {
+  image_base_t<VA, elf_wrapper>::set_base_image_name(n);
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-const std::string& 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_base_image_name() const
-{
-  return (image_base_t<VA,elf_wrapper>::get_base_image_name());
+const std::string& linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_base_image_name()
+    const {
+  return (image_base_t<VA, elf_wrapper>::get_base_image_name());
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_path
-(std::string& n)
-{
-  image_base_t<VA,elf_wrapper>::set_path(n);
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_path(std::string& n) {
+  image_base_t<VA, elf_wrapper>::set_path(n);
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-const std::string& 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_path() const
-{
-  return (image_base_t<VA,elf_wrapper>::get_path());
+const std::string& linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_path() const {
+  return (image_base_t<VA, elf_wrapper>::get_path());
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_native_exec_handler
-(elf_wrapper* h)
-{
-  image_base_t<VA,elf_wrapper>::set_native_exec_handler(h);  
+void linux_image_t<LINUX_IMAGE_TEMPLPARAM>::set_native_exec_handler(
+    elf_wrapper* h) {
+  image_base_t<VA, elf_wrapper>::set_native_exec_handler(h);
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-elf_wrapper* 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_native_exec_handler()
-{
-  return (image_base_t<VA,elf_wrapper>::get_native_exec_handler());
+elf_wrapper* linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_native_exec_handler() {
+  return (image_base_t<VA, elf_wrapper>::get_native_exec_handler());
 }
-
 
 template <LINUX_IMAGE_TEMPLATELIST>
-std::map<std::string, symbol_base_t<VA>*, ltstr>& 
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_linkage_symtab()
-{
-  return (image_base_t<VA,elf_wrapper>::linkage_symtab);
+std::map<std::string, symbol_base_t<VA>*, ltstr>&
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::get_linkage_symtab() {
+  return (image_base_t<VA, elf_wrapper>::linkage_symtab);
 }
 
-#endif // SDBG_LINUX_SYMTAB_IMPL_HXX
-
-
-
-
-
+#endif  // SDBG_LINUX_SYMTAB_IMPL_HXX
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_proc_service.cxx
+++ b/launchmon/src/linux/sdbg_proc_service.cxx
@@ -1,45 +1,46 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/linux/sdbg_proc_service.cxx,v 1.3.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
  *        May  02 2018 KMD: Added aarch64 support
  *        Mar  11 2008 DHA: Added PowerPC support
  *        Feb  09 2008 DHA: Added LLNS Copyright
- *        Jul  18 2006 DHA: Initial Linux PPC (BG/L) port 
+ *        Jul  18 2006 DHA: Initial Linux PPC (BG/L) port
  *        Jul  14 2006 DHA: Initial Linux X86-64 port
  *        Feb  07 2006 DHA: Made it compilable with templated class objects
  *        Jan  10 2006 DHA: Created file.
- */ 
-
+ */
 
 //! file sdbg_proc_service.cxx
 /*!
   This file contains a set of routines that Linux thread debug
-  library expects from a debugger. 
+  library expects from a debugger.
 */
 
 #include "sdbg_std.hxx"
@@ -47,15 +48,14 @@
 #ifndef LINUX_CODE_REQUIRED
 #error This source file requires a LINUX OS
 #endif
- 
 
-#include "sdbg_proc_service.hxx"
-#include "sdbg_linux_std.hxx"
-#include "sdbg_linux_ptracer.hxx"
-#include "sdbg_linux_ptracer_impl.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_mach_impl.hxx"
 #include "sdbg_linux_mach.hxx"
+#include "sdbg_linux_ptracer.hxx"
+#include "sdbg_linux_ptracer_impl.hxx"
+#include "sdbg_linux_std.hxx"
+#include "sdbg_proc_service.hxx"
 
 extern "C" {
 #include <libgen.h>
@@ -68,24 +68,23 @@ extern "C" {
 #define PTRACE_GET_THREAD_AREA 25
 #endif
 
-struct user_desc
-{
+struct user_desc {
   unsigned int entry_number;
   unsigned long int base_addr;
   unsigned int limit;
-  unsigned int seg_32bit:1;
-  unsigned int contents:2;
-  unsigned int read_exec_only:1;
-  unsigned int limit_in_pages:1;
-  unsigned int seg_not_present:1;
-  unsigned int useable:1;
-  unsigned int empty:25;
+  unsigned int seg_32bit : 1;
+  unsigned int contents : 2;
+  unsigned int read_exec_only : 1;
+  unsigned int limit_in_pages : 1;
+  unsigned int seg_not_present : 1;
+  unsigned int useable : 1;
+  unsigned int empty : 25;
 };
 
 #elif X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
 
 #ifndef PTRACE_ARCH_PRCTL
-#define PTRACE_ARCH_PRCTL       30    /* arch_prctl for child */
+#define PTRACE_ARCH_PRCTL 30 /* arch_prctl for child */
 #endif
 #ifndef ARCH_GET_GS
 #define ARCH_GET_GS 0x1004
@@ -93,7 +92,7 @@ struct user_desc
 #ifndef ARCH_GET_FS
 #define ARCH_GET_FS 0x1003
 #endif
-#ifndef GS 
+#ifndef GS
 #define GS 26
 #endif
 #ifndef FS
@@ -104,208 +103,166 @@ struct user_desc
 
 linux_ptracer_t<SDBG_LINUX_DFLT_INSTANTIATION> myprocess_tracer;
 
-
 //! PUBLIC: ps_pdread
 /*!
-    a routine to read from the given process, which 
+    a routine to read from the given process, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_pdread ( struct ps_prochandle *ph,  psaddr_t addr,
-	    void *buf,  size_t size )
-{
-  bool use_cxt = true; 
-  if ( myprocess_tracer.tracer_read (*(ph->p), 
-				     (T_VA) addr, 
-				     buf, 
-				     size, 
-				     use_cxt)
-                                 != SDBG_TRACE_OK ) {
+extern "C" ps_err_e ps_pdread(struct ps_prochandle *ph, psaddr_t addr,
+                              void *buf, size_t size) {
+  bool use_cxt = true;
+  if (myprocess_tracer.tracer_read(*(ph->p), (T_VA)addr, buf, size, use_cxt) !=
+      SDBG_TRACE_OK) {
     return PS_ERR;
   }
-  
+
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_pdwrite
 /*!
-    a routine to write into the given process, which 
+    a routine to write into the given process, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_pdwrite ( struct ps_prochandle *ph,  psaddr_t addr, 
-	     const void *buf, size_t size )
-{  
+extern "C" ps_err_e ps_pdwrite(struct ps_prochandle *ph, psaddr_t addr,
+                               const void *buf, size_t size) {
   bool use_cxt = true;
-  if ( myprocess_tracer.tracer_write (*(ph->p), 
-				      (T_VA) addr, 
-				      buf, 
-				      size,
-				      use_cxt)
-                                 != SDBG_TRACE_OK ) {
+  if (myprocess_tracer.tracer_write(*(ph->p), (T_VA)addr, buf, size, use_cxt) !=
+      SDBG_TRACE_OK) {
     return PS_ERR;
   }
 
   return PS_OK;
 }
 
-
 //! PUBLIC: ps_ptread
 /*!
-    a routine to read from the given thread, which 
+    a routine to read from the given thread, which
     the thread debug library uses. (Identical to process read)
 */
-extern "C" ps_err_e 
-ps_ptread ( struct ps_prochandle *ph,  psaddr_t addr,  
-	    void *buf,  size_t size )
-{
-  return (ps_pdread (ph, addr, buf, size));
+extern "C" ps_err_e ps_ptread(struct ps_prochandle *ph, psaddr_t addr,
+                              void *buf, size_t size) {
+  return (ps_pdread(ph, addr, buf, size));
 }
-
 
 //! PUBLIC: ps_ptwrite
 /*!
-    a routine to read from the given thread, which 
+    a routine to read from the given thread, which
     the thread debug library uses. (Identical to process write)
 */
-extern "C" ps_err_e 
-ps_ptwrite ( struct ps_prochandle *ph,  psaddr_t addr, 
-	     const void *buf, size_t size )
-{
-  return (ps_pdwrite (ph, addr, buf, size));
+extern "C" ps_err_e ps_ptwrite(struct ps_prochandle *ph, psaddr_t addr,
+                               const void *buf, size_t size) {
+  return (ps_pdwrite(ph, addr, buf, size));
 }
-
 
 //! PUBLIC: ps_lgetregs
 /*!
-    a routine to read registers from the given thread, which 
+    a routine to read registers from the given thread, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_lgetregs ( struct ps_prochandle* ph, 
-	      lwpid_t id, prgregset_t reg)
-{ 
+extern "C" ps_err_e ps_lgetregs(struct ps_prochandle *ph, lwpid_t id,
+                                prgregset_t reg) {
   bool use_cxt = true;
 
-  if ( myprocess_tracer.tracer_getregs (*(ph->p), use_cxt)
-                                       != SDBG_TRACE_OK ) {
-
+  if (myprocess_tracer.tracer_getregs(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
 
   // copy ph->p's GPR to reg
-  memcpy((T_GRS*) reg, &(ph->p->get_gprset(use_cxt)->get_native_rs()), sizeof(T_GRS)); 
+  memcpy((T_GRS *)reg, &(ph->p->get_gprset(use_cxt)->get_native_rs()),
+         sizeof(T_GRS));
 
   return PS_OK;
 }
-  
 
 //! PUBLIC: ps_lsetregs
 /*!
-    a routine to set registers for the given thread, which 
+    a routine to set registers for the given thread, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_lsetregs (struct ps_prochandle* ph, 
-	     lwpid_t id, const prgregset_t reg)
-{
+extern "C" ps_err_e ps_lsetregs(struct ps_prochandle *ph, lwpid_t id,
+                                const prgregset_t reg) {
   bool use_cxt = true;
 
-  if ( myprocess_tracer.tracer_setregs (*(ph->p), use_cxt) 
-                                       != SDBG_TRACE_OK ) {
-
+  if (myprocess_tracer.tracer_setregs(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
-  //printf("Please implement ps_lsetregs\n");
+  // printf("Please implement ps_lsetregs\n");
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_lgetfpregs
 /*!
-    a routine to get FP registers for the given thread, which 
+    a routine to get FP registers for the given thread, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_lgetfpregs ( struct ps_prochandle* ph, lwpid_t id, 
-		prfpregset_t* reg )
-{
+extern "C" ps_err_e ps_lgetfpregs(struct ps_prochandle *ph, lwpid_t id,
+                                  prfpregset_t *reg) {
   bool use_cxt = true;
 
-  if ( myprocess_tracer.tracer_getfpregs (*(ph->p), use_cxt) 
-                                       != SDBG_TRACE_OK ) {
-
+  if (myprocess_tracer.tracer_getfpregs(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
-  // copy ph->p  FPR to reg  
+  // copy ph->p  FPR to reg
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_lsetfpregs
 /*!
-    a routine to set FP registers for the given thread, which 
+    a routine to set FP registers for the given thread, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_lsetfpregs ( struct ps_prochandle* ph, lwpid_t id, 
-		const prfpregset_t* reg)
+extern "C" ps_err_e ps_lsetfpregs(struct ps_prochandle *ph, lwpid_t id,
+                                  const prfpregset_t *reg)
 
 {
   bool use_cxt = true;
 
-  if ( myprocess_tracer.tracer_setfpregs (*(ph->p), use_cxt) 
-                      != SDBG_TRACE_OK ) {
+  if (myprocess_tracer.tracer_setfpregs(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
 
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_getpid
 /*!
     a routine to get the pid of the main process, which
     the thread debug library uses.
 */
-extern "C" pid_t ps_getpid ( struct ps_prochandle *ph )
-{
+extern "C" pid_t ps_getpid(struct ps_prochandle *ph) {
   return (ph->p->get_master_thread_pid());
 }
-
 
 //! PUBLIC: ps_get_thread_area
 /*!
     a routine to get the thread specific area, which
     the thread debug library uses.
 */
-extern "C" ps_err_e 
-ps_get_thread_area ( const struct ps_prochandle *ph,
-		     lwpid_t lpid, int x, psaddr_t *addr)
-{
+extern "C" ps_err_e ps_get_thread_area(const struct ps_prochandle *ph,
+                                       lwpid_t lpid, int x, psaddr_t *addr) {
   bool use_cxt = true;
 
 #if X86_ARCHITECTURE || PPC_ARCHITECTURE
   /*
    * How to fetch thread-specific area for x86/linux and powerPC/linux
    *
-   */ 
+   */
 
   /*
-    a linux kernel patch added two new ptrace requests for 
+    a linux kernel patch added two new ptrace requests for
     this architecture "PTRACE_GET_THREAD_AREA" and "
     "PTRACE_SET_THREAD_AREA"
 
-    Those macroes are not exported via standard /usr/include 
-    header files. So are struct user_desc definition and 
+    Those macroes are not exported via standard /usr/include
+    header files. So are struct user_desc definition and
     ifndef PTRACE_GET_THREA_AREA to be 25
   */
 
   // -- excerpt from an email written by Roland McGrath @ Redhat
   /*
     Roland McGrath (roland@redhat.com)
-    Fri, 20 Dec 2002 00:32:41 -0800 
+    Fri, 20 Dec 2002 00:32:41 -0800
 
     This patch vs 2.5.51 (should apply fine to 2.5.52) adds two new ptrace
     requests for i386, PTRACE_GET_THREAD_AREA and PTRACE_SET_THREAD_AREA.
@@ -333,26 +290,24 @@ ps_get_thread_area ( const struct ps_prochandle *ph,
 
     People I talked to preferred adding this interface over putting an array of
     struct user_desc in struct user as accessed by PTRACE_PEEKUSR/POKEUSR
-    (which would be a bit unnatural since those calls access one word at a time).
+    (which would be a bit unnatural since those calls access one word at a
+    time).
   */
 
-  struct user_desc tsd_desc; 
-  if ( myprocess_tracer.baretracer (PTRACE_GET_THREAD_AREA, 
-				    ph->p->get_pid(use_cxt), 
-				    (T_VA)x, 
-				    (T_WT*)&tsd_desc ) 
-                                        != SDBG_TRACE_OK ) 
-    {
-      return PS_ERR;
-    }
+  struct user_desc tsd_desc;
+  if (myprocess_tracer.baretracer(PTRACE_GET_THREAD_AREA,
+                                  ph->p->get_pid(use_cxt), (T_VA)x,
+                                  (T_WT *)&tsd_desc) != SDBG_TRACE_OK) {
+    return PS_ERR;
+  }
 
-  *addr = (psaddr_t) (tsd_desc.base_addr);
+  *addr = (psaddr_t)(tsd_desc.base_addr);
 
 #elif X86_64_ARCHITECTURE || AARCH64_ARCHITECTURE
   /*
    * How to fetch thread-specific area for x86-64/linux
    *
-   */ 
+   */
 
   /*
     A comment from  x86_64/kernel/ptrace.c about PTRACE_GET_THREAD_AREA
@@ -370,14 +325,14 @@ ps_get_thread_area ( const struct ps_prochandle *ph,
       -----
       " normal 64bit interface to access TLS data.
         Works just like arch_prctl, except that the arguments
-	are reversed."
+        are reversed."
 
       case PTRACE_ARCH_PRCTL:
               ret = do_arch_prctl(child, data, addr);
               break;
 
 
-      And do_arch_prctl is defined in x86_64/kernel/process.c 
+      And do_arch_prctl is defined in x86_64/kernel/process.c
 
       -----
       ... prctl.h
@@ -391,21 +346,21 @@ ps_get_thread_area ( const struct ps_prochandle *ph,
 
        switch (code) {
         case ARCH_SET_GS:
-	
-	<CUT>
-	
-	case ARCH_SET_FS:
 
-	<CUT>
+        <CUT>
 
-	case ARCH_GET_FS: 
+        case ARCH_SET_FS:
 
-	<CUT>
+        <CUT>
 
-	case ARCH_GET_GS: 
+        case ARCH_GET_FS:
+
+        <CUT>
+
+        case ARCH_GET_GS:
 
 
-      Assuming thread debug library is passing a valid x which is 
+      Assuming thread debug library is passing a valid x which is
       one of above four
 
 
@@ -445,8 +400,7 @@ ps_get_thread_area ( const struct ps_prochandle *ph,
   T_WT arg;
   psaddr_t thread_area;
 
-  switch (x) 
-    {
+  switch (x) {
     case GS:
       arg = ARCH_GET_GS;
       break;
@@ -456,44 +410,34 @@ ps_get_thread_area ( const struct ps_prochandle *ph,
     default:
       // FIXME:
       arg = 0;
-      break;      	
-    }
+      break;
+  }
 
-  if ( myprocess_tracer.baretracer (PTRACE_ARCH_PRCTL, 
-				    ph->p->get_pid(use_cxt), 
-				    (T_VA) &thread_area, 
-				    (T_WT*) arg ) != SDBG_TRACE_OK ) 
-    {
-      if ( arg == ARCH_GET_GS )	
-        {
-         printf ("thread area fetching failed for general purpose register\n");
-	}
-      else if ( arg == ARCH_GET_FS )
-	{
-         printf ("thread area fetching failed for floating point register\n");
-	} 
-      return PS_ERR;
+  if (myprocess_tracer.baretracer(PTRACE_ARCH_PRCTL, ph->p->get_pid(use_cxt),
+                                  (T_VA)&thread_area,
+                                  (T_WT *)arg) != SDBG_TRACE_OK) {
+    if (arg == ARCH_GET_GS) {
+      printf("thread area fetching failed for general purpose register\n");
+    } else if (arg == ARCH_GET_FS) {
+      printf("thread area fetching failed for floating point register\n");
     }
+    return PS_ERR;
+  }
 
   *addr = thread_area;
-  
-  
+
 #elif IA64_ARCHITECTURE
-  /*
-   * How to fetch thread-specific area for ia64/linux
-   *
-   */  
+/*
+ * How to fetch thread-specific area for ia64/linux
+ *
+ */
 
 #endif
 
   return PS_OK;
 }
 
-
-static 
-bool 
-equal_base(std::string const & path, std::string const & refpath)
-{
+static bool equal_base(std::string const &path, std::string const &refpath) {
   char tmp[PATH_MAX];
   char *bn;
 
@@ -501,30 +445,28 @@ equal_base(std::string const & path, std::string const & refpath)
   bn = basename(tmp);
 
   return (path == std::string(bn));
-} 
+}
 
-static std::string& get_basename( std::string path)
-{ 
+static std::string &get_basename(std::string path) {
   char tmp[PATH_MAX];
-  char *bn; 
- 
+  char *bn;
+
   sprintf(tmp, "%s", path.c_str());
-  bn = basename(tmp); 
-  std::string* rstr = new std::string(bn);
- 
+  bn = basename(tmp);
+  std::string *rstr = new std::string(bn);
+
   return *rstr;
-} 
+}
 
 //! PUBLIC: ps_pglobal_lookup
 /*!
     a routine to fetch a global symbol, which the thread db
     library uses
 */
-extern "C" ps_err_e 
-ps_pglobal_lookup ( struct ps_prochandle *ph, 
-			     const char *object_name, 
-			     const char *sym_name, psaddr_t *sym_addr )
-{
+extern "C" ps_err_e ps_pglobal_lookup(struct ps_prochandle *ph,
+                                      const char *object_name,
+                                      const char *sym_name,
+                                      psaddr_t *sym_addr) {
   using namespace std;
   ps_err_e error_code;
 
@@ -533,142 +475,114 @@ ps_pglobal_lookup ( struct ps_prochandle *ph,
   string pthread_path(ph->p->get_mythread_lib_image()->get_path());
   string myimage_path(ph->p->get_myimage()->get_path());
   string loader_path(ph->p->get_mydynloader_image()->get_path());
-  
-  if (!object_name)
-    return PS_ERR;
+
+  if (!object_name) return PS_ERR;
 
   //
-  // TODO: This if/else should be modified once process_base_t class 
-  // gets to retain std::map obj and maintain each and every library 
+  // TODO: This if/else should be modified once process_base_t class
+  // gets to retain std::map obj and maintain each and every library
   // that the target process brings into its process-address space.
   //
-  if ( equal_base(objpath, pthread_path) ) {
-
-    const symbol_base_t<T_VA>& asym 
-      = ph->p->get_mythread_lib_image()->get_a_symbol(sym);
-    if (asym.get_raw_address()!= SYMTAB_UNINIT_ADDR && 
-	asym.get_relocated_address()) {
-
-      (*sym_addr) = (psaddr_t) asym.get_relocated_address();
-      error_code = (*sym_addr)? PS_OK : PS_ERR;
-    }
-    else {
+  if (equal_base(objpath, pthread_path)) {
+    const symbol_base_t<T_VA> &asym =
+        ph->p->get_mythread_lib_image()->get_a_symbol(sym);
+    if (asym.get_raw_address() != SYMTAB_UNINIT_ADDR &&
+        asym.get_relocated_address()) {
+      (*sym_addr) = (psaddr_t)asym.get_relocated_address();
+      error_code = (*sym_addr) ? PS_OK : PS_ERR;
+    } else {
       error_code = PS_NOSYM;
     }
-  }
-  else if ( equal_base(objpath, myimage_path) ) {
-
-    const symbol_base_t<T_VA>& asym 
-      =  ph->p->get_myimage()->get_a_symbol(sym);
-    if (asym.get_raw_address()!= SYMTAB_UNINIT_ADDR && 
-	asym.get_relocated_address()) {
-
-      (*sym_addr) = (psaddr_t) asym.get_relocated_address();
-      error_code = (*sym_addr)? PS_OK : PS_ERR;
-    }
-    else {
+  } else if (equal_base(objpath, myimage_path)) {
+    const symbol_base_t<T_VA> &asym = ph->p->get_myimage()->get_a_symbol(sym);
+    if (asym.get_raw_address() != SYMTAB_UNINIT_ADDR &&
+        asym.get_relocated_address()) {
+      (*sym_addr) = (psaddr_t)asym.get_relocated_address();
+      error_code = (*sym_addr) ? PS_OK : PS_ERR;
+    } else {
       error_code = PS_NOSYM;
     }
-  }
-  else if ( equal_base(objpath, loader_path)) {
-
-    const symbol_base_t<T_VA>& asym 
-      =  ph->p->get_mydynloader_image()->get_a_symbol(sym);
-    if (asym.get_raw_address()!= SYMTAB_UNINIT_ADDR && 
-	asym.get_relocated_address()) {
-
-      (*sym_addr) = (psaddr_t) asym.get_relocated_address();
-      error_code = (*sym_addr)? PS_OK : PS_ERR;
-    }
-    else {
+  } else if (equal_base(objpath, loader_path)) {
+    const symbol_base_t<T_VA> &asym =
+        ph->p->get_mydynloader_image()->get_a_symbol(sym);
+    if (asym.get_raw_address() != SYMTAB_UNINIT_ADDR &&
+        asym.get_relocated_address()) {
+      (*sym_addr) = (psaddr_t)asym.get_relocated_address();
+      error_code = (*sym_addr) ? PS_OK : PS_ERR;
+    } else {
       error_code = PS_NOSYM;
     }
-  }
-  else {
+  } else {
     error_code = PS_ERR;
   }
 
   return error_code;
 }
 
-
 //! PUBLIC: ps_pstop
 /*!
     a routine to stop the given process, which the thread db
     library uses
 */
-extern "C" ps_err_e 
-ps_pstop ( const struct ps_prochandle *ph)
-{
+extern "C" ps_err_e ps_pstop(const struct ps_prochandle *ph) {
   bool use_cxt = false;
-  if ( myprocess_tracer.tracer_stop(*(ph->p), use_cxt)
-                                    != SDBG_TRACE_OK ) {
-
+  if (myprocess_tracer.tracer_stop(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
 
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_pcontinue
 /*!
     a routine to continue the given process, which the thread db
     library uses
 */
-extern "C" ps_err_e 
-ps_pcontinue ( const struct ps_prochandle *ph )
-{
+extern "C" ps_err_e ps_pcontinue(const struct ps_prochandle *ph) {
   bool use_cxt = false;
-  if ( myprocess_tracer.tracer_continue(*(ph->p), use_cxt)
-                                      != SDBG_TRACE_OK ) {
+  if (myprocess_tracer.tracer_continue(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
     return PS_ERR;
   }
 
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_lstop
 /*!
     a routine to stop the given thread, which the thread db
     library uses
 */
-extern "C" ps_err_e 
-ps_lstop ( const struct ps_prochandle *ph, lwpid_t lp)
-{
+extern "C" ps_err_e ps_lstop(const struct ps_prochandle *ph, lwpid_t lp) {
   bool use_cxt = true;
 
-  ph->p->make_context ( (const int) lp );
-  if (myprocess_tracer.tracer_stop(*(ph->p), use_cxt)
-	                          != SDBG_TRACE_OK) {
-    ph->p->check_and_undo_context( (const int) lp );
+  ph->p->make_context((const int)lp);
+  if (myprocess_tracer.tracer_stop(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
+    ph->p->check_and_undo_context((const int)lp);
     return PS_ERR;
   }
-  ph->p->check_and_undo_context( (const int) lp );
+  ph->p->check_and_undo_context((const int)lp);
 
   return PS_OK;
 }
-
 
 //! PUBLIC: ps_lcontinue
 /*!
     a routine to continue the given thread, which the thread db
     library uses
 */
-extern "C" ps_err_e 
-ps_lcontinue (const struct ps_prochandle *ph, lwpid_t lp)
-{
+extern "C" ps_err_e ps_lcontinue(const struct ps_prochandle *ph, lwpid_t lp) {
   bool use_cxt = true;
 
-  ph->p->make_context ( (const int) lp );
-  if (myprocess_tracer.tracer_continue(*(ph->p), use_cxt)
-	                          != SDBG_TRACE_OK) {
-    ph->p->check_and_undo_context( (const int) lp );
+  ph->p->make_context((const int)lp);
+  if (myprocess_tracer.tracer_continue(*(ph->p), use_cxt) != SDBG_TRACE_OK) {
+    ph->p->check_and_undo_context((const int)lp);
     return PS_ERR;
   }
-  ph->p->check_and_undo_context( (const int) lp );
+  ph->p->check_and_undo_context((const int)lp);
 
   return PS_OK;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_proc_service.hxx
+++ b/launchmon/src/linux/sdbg_proc_service.hxx
@@ -29,72 +29,65 @@ extern "C" {
 #include <sys/procfs.h>
 
 /* Functions in this interface return one of these status codes.  */
-typedef enum
-{
-  PS_OK,		/* Generic "call succeeded".  */
-  PS_ERR,		/* Generic error. */
-  PS_BADPID,		/* Bad process handle.  */
-  PS_BADLID,		/* Bad LWP identifier.  */
-  PS_BADADDR,		/* Bad address.  */
-  PS_NOSYM,		/* Could not find given symbol.  */
-  PS_NOFREGS		/* FPU register set not available for given LWP.  */
+typedef enum {
+  PS_OK,      /* Generic "call succeeded".  */
+  PS_ERR,     /* Generic error. */
+  PS_BADPID,  /* Bad process handle.  */
+  PS_BADLID,  /* Bad LWP identifier.  */
+  PS_BADADDR, /* Bad address.  */
+  PS_NOSYM,   /* Could not find given symbol.  */
+  PS_NOFREGS  /* FPU register set not available for given LWP.  */
 } ps_err_e;
-
 
 /* This type is opaque in this interface.
    It's defined by the user of libthread_db.  */
 struct ps_prochandle;
 
 /* Read or write process memory at the given address.  */
-extern ps_err_e ps_pdread (struct ps_prochandle *,
-			   psaddr_t, void *, size_t);
-extern ps_err_e ps_pdwrite (struct ps_prochandle *,
-			    psaddr_t, const void *, size_t);
-extern ps_err_e ps_ptread (struct ps_prochandle *,
-			   psaddr_t, void *, size_t);
-extern ps_err_e ps_ptwrite (struct ps_prochandle *,
-			    psaddr_t, const void *, size_t);
-
+extern ps_err_e ps_pdread(struct ps_prochandle *, psaddr_t, void *, size_t);
+extern ps_err_e ps_pdwrite(struct ps_prochandle *, psaddr_t, const void *,
+                           size_t);
+extern ps_err_e ps_ptread(struct ps_prochandle *, psaddr_t, void *, size_t);
+extern ps_err_e ps_ptwrite(struct ps_prochandle *, psaddr_t, const void *,
+                           size_t);
 
 /* Get and set the given LWP's general or FPU register set.  */
-extern ps_err_e ps_lgetregs (struct ps_prochandle *,
-			     lwpid_t, prgregset_t);
-extern ps_err_e ps_lsetregs (struct ps_prochandle *,
-			     lwpid_t, const prgregset_t);
-extern ps_err_e ps_lgetfpregs (struct ps_prochandle *,
-			       lwpid_t, prfpregset_t *);
-extern ps_err_e ps_lsetfpregs (struct ps_prochandle *,
-			       lwpid_t, const prfpregset_t *);
+extern ps_err_e ps_lgetregs(struct ps_prochandle *, lwpid_t, prgregset_t);
+extern ps_err_e ps_lsetregs(struct ps_prochandle *, lwpid_t, const prgregset_t);
+extern ps_err_e ps_lgetfpregs(struct ps_prochandle *, lwpid_t, prfpregset_t *);
+extern ps_err_e ps_lsetfpregs(struct ps_prochandle *, lwpid_t,
+                              const prfpregset_t *);
 
 /* Return the PID of the process.  */
-extern pid_t ps_getpid (struct ps_prochandle *);
+extern pid_t ps_getpid(struct ps_prochandle *);
 
 /* Fetch the special per-thread address associated with the given LWP.
    This call is only used on a few platforms (most use a normal register).
    The meaning of the `int' parameter is machine-dependent.  */
-extern ps_err_e ps_get_thread_area (const struct ps_prochandle *,
-				    lwpid_t, int, psaddr_t *);
-
+extern ps_err_e ps_get_thread_area(const struct ps_prochandle *, lwpid_t, int,
+                                   psaddr_t *);
 
 /* Look up the named symbol in the named DSO in the symbol tables
    associated with the process being debugged, filling in *SYM_ADDR
    with the corresponding run-time address.  */
-extern ps_err_e ps_pglobal_lookup (struct ps_prochandle *,
-				   const char *object_name,
-				   const char *sym_name,
-				   psaddr_t *sym_addr);
-
+extern ps_err_e ps_pglobal_lookup(struct ps_prochandle *,
+                                  const char *object_name, const char *sym_name,
+                                  psaddr_t *sym_addr);
 
 /* Stop or continue the entire process.  */
-extern ps_err_e ps_pstop (const struct ps_prochandle *);
-extern ps_err_e ps_pcontinue (const struct ps_prochandle *);
+extern ps_err_e ps_pstop(const struct ps_prochandle *);
+extern ps_err_e ps_pcontinue(const struct ps_prochandle *);
 
 /* Stop or continue the given LWP alone.  */
-extern ps_err_e ps_lstop (const struct ps_prochandle *, lwpid_t);
-extern ps_err_e ps_lcontinue (const struct ps_prochandle *, lwpid_t);
+extern ps_err_e ps_lstop(const struct ps_prochandle *, lwpid_t);
+extern ps_err_e ps_lcontinue(const struct ps_prochandle *, lwpid_t);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* SDBG_PROC_SERVICE_HXX */
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_rm_spawner.hxx
+++ b/launchmon/src/linux/sdbg_rm_spawner.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        May 31 2012 DHA: Copied from the 0.8-middleware-support branch
@@ -45,9 +45,8 @@
 #include "sdbg_rm_map.hxx"
 #include "sdbg_self_trace.hxx"
 
-class spawner_rm_t : public spawner_base_t
-{
-public:
+class spawner_rm_t : public spawner_base_t {
+ public:
   ////////////////////////////////////////////////////////////
   //
   //  Public Interfaces
@@ -55,14 +54,11 @@ public:
   spawner_rm_t();
   ~spawner_rm_t();
 
-  spawner_rm_t(const std::string &rac,
-		 const std::vector<std::string> & racargs,
-		 const std::string ep);
+  spawner_rm_t(const std::string &rac, const std::vector<std::string> &racargs,
+               const std::string ep);
 
-  spawner_rm_t(const std::string &rac,
-		 const std::vector<std::string> & racargs,
-		 const std::string ep,
-		 const std::vector<std::string> & hosts);
+  spawner_rm_t(const std::string &rac, const std::vector<std::string> &racargs,
+               const std::string ep, const std::vector<std::string> &hosts);
 
   virtual ~spawner_rm_t();
 
@@ -72,9 +68,12 @@ public:
 
   static spawner_rm_t *new_spawner_rm_t(...);
 
-private:
-
-  explict spawner_rm_t (const spawner_rsh_t & s);
+ private:
+  explict spawner_rm_t(const spawner_rsh_t &s);
 };
 
-#endif // SDBG_RM_SPAWNER_HXX
+#endif  // SDBG_RM_SPAWNER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_rsh_spawner.cxx
+++ b/launchmon/src/linux/sdbg_rsh_spawner.cxx
@@ -1,30 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        May 31 2012 DHA: Copied from the 0.8-middleware-support branch
@@ -38,123 +38,100 @@
 #error This source file requires a LINUX OS
 #endif
 
+#include <string.h>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
-#include <string.h>
 #include <vector>
 #include "lmon_api/lmon_say_msg.hxx"
 #include "sdbg_rsh_spawner.hxx"
-
 
 //////////////////////////////////////////////////////////////////////////
 //
 //   Public Interface
 //
-bool
-spawner_rsh_t::spawn()
-{
-  if (get_hosts_vector().empty())
-    {
-      return false;
-    }
+bool spawner_rsh_t::spawn() {
+  if (get_hosts_vector().empty()) {
+    return false;
+  }
 
-  unsigned int i=0;
-  unsigned int j=0;
+  unsigned int i = 0;
+  unsigned int j = 0;
   unsigned int halfhosts = get_hosts_vector().size() / 2;
   unsigned int right_start_index = halfhosts + 1;
-  unsigned int left_start_index = 1; 
+  unsigned int left_start_index = 1;
   bool lefton = false;
   bool righton = false;
   std::string leftrsh = std::string(LMON_RSHSPAWNER_OPT) + std::string("=");
   std::string rightrsh = leftrsh;
 
-  if (get_hosts_vector().size() > 0)
-    {
-      lefton = true;
+  if (get_hosts_vector().size() > 0) {
+    lefton = true;
 
-      if (halfhosts > 0)
-        righton = true;
+    if (halfhosts > 0) righton = true;
+  }
+
+  if (righton) {
+    for (i = right_start_index; i < (get_hosts_vector().size() - 1); ++i) {
+      rightrsh += get_hosts_vector()[i] + std::string(LMON_HOST_DELIM);
     }
 
-
-  if (righton)
-    {
-      for (i=right_start_index; i < (get_hosts_vector().size()-1); ++i)
-        {
-          rightrsh += get_hosts_vector()[i] + std::string(LMON_HOST_DELIM);
-        }
-
-      if (i == (get_hosts_vector().size()-1))
-        {
-          rightrsh += get_hosts_vector()[i++];
-        }
-
-      if (i == right_start_index)
-        {
-          rightrsh += LMON_NO_HOST;
-        }
+    if (i == (get_hosts_vector().size() - 1)) {
+      rightrsh += get_hosts_vector()[i++];
     }
 
-  if (lefton)
-    {
-      for (j=left_start_index; j+1 < halfhosts; ++j)
-        {
-            leftrsh += get_hosts_vector()[j] + std::string(LMON_HOST_DELIM);;
-        }
+    if (i == right_start_index) {
+      rightrsh += LMON_NO_HOST;
+    }
+  }
 
-      if (j+1 == halfhosts)
-        {
-          leftrsh += get_hosts_vector()[j++];
-        }
-
-      if (j == left_start_index)
-        {
-          leftrsh += LMON_NO_HOST;
-        }
+  if (lefton) {
+    for (j = left_start_index; j + 1 < halfhosts; ++j) {
+      leftrsh += get_hosts_vector()[j] + std::string(LMON_HOST_DELIM);
     }
 
-  if (lefton)
-    {
-      if ( !(rightpid = fork()))
-        {
-          if (!execute_rsh(get_hosts_vector()[0], leftrsh))
-            {
-              //
-              // This is within the child process that failed to exec
-              // So ** SINK HERE **
-              //
-              exit(1);
-            }
-         }
+    if (j + 1 == halfhosts) {
+      leftrsh += get_hosts_vector()[j++];
     }
-  
-  if (righton)
-    {
-      if ( !(leftpid = fork()))
-        {
-          if (!execute_rsh(get_hosts_vector()[halfhosts], rightrsh))
-            {
-              //
-              // This is within the child process that failed to exec
-              // So ** SINK HERE **
-              // 
-              exit(1);
-            }
-        }
+
+    if (j == left_start_index) {
+      leftrsh += LMON_NO_HOST;
     }
+  }
+
+  if (lefton) {
+    if (!(rightpid = fork())) {
+      if (!execute_rsh(get_hosts_vector()[0], leftrsh)) {
+        //
+        // This is within the child process that failed to exec
+        // So ** SINK HERE **
+        //
+        exit(1);
+      }
+    }
+  }
+
+  if (righton) {
+    if (!(leftpid = fork())) {
+      if (!execute_rsh(get_hosts_vector()[halfhosts], rightrsh)) {
+        //
+        // This is within the child process that failed to exec
+        // So ** SINK HERE **
+        //
+        exit(1);
+      }
+    }
+  }
 
   return lefton;
 }
-
 
 //////////////////////////////////////////////////////////////////////////
 //
 //   Private Methods
 //
-bool
-spawner_rsh_t::execute_rsh(const std::string &headhost, const std::string &hostsarg)
-{
+bool spawner_rsh_t::execute_rsh(const std::string &headhost,
+                                const std::string &hostsarg) {
   //
   // compute required malloc size
   // 1: launcher command
@@ -162,27 +139,26 @@ spawner_rsh_t::execute_rsh(const std::string &headhost, const std::string &hosts
   // 1: headhost
   // 1: deamonpath
   // m: daemonargs
-  // 1: LMON_RSHSPAWNER_OPT option 
+  // 1: LMON_RSHSPAWNER_OPT option
   // 1: null-termination
 
   int nargvs = get_launch_cmd_args().size() + get_daemon_args().size() + 5;
   int i = 0;
-  char **av = (char **) malloc (nargvs * sizeof(av));
-  av[i++] = strdup (get_remote_launch_cmd().c_str());
+  char **av = (char **)malloc(nargvs * sizeof(av));
+  av[i++] = strdup(get_remote_launch_cmd().c_str());
   std::vector<std::string>::const_iterator iter;
-  for (iter = get_launch_cmd_args().begin(); 
-         iter != get_launch_cmd_args().end(); ++iter)
-    {
-      av[i++] = strdup((*iter).c_str());
-    }
+  for (iter = get_launch_cmd_args().begin();
+       iter != get_launch_cmd_args().end(); ++iter) {
+    av[i++] = strdup((*iter).c_str());
+  }
 
   av[i++] = strdup(headhost.c_str());
   av[i++] = strdup(get_daemon_path().c_str());
 
-  for (iter = get_daemon_args().begin(); iter != get_daemon_args().end(); ++iter)
-    {
-      av[i++] = strdup ((*iter).c_str());
-    }
+  for (iter = get_daemon_args().begin(); iter != get_daemon_args().end();
+       ++iter) {
+    av[i++] = strdup((*iter).c_str());
+  }
 
   av[i++] = strdup(hostsarg.c_str());
   av[i++] = NULL;
@@ -191,10 +167,9 @@ spawner_rsh_t::execute_rsh(const std::string &headhost, const std::string &hosts
   // We use excvp so that we don't have to copy environ
   // If works, this is SINK
   //
-  if ( execvp ( av[0], av) < 0 )
-    {
-      return false;
-    }
+  if (execvp(av[0], av) < 0) {
+    return false;
+  }
 
   //
   // Unreachable but to satisfy the compiler
@@ -202,3 +177,6 @@ spawner_rsh_t::execute_rsh(const std::string &headhost, const std::string &hosts
   return true;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/linux/sdbg_rsh_spawner.hxx
+++ b/launchmon/src/linux/sdbg_rsh_spawner.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        May 31 2012 DHA: Copied from the 0.8-middleware-support branch
@@ -36,122 +36,94 @@
 
 #include "sdbg_std.hxx"
 
-#include <string>
 #include <string.h>
+#include <string>
 #include <vector>
 #include "sdbg_base_spawner.hxx"
 
 const char LMON_RSHSPAWNER_OPT[] = "--lmon-rsh";
 const char LMON_NO_HOST[] = "nohost";
 
-class spawner_rsh_t : public spawner_base_t
-{
-public:
+class spawner_rsh_t : public spawner_base_t {
+ public:
   ////////////////////////////////////////////////////////////
   //
   //  Public Interfaces
   //
-  spawner_rsh_t()
-    {
+  spawner_rsh_t() {}
 
-    }
-
-  spawner_rsh_t(const std::string &rac,
-    const std::vector<std::string> &racargs,
-    const std::string &dpath,
-    const std::vector<std::string> &dmonopts)
-      : spawner_base_t(rac, racargs, dpath, dmonopts)
-    {
-
-    }
+  spawner_rsh_t(const std::string &rac, const std::vector<std::string> &racargs,
+                const std::string &dpath,
+                const std::vector<std::string> &dmonopts)
+      : spawner_base_t(rac, racargs, dpath, dmonopts) {}
 
   //
-  // ctor to use when a standard RSHCMD will 
+  // ctor to use when a standard RSHCMD will
   // perform what you want
   //
   spawner_rsh_t(const std::string &dpath,
-    const std::vector<std::string> &dmonopts)
-      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath, dmonopts)
-    {
+                const std::vector<std::string> &dmonopts)
+      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath,
+                       dmonopts) {}
 
-    }
-
-  spawner_rsh_t(const std::string &rac,
-    const std::vector<std::string> &racargs,
-    const std::string &dpath,
-    const std::vector<std::string> &dmonopts,
-    const std::vector<std::string> &hosts)
-      : spawner_base_t(rac, racargs, dpath, dmonopts, hosts)
-    {
-
-    }
+  spawner_rsh_t(const std::string &rac, const std::vector<std::string> &racargs,
+                const std::string &dpath,
+                const std::vector<std::string> &dmonopts,
+                const std::vector<std::string> &hosts)
+      : spawner_base_t(rac, racargs, dpath, dmonopts, hosts) {}
 
   //
-  // ctor to use when a standard RSHCMD will 
-  // perform what you want 
+  // ctor to use when a standard RSHCMD will
+  // perform what you want
   //
   spawner_rsh_t(const std::string &dpath,
-    const std::vector<std::string> &dmonopts,
-    const std::vector<std::string> &hosts)
-      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath, dmonopts, hosts)
-    {
+                const std::vector<std::string> &dmonopts,
+                const std::vector<std::string> &hosts)
+      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath,
+                       dmonopts, hosts) {}
 
+  spawner_rsh_t(const std::string &rac, const std::vector<std::string> &racargs,
+                const std::string &dpath,
+                const std::vector<std::string> &dmonopts, const char *hlsarg)
+      : spawner_base_t(rac, racargs, dpath, dmonopts) {
+    char *hlsargcp = strdup(hlsarg);
+    const char *token = strtok(hlsargcp, LMON_HOST_DELIM);
+
+    while (token) {
+      if (strcmp(token, LMON_NO_HOST) != 0) {
+        get_hosts_vector().push_back(std::string(token));
+      }
+      token = strtok(NULL, LMON_HOST_DELIM);
     }
-
-  spawner_rsh_t(const std::string &rac,
-    const std::vector<std::string> &racargs,
-    const std::string &dpath,
-    const std::vector<std::string> &dmonopts,
-    const char *hlsarg)
-      : spawner_base_t(rac, racargs, dpath, dmonopts)
-    {
-      char *hlsargcp = strdup(hlsarg);
-      const char *token = strtok(hlsargcp, LMON_HOST_DELIM);
-
-      while ( token )
-        {
-          if (strcmp(token, LMON_NO_HOST) != 0)
-            {
-              get_hosts_vector().push_back(std::string(token));
-            }
-          token = strtok(NULL, LMON_HOST_DELIM);
-        }
-    }
+  }
 
   //
-  // ctor to use when a standard RSHCMD will 
+  // ctor to use when a standard RSHCMD will
   // perform what you want over a delimited hostlist c-string
   //
   spawner_rsh_t(const std::string &dpath,
-    const std::vector<std::string> &dmonopts,
-    const char *hlsarg)
-      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath, dmonopts)
-    {
-      char *hlsargcp = strdup(hlsarg);
-      const char *token = strtok(hlsargcp, LMON_HOST_DELIM);
+                const std::vector<std::string> &dmonopts, const char *hlsarg)
+      : spawner_base_t(std::string(RSHCMD), std::vector<std::string>(), dpath,
+                       dmonopts) {
+    char *hlsargcp = strdup(hlsarg);
+    const char *token = strtok(hlsargcp, LMON_HOST_DELIM);
 
-      while ( token )
-        {
-          if (strcmp(token, LMON_NO_HOST) != 0)
-            {
-              get_hosts_vector().push_back(std::string(token));
-            }
-          token = strtok(NULL, LMON_HOST_DELIM);
-        }
+    while (token) {
+      if (strcmp(token, LMON_NO_HOST) != 0) {
+        get_hosts_vector().push_back(std::string(token));
+      }
+      token = strtok(NULL, LMON_HOST_DELIM);
     }
+  }
 
-  virtual ~spawner_rsh_t()
-    {
-
-    }
+  virtual ~spawner_rsh_t() {}
 
   virtual bool spawn();
 
-private:
-  explicit spawner_rsh_t (const spawner_rsh_t & s)
-   {
-     // does nothing
-   }
+ private:
+  explicit spawner_rsh_t(const spawner_rsh_t &s) {
+    // does nothing
+  }
 
   bool execute_rsh(const std::string &headhost, const std::string &hostsarg);
 
@@ -159,4 +131,8 @@ private:
   pid_t rightpid;
 };
 
-#endif // SDBG_RSH_SPAWNER_HXX
+#endif  // SDBG_RSH_SPAWNER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_bp.hxx
+++ b/launchmon/src/sdbg_base_bp.hxx
@@ -1,52 +1,53 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_bp.hxx,v 1.4.2.1 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Oct 26 2010 DHA: Hid status and added status set/unset methods
  *        Mar 06 2008 DHA: Added indirect breakpoint
  *        Feb 09 2008 DHA: Added LLNS Copyright
- *        Jun 06 2006 DHA: Added DOXYGEN comments on the file scope 
- *                         and the class (breakpoint_base_t) 
+ *        Jun 06 2006 DHA: Added DOXYGEN comments on the file scope
+ *                         and the class (breakpoint_base_t)
  *        Jan 12 2006 DHA: Created file.
- */ 
+ */
 
 //! FILE: sdbg_base_bp.hxx
 /*!
     The file contains the base class for breakpoint objects.
-    The templated breakpoint_base_t gets instantiated by 
+    The templated breakpoint_base_t gets instantiated by
     a platform-specific layer in regards to the virtual address
-    type and the instruction type. 
+    type and the instruction type.
 
     Since most of the archtecture employ a trap instruction
-    to implement the breakpoint, this class carries the trap 
-    instruction itself around. 
+    to implement the breakpoint, this class carries the trap
+    instruction itself around.
 
     Note that one should only put platform independent logics
-    into this file. 
+    into this file.
 */
 
 #ifndef SDBG_BASE_BP_HXX
@@ -55,7 +56,7 @@
 //! breakpoint_base_t:
 /*!
     The platform-independent breakpoint class. A platform
-    specific layer should provide this with a virtual 
+    specific layer should provide this with a virtual
     address type and an instruction type.
 
     A noteworthy feature is that this class attemps to blend
@@ -64,99 +65,72 @@
     indirect call.
 */
 template <class VA, class IT>
-class breakpoint_base_t
-{
+class breakpoint_base_t {
+ public:
+  enum bp_status_e { bp_unset, bp_set, bp_enabled, bp_disabled };
 
-public:
+  breakpoint_base_t() { status = bp_unset; }
 
-  enum bp_status_e {
-    bp_unset,
-    bp_set,
-    bp_enabled, 
-    bp_disabled
-  };
+  breakpoint_base_t(const breakpoint_base_t<VA, IT> &b) {
+    address_at = b.address_at;
+    indirect_address_at = b.indirect_address_at;
+    return_addr = b.return_addr;
+    trap_instruction = b.trap_instruction;
+    orig_instruction = b.orig_instruction;
+    blend_mask = b.blend_mask;
+    status = b.status;
+    use_indirection = b.use_indirection;
+  }
 
-  
-  breakpoint_base_t ()                     {
-					     status = bp_unset; 
-					   }
+  virtual ~breakpoint_base_t() {}
 
-  breakpoint_base_t ( const breakpoint_base_t<VA, IT> &b )
-                                           {
-					     address_at = b.address_at;
-					     indirect_address_at = b.indirect_address_at;
-					     return_addr = b.return_addr;
-					     trap_instruction = b.trap_instruction;
-					     orig_instruction = b.orig_instruction;
-					     blend_mask = b.blend_mask;
-					     status = b.status;
-					     use_indirection = b.use_indirection;
-					   }
+  bool get_use_indirection() const { return use_indirection; }
+  VA const &get_address_at() const { return address_at; }
+  VA const &get_indirect_address_at() const { return indirect_address_at; }
+  VA const &get_return_addr() const { return return_addr; }
+  IT const &get_trap_instruction() const { return trap_instruction; }
+  IT const &get_orig_instruction() const { return orig_instruction; }
+  IT const &get_blend_mask() const { return blend_mask; }
 
-  virtual ~breakpoint_base_t ()            { }
+  virtual VA const &get_where_pc_would_be() { return address_at; }
+  virtual bool is_pc_part_of_bp_op(VA pc) {
+    return ((pc == address_at) ? true : false);
+  }
 
-  bool get_use_indirection() const         { return use_indirection; }
-  VA const & get_address_at() const        { return address_at; }
-  VA const & get_indirect_address_at() const 
-                                           { return indirect_address_at; }
-  VA const & get_return_addr() const       { return return_addr; }
-  IT const & get_trap_instruction () const { return trap_instruction; }
-  IT const & get_orig_instruction () const { return orig_instruction; }
-  IT const & get_blend_mask () const       { return blend_mask; }
-
-  virtual VA const & get_where_pc_would_be() 
-                                           { return address_at; }
-  virtual bool is_pc_part_of_bp_op(VA pc)  { return ((pc==address_at)?true: false); }
-
-  void set_use_indirection ()              { use_indirection = true; }
-  void unset_use_indirection ()            { use_indirection = false; }
-  void set_address_at ( const VA &addr )   { address_at = addr; }
+  void set_use_indirection() { use_indirection = true; }
+  void unset_use_indirection() { use_indirection = false; }
+  void set_address_at(const VA &addr) { address_at = addr; }
   void set_indirect_address_at(const VA &addr) { indirect_address_at = addr; }
-  void set_return_addr (const VA &raddr)    { return_addr = raddr; }
-  void set_trap_instruction ( const IT &i ) { trap_instruction = i; }
-  void set_orig_instruction ( const IT &i ) { orig_instruction = i; }
-  void set_blend_mask ( const IT &i)        { blend_mask = i; }
+  void set_return_addr(const VA &raddr) { return_addr = raddr; }
+  void set_trap_instruction(const IT &i) { trap_instruction = i; }
+  void set_orig_instruction(const IT &i) { orig_instruction = i; }
+  void set_blend_mask(const IT &i) { blend_mask = i; }
 
-  bool enable()                             
-         { 
-           status = ((status == bp_set) || (status == bp_disabled)) ? bp_enabled : status; 
-           return (status == bp_enabled) ? true : false; 
-         }
-                                                 
-  bool disable()
-         { 
-           status = ((status == bp_enabled)) ? bp_disabled : status; 
-           return (status == bp_disabled) ? true : false; 
-         }
+  bool enable() {
+    status =
+        ((status == bp_set) || (status == bp_disabled)) ? bp_enabled : status;
+    return (status == bp_enabled) ? true : false;
+  }
 
-  bool set()
-         { 
-           status = ((status == bp_unset)) ? bp_set : status; 
-           return (status == bp_set) ? true : false; 
-         }
+  bool disable() {
+    status = ((status == bp_enabled)) ? bp_disabled : status;
+    return (status == bp_disabled) ? true : false;
+  }
 
-  bool is_enabled()
-         { 
-           return (status == bp_enabled) ? true : false; 
-         }
+  bool set() {
+    status = ((status == bp_unset)) ? bp_set : status;
+    return (status == bp_set) ? true : false;
+  }
 
-  bool is_disabled()
-         { 
-           return (status == bp_disabled) ? true : false; 
-         }
+  bool is_enabled() { return (status == bp_enabled) ? true : false; }
 
-  bool is_set()
-         { 
-           return (status == bp_set) ? true : false; 
-         }
+  bool is_disabled() { return (status == bp_disabled) ? true : false; }
 
-  bool is_unset() 
-         { 
-           return (status == bp_unset) ? true : false; 
-         }
+  bool is_set() { return (status == bp_set) ? true : false; }
 
-private:
+  bool is_unset() { return (status == bp_unset) ? true : false; }
 
+ private:
   //! status
   /*!
       status of the BP object
@@ -165,8 +139,8 @@ private:
 
   //! use_indirect:
   /*!
-      This is to support indirect calls. 
-      E.g., call *foo as opposed to call foo. 
+      This is to support indirect calls.
+      E.g., call *foo as opposed to call foo.
   */
   bool use_indirection;
 
@@ -178,22 +152,22 @@ private:
 
   //! address_at:
   /*!
-      Target indirect code address 
+      Target indirect code address
   */
   VA indirect_address_at;
 
   //! address_at:
   /*!
-      return address; this is needed in case the next 
-      instruction address is the next instructon of the 
-      caller function 
+      return address; this is needed in case the next
+      instruction address is the next instructon of the
+      caller function
   */
   VA return_addr;
 
   //! trap_instruction:
   /*!
       Break point trap instruction to use, which differs by
-      platforms 
+      platforms
   */
   IT trap_instruction;
 
@@ -210,4 +184,8 @@ private:
   IT blend_mask;
 };
 
-#endif // SDBG_BASE_BP_HXX
+#endif  // SDBG_BASE_BP_HXX
+
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_driver.hxx
+++ b/launchmon/src/sdbg_base_driver.hxx
@@ -1,48 +1,48 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_driver.hxx,v 1.6.2.1 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
- *			
+ *
  *  Update Log:
  *        Aug 13 2009 DHA: Move copy constructor and create operator=
  *                         into the private section.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Jun 06 2006 DHA: Added DOXYGEN comments on the file scope. 
- *                         and the class (driver_base_t) 
+ *        Jun 06 2006 DHA: Added DOXYGEN comments on the file scope.
+ *                         and the class (driver_base_t)
  *        Jan 08 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_BASE_DRIVER_HXX
 #define SDBG_BASE_DRIVER_HXX 1
 
 #include <string>
-#include "sdbg_std.hxx"
+#include "sdbg_base_launchmon.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_event_manager.hxx"
-#include "sdbg_base_launchmon.hxx"
+#include "sdbg_std.hxx"
 
 //! FILE: sdbg_base_driver.hxx
 /*!
@@ -52,18 +52,14 @@
 
 //! enumerator driver_error_e
 /*!
-    Defines a set of driver's return codes.   
+    Defines a set of driver's return codes.
 */
-enum driver_error_e {
-  SDBG_DRIVER_OK,
-  SDBG_DRIVER_FAILED
-};
-
+enum driver_error_e { SDBG_DRIVER_OK, SDBG_DRIVER_FAILED };
 
 //! class driver_base_t
 /*!
     This class uses its containing event_manager_t object
-    and launchmon_base_t object to drive the entire 
+    and launchmon_base_t object to drive the entire
     launchmon procedure.
 
     This is a pure abstract class; has a couple of pure
@@ -72,11 +68,9 @@ enum driver_error_e {
     methods in a way that makes sense to its own platform.
 */
 
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-class driver_base_t 
-{
-public:
-  
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+class driver_base_t {
+ public:
   /*
    * constructors and destructors
    */
@@ -88,36 +82,33 @@ public:
    */
   event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *get_evman();
   launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *get_lmon();
-  void set_evman(event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *ev); 
+  void set_evman(event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *ev);
   void set_lmon(launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *lm);
 
-  driver_error_e drive_engine ( opts_args_t *opt );
-  driver_error_e drive ( int argc, char **argv );
-  driver_error_e drive ( opts_args_t *opt );
+  driver_error_e drive_engine(opts_args_t *opt);
+  driver_error_e drive(int argc, char **argv);
+  driver_error_e drive(opts_args_t *opt);
 
-  virtual process_base_t<SDBG_DEFAULT_TEMPLPARAM> * 
-                 create_process ( pid_t pid, 
-				  const std::string &mi,
-				  const std::string &md,
-				  const std::string &mt,
-				  const std::string &mc ) = 0;
+  virtual process_base_t<SDBG_DEFAULT_TEMPLPARAM> *create_process(
+      pid_t pid, const std::string &mi, const std::string &md,
+      const std::string &mt, const std::string &mc) = 0;
 
-  virtual process_base_t<SDBG_DEFAULT_TEMPLPARAM>* 
-                 create_process ( pid_t pid, 
-				  const std::string &mi ) = 0;
+  virtual process_base_t<SDBG_DEFAULT_TEMPLPARAM> *create_process(
+      pid_t pid, const std::string &mi) = 0;
 
-private:
-
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().driver_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().driver_module_trace.verbosity_level >=
+            level);
+  }
 
   //
-  // make the copy constructor and operator= private 
-  // so that another driver class cannot be constructed 
+  // make the copy constructor and operator= private
+  // so that another driver class cannot be constructed
   // by copyting this object.
   //
   driver_base_t(const driver_base_t &d);
-  driver_base_t & operator=(const driver_base_t &rhs);
+  driver_base_t &operator=(const driver_base_t &rhs);
 
   //
   // event manage object
@@ -131,9 +122,11 @@ private:
 
   //
   // For self tracing
-  // 
-  std::string MODULENAME;  
-
+  //
+  std::string MODULENAME;
 };
-#endif // SDBG_BASE_DRIVER_HXX
+#endif  // SDBG_BASE_DRIVER_HXX
 
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_driver_impl.hxx
+++ b/launchmon/src/sdbg_base_driver_impl.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_driver_impl.hxx,v 1.7.2.2 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *
  *
  *  Update Log:
  *        Dec 07 2012 DHA: Made the false condition of init_rm_instance fatal
@@ -34,8 +34,8 @@
  *        Jul 05 2006 DHA: Added self tracing support
  *        Jun 08 2006 DHA: Added attach-to-a-running job support
  *        Jun 08 2006 DHA: Added process_args support
- *        Jan 08 2006 DHA: Created file.          
- */ 
+ *        Jan 08 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_BASE_DRIVER_IMPL_HXX
 #define SDBG_BASE_DRIVER_IMPL_HXX 1
@@ -44,15 +44,14 @@
 #include "config.h"
 #endif
 
-#include "sdbg_opt.hxx"
+#include "sdbg_base_driver.hxx"
 #include "sdbg_base_tracer.hxx"
 #include "sdbg_event_manager.hxx"
 #include "sdbg_event_manager_impl.hxx"
+#include "sdbg_opt.hxx"
 #include "sdbg_rm_map.hxx"
-#include "sdbg_base_driver.hxx"
 #include "sdbg_signal_hlr.hxx"
 #include "sdbg_signal_hlr_impl.hxx"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -64,10 +63,9 @@
 /*!  driver_base_t<> constructors
 
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::driver_base_t
-(const driver_base_t &d) : evman(NULL), lmon(NULL)
-{
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::driver_base_t(const driver_base_t &d)
+    : evman(NULL), lmon(NULL) {
   // this copy construct doesn't copy evman and lmon
   MODULENAME = d.MODULENAME;
 }
@@ -76,18 +74,15 @@ driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::driver_base_t
 /*!  driver_base_t<> operator=
 
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM> & 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
-( const driver_base_t &rhs )
-{
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_base_t<SDBG_DEFAULT_TEMPLPARAM> &driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::
+operator=(const driver_base_t &rhs) {
   evman(NULL);
   lmon(NULL);
   MODULENAME = rhs.MODULENAME;
 
   return *this;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -99,10 +94,9 @@ driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
 /*!  driver_base_t<> constructors
 
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::driver_base_t()
-  : evman(NULL), lmon(NULL)
-{
+    : evman(NULL), lmon(NULL) {
   //
   // sets the module name for debugging support
   //
@@ -113,264 +107,220 @@ driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::driver_base_t()
 /*!  driver_base_t<> dtor
 
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::~driver_base_t()
-{
-  if (evman) 
-    {
-      //
-      // This must be the only place to delete evman 
-      //
-      delete evman;
-    }
-  
-  if (lmon) 
-    {
-      //
-      // This must be the only place to delete lmon
-      // and lmon must have virtual dtor.
-      //
-      delete lmon;
-    }
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::~driver_base_t() {
+  if (evman) {
+    //
+    // This must be the only place to delete evman
+    //
+    delete evman;
+  }
+
+  if (lmon) {
+    //
+    // This must be the only place to delete lmon
+    // and lmon must have virtual dtor.
+    //
+    delete lmon;
+  }
 }
 
 //!
 /*!  driver_base_t<> accessors
-      
-    
+
+
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM> * 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_evman()
-{ 
-  return evman; 
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+event_manager_t<SDBG_DEFAULT_TEMPLPARAM>
+    *driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_evman() {
+  return evman;
 }
 
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> * 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_lmon()
-{ 
-  return lmon;  
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>
+    *driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_lmon() {
+  return lmon;
 }
 
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-void 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_evman 
-(event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *em) 
-{ 
-  evman = em; 
-} 
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+void driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_evman(
+    event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *em) {
+  evman = em;
+}
 
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-void 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lmon 
-(launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *lm) 
-{ 
-  lmon = lm; 
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+void driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lmon(
+    launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *lm) {
+  lmon = lm;
 }
 
 //! drive_engine:
 /*! driver_base_t<> drive_engine
     Method that performs the core of event driving
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_error_e 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive_engine(opts_args_t *opt)
-{
-  try 
-    {
-      using namespace std;
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_error_e driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive_engine(
+    opts_args_t *opt) {
+  try {
+    using namespace std;
 
-      pid_t pid;
+    pid_t pid;
 
-      if ( !evman || !lmon ) 	   
-        return SDBG_DRIVER_FAILED;
-  
+    if (!evman || !lmon) return SDBG_DRIVER_FAILED;
+
+    //
+    // launchmon engine initialization
+    // this includes connecting to the FE client.
+    //
+    if (lmon->init(opt) != LAUNCHMON_OK) return SDBG_DRIVER_FAILED;
+
+    if (!opt->get_my_opt()->attach) {
       //
-      // launchmon engine initialization
-      // this includes connecting to the FE client.
       //
-      if (lmon->init( opt ) != LAUNCHMON_OK) 
-        return SDBG_DRIVER_FAILED;
+      //  launch case (I need to create a new process and get that pid)
+      //
+      //
+      if ((pid = fork()) == 0) {
+        //
+        // I'm a new RM launcher process and thus the child!
+        //
+        lmon->get_tracer()->tracer_trace_me();
 
-      if ( !opt->get_my_opt()->attach ) 
-	{
-	  //
-	  //  
-	  //  launch case (I need to create a new process and get that pid) 
-	  // 
-	  //
-	  if ( (pid = fork()) == 0 ) 
-	    { 
-              //
-              // I'm a new RM launcher process and thus the child!
-              // 
-	      lmon->get_tracer()->tracer_trace_me(); 
-
-              //
-	      // Thus, I'm executing the debugtarget which should
-              // be the name of RM launcher.
-              //
-	      execv ( opt->get_my_opt()->debugtarget.c_str(), 
-		      opt->get_my_opt()->remaining );
-              //                                           //
-              //           ** SINK **                      //
-              //                                           //
-	    }
-	}
-      else 	
-	{
-	  //
-	  // 
-	  //  attach case (all I need to know is the given target pid)
-	  // 
-	  //
-	  pid = opt->get_my_opt()->launcher_pid;   
-	}
-
-
-      {
-	self_trace_t::trace ( LEVELCHK(level2), 
-	  MODULENAME,
-	  0,
-	  "now creating a process object based on pid=%d, exe=%s",
-	  pid,
-	  opt->get_my_opt()->debugtarget.c_str() );
+        //
+        // Thus, I'm executing the debugtarget which should
+        // be the name of RM launcher.
+        //
+        execv(opt->get_my_opt()->debugtarget.c_str(),
+              opt->get_my_opt()->remaining);
+        //                                           //
+        //           ** SINK **                      //
+        //                                           //
       }
-	  
+    } else {
+      //
+      //
+      //  attach case (all I need to know is the given target pid)
+      //
+      //
+      pid = opt->get_my_opt()->launcher_pid;
+    }
 
-      //
-      // create a main process object using create_process(int, string) 
-      //
-      process_base_t<SDBG_DEFAULT_TEMPLPARAM> *launcher_proc 
-        = create_process ( pid, string ( opt->get_my_opt()->debugtarget) );
+    {
+      self_trace_t::trace(
+          LEVELCHK(level2), MODULENAME, 0,
+          "now creating a process object based on pid=%d, exe=%s", pid,
+          opt->get_my_opt()->debugtarget.c_str());
+    }
 
-      //
-      // Construct launch string
-      //
+    //
+    // create a main process object using create_process(int, string)
+    //
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> *launcher_proc =
+        create_process(pid, string(opt->get_my_opt()->debugtarget));
+
+//
+// Construct launch string
+//
 #ifdef RM_BE_STUB_CMD
-      char *pref;
-      std::string bestub(RM_BE_STUB_CMD);
-      if (pref = getenv("LMON_PREFIX"))
-        bestub = std::string(pref) + std::string("/bin/") + bestub;
-      else if (pref = getenv("LMON_COLOC_UTIL_DIR"))
-        bestub = std::string(pref) + ("/") + bestub;
+    char *pref;
+    std::string bestub(RM_BE_STUB_CMD);
+    if (pref = getenv("LMON_PREFIX"))
+      bestub = std::string(pref) + std::string("/bin/") + bestub;
+    else if (pref = getenv("LMON_COLOC_UTIL_DIR"))
+      bestub = std::string(pref) + ("/") + bestub;
 #endif
 
-      std::string bulklauncher = opt->get_my_opt()->debugtarget;
+    std::string bulklauncher = opt->get_my_opt()->debugtarget;
 
 #ifdef RM_FE_COLOC_CMD
-      char *bnbuf = strdup(bulklauncher.c_str());
-      char *dt = basename(bnbuf);
+    char *bnbuf = strdup(bulklauncher.c_str());
+    char *dt = basename(bnbuf);
 
-      char *pref2;
-      bulklauncher = RM_FE_COLOC_CMD;
-      if (pref2 = getenv("LMON_PREFIX"))
-        {
-           bulklauncher = std::string(pref2)
-                         + std::string("/bin/")
-                         + bulklauncher;
-        }
-      else if (pref2 = getenv("LMON_COLOC_UTIL_DIR"))
-        {
-           bulklauncher = std::string(pref2)
-                         + std::string("/")
-                         + bulklauncher;
-        }
+    char *pref2;
+    bulklauncher = RM_FE_COLOC_CMD;
+    if (pref2 = getenv("LMON_PREFIX")) {
+      bulklauncher = std::string(pref2) + std::string("/bin/") + bulklauncher;
+    } else if (pref2 = getenv("LMON_COLOC_UTIL_DIR")) {
+      bulklauncher = std::string(pref2) + std::string("/") + bulklauncher;
+    }
 #endif
-      rc_rm_plat_matcher<VA, EXECHANDLER> platobj; 
-      bool initc = platobj.init_rm_instance(*(opt->get_my_rmconfig()),
-                            bulklauncher,
-                            opt->get_my_opt()->tool_daemon,
-                            opt->get_my_opt()->tool_daemon_opts,
-                            launcher_proc->get_myimage(),
-                            launcher_proc->get_myrmso_image()
+    rc_rm_plat_matcher<VA, EXECHANDLER> platobj;
+    bool initc = platobj.init_rm_instance(
+        *(opt->get_my_rmconfig()), bulklauncher, opt->get_my_opt()->tool_daemon,
+        opt->get_my_opt()->tool_daemon_opts, launcher_proc->get_myimage(),
+        launcher_proc->get_myrmso_image()
 #ifdef RM_BE_STUB_CMD
-                           ,bestub
+            ,
+        bestub
 #endif
-                            );      
+        );
 
-      if (!initc)
-      {
-	self_trace_t::trace ( true, 
-	  MODULENAME,
-	  0,
-	  "Unknown resource manager type: it could be misconfiguration in a rm config file.");
-         return SDBG_DRIVER_FAILED;
-      }
-
-      //
-      // process object carries "opt" around for future reference.
-      //
-      launcher_proc->set_myopts(opt); 
-
-      //
-      // install signal handlers (This is required to beef up the 
-      // interactions between this and the parallel launcher proc
-      //
-      signal_handler_t<SDBG_DEFAULT_TEMPLPARAM> sh;
-      sh.set_tracer ( lmon->get_tracer() );
-      sh.set_launcher_proc ( launcher_proc );
-      sh.set_evman ( evman );
-      sh.set_lmon ( lmon );
-      sh.install_hdlr_for_all_sigs ( );
-
-      //
-      // Attach case needs one more launchmon handler call
-      //
-      if ( opt->get_my_opt()->attach )
-	lmon->handle_attach_event ( (*launcher_proc) );
-
-      //
-      // event manager begin monitoring events coming from launcher_proc
-      // and the channel connecting to the FE client.
-      //
-      while ( evman->multiplex_events ( *launcher_proc, *lmon) )
-	{
-
-	  //                                              //
-	  // * * * * * Main Event Handler Loop * * * * *  //
-	  //                                              //
-	  //      +                               +       // 
-	  //        -----------------------------         //
-	}
-
-      //
-      // this must be the only place to delete launcher_proc
-      // launcher_proc must have a virtual dtor
-      //
-      delete launcher_proc;
-
-      return SDBG_DRIVER_OK;
-    }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
+    if (!initc) {
+      self_trace_t::trace(true, MODULENAME, 0,
+                          "Unknown resource manager type: it could be "
+                          "misconfiguration in a rm config file.");
       return SDBG_DRIVER_FAILED;
     }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      return SDBG_DRIVER_FAILED;
-    } 
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      return SDBG_DRIVER_FAILED;
+
+    //
+    // process object carries "opt" around for future reference.
+    //
+    launcher_proc->set_myopts(opt);
+
+    //
+    // install signal handlers (This is required to beef up the
+    // interactions between this and the parallel launcher proc
+    //
+    signal_handler_t<SDBG_DEFAULT_TEMPLPARAM> sh;
+    sh.set_tracer(lmon->get_tracer());
+    sh.set_launcher_proc(launcher_proc);
+    sh.set_evman(evman);
+    sh.set_lmon(lmon);
+    sh.install_hdlr_for_all_sigs();
+
+    //
+    // Attach case needs one more launchmon handler call
+    //
+    if (opt->get_my_opt()->attach) lmon->handle_attach_event((*launcher_proc));
+
+    //
+    // event manager begin monitoring events coming from launcher_proc
+    // and the channel connecting to the FE client.
+    //
+    while (evman->multiplex_events(*launcher_proc, *lmon)) {
+      //                                              //
+      // * * * * * Main Event Handler Loop * * * * *  //
+      //                                              //
+      //      +                               +       //
+      //        -----------------------------         //
     }
+
+    //
+    // this must be the only place to delete launcher_proc
+    // launcher_proc must have a virtual dtor
+    //
+    delete launcher_proc;
+
+    return SDBG_DRIVER_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    return SDBG_DRIVER_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    return SDBG_DRIVER_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    return SDBG_DRIVER_FAILED;
+  }
 }
-
 
 //! drive:
 /*! driver_base_t<> drive
-    The entry point of this method is the standalone case    
+    The entry point of this method is the standalone case
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_error_e 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive 
-( int argc, char **argv )
-{
- 
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_error_e driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive(int argc,
+                                                             char **argv) {
   opts_args_t *opt = new opts_args_t();
   driver_error_e rc;
 
@@ -383,17 +333,17 @@ driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive
   return (rc);
 }
 
-
 //! drive:
 /*! driver_base_t<> drive
-    The entry point of this method is LMON FE APIs case     
+    The entry point of this method is LMON FE APIs case
 */
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-driver_error_e 
-driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive 
-( opts_args_t *opt )
-{
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+driver_error_e driver_base_t<SDBG_DEFAULT_TEMPLPARAM>::drive(opts_args_t *opt) {
   return (drive_engine(opt));
 }
 
-#endif // SDBG_BASE_DRIVER_IMPL_HXX
+#endif  // SDBG_BASE_DRIVER_IMPL_HXX
+
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_exception.hxx
+++ b/launchmon/src/sdbg_base_exception.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_exception.hxx,v 1.2.2.1 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *
  *
  *  Update Log:
  *        Feb 09 2008 DHA: Added LLNS Copyright
@@ -38,41 +38,37 @@
 #include <string>
 #include "sdbg_self_trace.hxx"
 
-class exception_base_t
-{
- 
-public:
- 
-  exception_base_t ()                         { }
-  explicit exception_base_t ( const char* m ) { message = m; }
-  explicit exception_base_t( const std::string& m )    
-					      { message = m; }
-  virtual ~exception_base_t ( )               { }
-  virtual void report()  {
-    self_trace_t::trace ( true, type, true,
-                          "[filename: %s, linenum: %d] %s",
-                          fn.c_str(),
-                          ln,
-                          message.c_str());
-    if ( bt.size() != 0 )
-      {
-        self_trace_t::trace ( true, type, true,  "%s", bt.c_str() );
-      }
+class exception_base_t {
+ public:
+  exception_base_t() {}
+  explicit exception_base_t(const char* m) { message = m; }
+  explicit exception_base_t(const std::string& m) { message = m; }
+  virtual ~exception_base_t() {}
+  virtual void report() {
+    self_trace_t::trace(true, type, true, "[filename: %s, linenum: %d] %s",
+                        fn.c_str(), ln, message.c_str());
+    if (bt.size() != 0) {
+      self_trace_t::trace(true, type, true, "%s", bt.c_str());
+    }
   }
- 
-  define_gset ( std::string, message )
-  define_gset ( std::string, type )
-  define_gset ( std::string, bt )
-  define_gset ( std::string, fn )
-  define_gset ( int, ln )
- 
-private:
- 
+
+  define_gset(std::string, message)
+  define_gset(std::string, type)
+  define_gset(std::string, bt)
+  define_gset(std::string, fn)
+  define_gset(int, ln)
+
+ private:
+
   std::string message;
   std::string type;
-  std::string bt; 
+  std::string bt;
   std::string fn;
   int ln;
 };
 
-#endif // SDBG_BASE_EXCEPTION_HXX
+#endif  // SDBG_BASE_EXCEPTION_HXX
+
+/*
+ * vi: ts=4 sw=4 expandtab
+ */

--- a/launchmon/src/sdbg_base_launchmon.hxx
+++ b/launchmon/src/sdbg_base_launchmon.hxx
@@ -1,43 +1,43 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_launchmon.hxx,v 1.11.2.2 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2012, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
- *        Oct 26 2012 DHA: Removed references to ttracer that has been 
+ *        Oct 26 2012 DHA: Removed references to ttracer that has been
  *                         deprecated.
  *        May 11 2010 DHA: Removed gettimeofdayD from this file
  *        Sep 24 2008 DHA: Added handle_daemon_exit_event to support
- *                         better error handling 
- *        Sep 22 2008 DHA: Added the last_seen and warm_period members 
- *                         to support a two-phase polling scheme in which 
- *                         the polling of the FE incoming socket will block 
- *                         for 1 milisecond, if no launchmon handler 
+ *                         better error handling
+ *        Sep 22 2008 DHA: Added the last_seen and warm_period members
+ *                         to support a two-phase polling scheme in which
+ *                         the polling of the FE incoming socket will block
+ *                         for 1 milisecond, if no launchmon handler
  *                         event has occurred in the last warm_period
- *                         seconds after last_seen. The default warm_period 
+ *                         seconds after last_seen. The default warm_period
  *                         is 10 seconds.
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Mar 13 2007 DHA: Removed writing_pfd, reading pfd member
@@ -45,11 +45,11 @@
  *                         All access except for pipe setting must
  *                         call getConstPfd for safer access.
  *        Jul 03 2006 DHA: Added self tracing support
- *        Jun 06 2006 DHA: Added comments on the file scope 
- *                         and the class (launchmon_base_t) 
+ *        Jun 06 2006 DHA: Added comments on the file scope
+ *                         and the class (launchmon_base_t)
  *                         itself.
  *        Jan 12 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_BASE_LAUNCHMON_HXX
 #define SDBG_BASE_LAUNCHMON_HXX 1
@@ -63,24 +63,24 @@ extern "C" {
 
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_tracer.hxx"
-#include "sdbg_self_trace.hxx"
 #include "sdbg_opt.hxx"
+#include "sdbg_self_trace.hxx"
 
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_lmonp_msg.h>
+#include <lmon_api/lmon_proctab.h>
 #include "lmon_api/lmon_say_msg.hxx"
 
 //! FILE: sdbg_base_launchmon.hxx
 /*!
     The file contains the base launchmon class.
-    The base launchmon class defines a set of interfaces 
-    (virtual methods) to be implemented by the 
-    platform-specific layer. Each interface dictates 
+    The base launchmon class defines a set of interfaces
+    (virtual methods) to be implemented by the
+    platform-specific layer. Each interface dictates
     the set of actions when and an important debugging
     event occurs.
 */
 
-//! enumerator launchmon_rc_e 
+//! enumerator launchmon_rc_e
 /*!
     Defines a set of launchmon engine handler's return codes.
 */
@@ -123,11 +123,16 @@ enum launchmon_event_e {
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 class launchmon_base_t {
+ public:
+  enum engine_state_e {
+    mpir_start,
+    mpir_null,
+    mpir_spawned,
+    mpir_abort,
+    mpir_unknown
+  };
 
-public:
-  enum engine_state_e {mpir_start, mpir_null, mpir_spawned, mpir_abort, mpir_unknown};
-
-  launchmon_base_t ();
+  launchmon_base_t();
 
   virtual ~launchmon_base_t();
 
@@ -140,188 +145,180 @@ public:
   // Accessors
   //
   //
-  void set_tracer ( tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *t );
-  void set_engine_state (int); 
-  tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> * get_tracer ();    
-  define_gset (int, resid)
-  define_gset (int, pcount)
-  define_gset (int, toollauncherpid)
-  define_gset (int, FE_sockfd)
-  define_gset (bool, API_mode)
-  define_gset (double, last_seen)
-  define_gset (double, warm_period)
-  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > & 
-    get_proctable_copy() { return proctable_copy; }
+  void set_tracer(tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *t);
+  void set_engine_state(int);
+  tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *get_tracer();
+  define_gset(int, resid)
+  define_gset(int, pcount)
+  define_gset(int, toollauncherpid)
+  define_gset(int, FE_sockfd)
+  define_gset(bool, API_mode)
+  define_gset(double, last_seen)
+  define_gset(double, warm_period)
+  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >
+      &get_proctable_copy() {
+    return proctable_copy;
+  }
 
   //
   // Method that invokes a corresponding handler based on e
   //
   //
-  virtual launchmon_rc_e invoke_handler ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-		const launchmon_event_e e,
-		const int data );
+  virtual launchmon_rc_e invoke_handler(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, const launchmon_event_e e,
+      const int data);
 
   //
   // Method that send an event msg to the Front-end runtime
   //
   //
-  launchmon_rc_e say_fetofe_msg ( lmonp_fe_to_fe_msg_e msg_type );
+  launchmon_rc_e say_fetofe_msg(lmonp_fe_to_fe_msg_e msg_type);
 
   //
   // init must be implemented by a derived class, filling all platform
-  // specific initialization procedures. 
+  // specific initialization procedures.
   //
-  virtual launchmon_rc_e init ( opts_args_t *opt )           =0;
+  virtual launchmon_rc_e init(opts_args_t *opt) = 0;
 
   //
   // Method that translates a low-level event e to launchmon_event_e
   //
   //
-  virtual launchmon_event_e decipher_an_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-		const debug_event_t &e )                     =0;
- 
+  virtual launchmon_event_e decipher_an_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, const debug_event_t &e) = 0;
+
   //
-  // defines a set of actions for attaching to a running job 
-  virtual launchmon_rc_e handle_attach_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  // defines a set of actions for attaching to a running job
+  virtual launchmon_rc_e handle_attach_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
   //
-  // defines a set of actions when the launch breakpoint 
+  // defines a set of actions when the launch breakpoint
   // (e.g. MPIR_Breakpoint) is hit
-  virtual launchmon_rc_e handle_launch_bp_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_launch_bp_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
   // defines a set of actions when the detach command is
   // issued
-  virtual launchmon_rc_e handle_detach_cmd_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_detach_cmd_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
   // defines a set of actions when the detach command is
   // issued
-  virtual launchmon_rc_e handle_kill_cmd_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_kill_cmd_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when the target process gets 
+  // defines a set of actions when the target process gets
   // initially fork'ed/exec'ed
-  virtual launchmon_rc_e handle_trap_after_exec_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_trap_after_exec_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when the target process gets 
+  // defines a set of actions when the target process gets
   // initially attached
-  virtual launchmon_rc_e handle_trap_after_attach_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_trap_after_attach_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when the target process 
+  // defines a set of actions when the target process
   // loads/unloads a shared library
-  virtual launchmon_rc_e handle_loader_bp_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_loader_bp_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when the target process exits 
-  virtual launchmon_rc_e handle_exit_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  // defines a set of actions when the target process exits
+  virtual launchmon_rc_e handle_exit_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when the target process gets 
+  // defines a set of actions when the target process gets
   // somehow terminated
-  virtual launchmon_rc_e handle_term_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_term_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
-  virtual
-  launchmon_rc_e handle_thrcreate_request
-                 ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int newlwpid ) =0;
-
+  virtual launchmon_rc_e handle_thrcreate_request(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int newlwpid) = 0;
 
   //
   // defines a set of actions when a new thread creation event
-  // is notified. 
-  virtual
-  launchmon_rc_e handle_thrcreate_trap_event
-                 ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) = 0;
-
-  //
-  // defines a set of actions when a new thread stop is reported 
   // is notified.
-  virtual launchmon_rc_e handle_newthread_trace_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_thrcreate_trap_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
-  // defines a set of actions when a new process is forked 
+  // defines a set of actions when a new thread stop is reported
+  // is notified.
+  virtual launchmon_rc_e handle_newthread_trace_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
+
+  //
+  // defines a set of actions when a new process is forked
   // and stopped.
-  virtual launchmon_rc_e handle_newproc_forked_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_newproc_forked_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
   // all unwonted stop events.
   //
-  virtual launchmon_rc_e handle_not_interested_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p ) =0;
+  virtual launchmon_rc_e handle_not_interested_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) = 0;
 
   //
   // all relay-signal events.
   //
-  virtual launchmon_rc_e handle_relay_signal_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-                int sig )                                    =0;
+  virtual launchmon_rc_e handle_relay_signal_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig) = 0;
 
   //
   // ships the RPDTAB to the FE API client
   //
-  launchmon_rc_e ship_proctab_msg ( lmonp_fe_to_fe_msg_e );
+  launchmon_rc_e ship_proctab_msg(lmonp_fe_to_fe_msg_e);
 
   //
   // ships the resource handle to the FE API client
   //
-  launchmon_rc_e ship_resourcehandle_msg ( 
-                lmonp_fe_to_fe_msg_e, int );
-  
+  launchmon_rc_e ship_resourcehandle_msg(lmonp_fe_to_fe_msg_e, int);
+
   //
   // ships the rminfo to the FE API client
   //
-  launchmon_rc_e ship_rminfo_msg ( 
-                lmonp_fe_to_fe_msg_e, int, rm_catalogue_e);
+  launchmon_rc_e ship_rminfo_msg(lmonp_fe_to_fe_msg_e, int, rm_catalogue_e);
 
   //
   // handle a message received from the FE API client
   //
-  launchmon_rc_e handle_incoming_socket_event (
-		process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p );
+  launchmon_rc_e handle_incoming_socket_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p);
 
   //
   // defines a set of actions when the back-end daemons exited
   //
-  launchmon_rc_e handle_daemon_exit_event ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p );
+  launchmon_rc_e handle_daemon_exit_event(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p);
 
-  
-  bool validate_mpir_state_transition(int s); 
-
+  bool validate_mpir_state_transition(int s);
 
   //
   // Utility method that handles a detach/kill request command
   //
-  bool request_detach(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-                pcont_req_reason reason);
-  bool request_kill(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-                pcont_req_reason reason);
-  bool request_cont_launch_bp(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p); 
+  bool request_detach(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                      pcont_req_reason reason);
+  bool request_kill(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                    pcont_req_reason reason);
+  bool request_cont_launch_bp(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p);
 
-private:
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().launchmon_module_trace.verbosity_level >=
+            level);
+  }
 
-  bool LEVELCHK(self_trace_verbosity level) { 
-                return (self_trace_t::self_trace().launchmon_module_trace.verbosity_level >= level); 
-                }
+  launchmon_base_t(const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &l);
 
-  launchmon_base_t (const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &l);
-
-  launchmon_base_t & operator=(
-                const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &rhs);
+  launchmon_base_t &operator=(
+      const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &rhs);
 
   //
   // process tracer
@@ -338,7 +335,7 @@ private:
   //
   int resid;
   int pcount;
-  int toollauncherpid; 
+  int toollauncherpid;
 
   //
   // The member containing all proctable entries
@@ -346,11 +343,11 @@ private:
   //
   // This table is filled by the platform dependent layer
   //
-  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > proctable_copy;  
+  std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> > proctable_copy;
 
   //
   // Unix PIPE with LAUNCHMON FE API STUB
-  // deprecating PIPE support in favor of socket support 
+  // deprecating PIPE support in favor of socket support
   // in anticipation for remote FE API
   //
   int FE_sockfd;
@@ -365,8 +362,11 @@ private:
   //
   // To support self tracing
   //
-  std::string MODULENAME; 
+  std::string MODULENAME;
 };
 
-#endif // __SDBG_BASE_LAUNCHMON_HXX
+#endif  // __SDBG_BASE_LAUNCHMON_HXX
 
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_launchmon_impl.hxx
+++ b/launchmon/src/sdbg_base_launchmon_impl.hxx
@@ -1,50 +1,51 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_launchmon_impl.hxx,v 1.15.2.2 2008/02/20 17:37:56 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008~2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Oct 26 2012 DHA: Removed methods on ttracer that has been
  *                         deprecated.
  *        Sep 12 2011 DHA: Added a be_fail_detection_supported check
- *                         within handle_daemon_exit for the orphaned 
+ *                         within handle_daemon_exit for the orphaned
  *                         alps_fe_colocat problem (ID: 3408210).
- *        Jun 28 2010 DHA: Added ship_rminfo_msg 
+ *        Jun 28 2010 DHA: Added ship_rminfo_msg
  *        Aug 07 2009 DHA: Added p.set_lwp_state tracking to decipher_an_event
  *                         method.
- *        Feb 09 2008 DHA: Added LLNS Copyright 
+ *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jul 24 2007 DHA: moved and embellished ship_proctab_msg
  *                         and ship_resourcehandle_msg here
  *                         They really belong to the base class.
  *                         As a matter of fact, all methods communicating
- *                         via FE API lmonp message should belong to 
+ *                         via FE API lmonp message should belong to
  *                         the base class
  *        Mar 13 2007 DHA: pipe_t support
  *        Jul 03 2006 DHA: Added self tracing support
  *        Jan 12 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_BASE_LAUNCHMON_IMPL_HXX
 #define SDBG_BASE_LAUNCHMON_IMPL_HXX 1
@@ -67,52 +68,48 @@
 ////////////////////////////////////////////////////////////////////
 //!
 /*!  launchmon_base_t<> constructor
-      
-    
+
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::launchmon_base_t (
-                const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &l) 
-{
-  tracer          = l.tracer;
-  resid           = l.resid;
-  pcount          = l.pcount;
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::launchmon_base_t(
+    const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &l) {
+  tracer = l.tracer;
+  resid = l.resid;
+  pcount = l.pcount;
   toollauncherpid = l.toollauncherpid;
-  FE_sockfd       = l.FE_sockfd;
-  API_mode        = l.API_mode;
-  last_seen       = l.last_seen;
-  warm_period     = l.warm_period;
+  FE_sockfd = l.FE_sockfd;
+  API_mode = l.API_mode;
+  last_seen = l.last_seen;
+  warm_period = l.warm_period;
   //
   // This should never be called
   //
 }
 
-
 //!
-/*!  launchmon_base_t<> operator= 
-      
-    
+/*!  launchmon_base_t<> operator=
+
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=(
-                const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &rhs ) 
-{
-  tracer          = rhs.tracer;
-  resid           = rhs.resid;
-  pcount          = rhs.pcount;
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>
+    &launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=(
+        const launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &rhs) {
+  tracer = rhs.tracer;
+  resid = rhs.resid;
+  pcount = rhs.pcount;
   toollauncherpid = rhs.toollauncherpid;
-  FE_sockfd       = rhs.FE_sockfd;
-  API_mode        = rhs.API_mode;
-  last_seen       = rhs.last_seen;
-  warm_period     = rhs.iwarm_period;
+  FE_sockfd = rhs.FE_sockfd;
+  API_mode = rhs.API_mode;
+  last_seen = rhs.last_seen;
+  warm_period = rhs.iwarm_period;
   //
   // This should actually never be called
   //
 
   return *this;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -121,197 +118,164 @@ launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=(
 ////////////////////////////////////////////////////////////////////
 //!
 /*!  launchmon_base_t<> constructor
-      
-    
+
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::launchmon_base_t () 
-  : engine_state(mpir_start),
-    resid(-1), 
-    pcount(-1),
-    toollauncherpid(-1),
-    FE_sockfd(-1),
-    API_mode(false),
-    MODULENAME(self_trace_t::self_trace().launchmon_module_trace.module_name)
-{
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::launchmon_base_t()
+    : engine_state(mpir_start),
+      resid(-1),
+      pcount(-1),
+      toollauncherpid(-1),
+      FE_sockfd(-1),
+      API_mode(false),
+      MODULENAME(
+          self_trace_t::self_trace().launchmon_module_trace.module_name) {
   char *warm_interval;
-  last_seen = gettimeofdayD ();
+  last_seen = gettimeofdayD();
   warm_period = DefaultWarmPeriods;
-  warm_interval = getenv ("LMON_ENGINE_WARM_INTERVAL"); 
-  if ( warm_interval ) 
-    warm_period = (double) atoi (warm_interval);
+  warm_interval = getenv("LMON_ENGINE_WARM_INTERVAL");
+  if (warm_interval) warm_period = (double)atoi(warm_interval);
 }
-
 
 //!
-/*!  launchmon_base_t<> destructor 
-      
-    
+/*!  launchmon_base_t<> destructor
+
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::~launchmon_base_t ()
-{
-  if (tracer)
-    delete tracer; 
-  
-  if (!proctable_copy.empty())
-    {
-      std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::iterator iter;
-      for(iter = proctable_copy.begin(); iter != proctable_copy.end(); ++iter)
-        {
-          if (!(iter->second.empty())) 
-            {
-              std::vector<MPIR_PROCDESC_EXT *>::iterator viter;
-              for (viter = iter->second.begin(); viter != iter->second.end(); ++viter)
-                {
-                  if ((*viter)->pd.host_name)
-                    {
-                      free((*viter)->pd.host_name);
-                    }
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::~launchmon_base_t() {
+  if (tracer) delete tracer;
 
-                  if ((*viter)->pd.executable_name)
-                    {
-                      free((*viter)->pd.executable_name);
-                    }
-                  free(*viter);
-                }
-            }
+  if (!proctable_copy.empty()) {
+    std::map<std::string, std::vector<MPIR_PROCDESC_EXT *> >::iterator iter;
+    for (iter = proctable_copy.begin(); iter != proctable_copy.end(); ++iter) {
+      if (!(iter->second.empty())) {
+        std::vector<MPIR_PROCDESC_EXT *>::iterator viter;
+        for (viter = iter->second.begin(); viter != iter->second.end();
+             ++viter) {
+          if ((*viter)->pd.host_name) {
+            free((*viter)->pd.host_name);
+          }
+
+          if ((*viter)->pd.executable_name) {
+            free((*viter)->pd.executable_name);
+          }
+          free(*viter);
         }
-      proctable_copy.clear();
+      }
     }
+    proctable_copy.clear();
+  }
 }
-
 
 //!
 /*!  launchmon_base_t<> request_detach
-     stops all threads and mark the detach flag to the process 
-    
+     stops all threads and mark the detach flag to the process
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_detach
-(process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, pcont_req_reason reason)
-{
-  if (p.get_please_detach() || p.get_please_kill())
-    {
-      //
-      // If either request has already been registered, we
-      // must not put additional request. Redundant requests
-      // would confuse actual detach/kill command handler.
-      //
-      return false;
-    }
- 
-  for ( p.thr_iter = p.get_thrlist().begin();
-        p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-    {
-      p.make_context ( p.thr_iter->first );
-      if (get_tracer()->status(p, true) == SDBG_TRACE_RUNNING)
-        {
-          get_tracer()->tracer_stop(p, true);
-          usleep (GracePeriodBNSignals);
-        }
-      p.check_and_undo_context ( p.thr_iter->first );
-    }
+bool launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_detach(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, pcont_req_reason reason) {
+  if (p.get_please_detach() || p.get_please_kill()) {
+    //
+    // If either request has already been registered, we
+    // must not put additional request. Redundant requests
+    // would confuse actual detach/kill command handler.
+    //
+    return false;
+  }
 
-  p.set_please_detach ( true );
-  p.set_reason (reason);
+  for (p.thr_iter = p.get_thrlist().begin();
+       p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+    p.make_context(p.thr_iter->first);
+    if (get_tracer()->status(p, true) == SDBG_TRACE_RUNNING) {
+      get_tracer()->tracer_stop(p, true);
+      usleep(GracePeriodBNSignals);
+    }
+    p.check_and_undo_context(p.thr_iter->first);
+  }
+
+  p.set_please_detach(true);
+  p.set_reason(reason);
 
   return true;
 }
-
 
 //!
 /*!  launchmon_base_t<> request_kill
-     stops all threads and mark the kill flag to the process 
-    
+     stops all threads and mark the kill flag to the process
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_kill
-(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, pcont_req_reason reason)
-{
-  if (p.get_please_detach() || p.get_please_kill())
-    {
-      //
-      // If either request has already been registered, we
-      // must not put additional request. Redundant requests
-      // would confuse actual detach/kill command handler.
-      //
-      return false;
-    }
+bool launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_kill(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, pcont_req_reason reason) {
+  if (p.get_please_detach() || p.get_please_kill()) {
+    //
+    // If either request has already been registered, we
+    // must not put additional request. Redundant requests
+    // would confuse actual detach/kill command handler.
+    //
+    return false;
+  }
 
-  for ( p.thr_iter = p.get_thrlist().begin();
-        p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-    {
-      p.make_context ( p.thr_iter->first );
-      if (get_tracer()->status(p, true) == SDBG_TRACE_RUNNING)
-        {
-          get_tracer()->tracer_stop(p, true);
-          usleep (GracePeriodBNSignals);
-        }
-      p.check_and_undo_context ( p.thr_iter->first );
+  for (p.thr_iter = p.get_thrlist().begin();
+       p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+    p.make_context(p.thr_iter->first);
+    if (get_tracer()->status(p, true) == SDBG_TRACE_RUNNING) {
+      get_tracer()->tracer_stop(p, true);
+      usleep(GracePeriodBNSignals);
     }
+    p.check_and_undo_context(p.thr_iter->first);
+  }
 
-  p.set_please_kill ( true );
-  p.set_reason (reason);
+  p.set_please_kill(true);
+  p.set_reason(reason);
 
   return true;
 }
-
 
 //!
 /*!  launchmon_base_t<> request_kill
-     stops all threads and mark the kill flag to the process 
-    
+     stops all threads and mark the kill flag to the process
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_cont_launch_bp
-(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p)
-{
-  for ( p.thr_iter = p.get_thrlist().begin();
-        p.thr_iter != p.get_thrlist().end(); p.thr_iter++ )
-    {
-      if (p.thr_iter->second->get_event_registered())
-        {
-          p.make_context ( p.thr_iter->first );
-          get_tracer()->tracer_continue(p, true);
-          p.thr_iter->second->set_event_registered(false); 
-          p.check_and_undo_context ( p.thr_iter->first );
-        }
+bool launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::request_cont_launch_bp(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) {
+  for (p.thr_iter = p.get_thrlist().begin();
+       p.thr_iter != p.get_thrlist().end(); p.thr_iter++) {
+    if (p.thr_iter->second->get_event_registered()) {
+      p.make_context(p.thr_iter->first);
+      get_tracer()->tracer_continue(p, true);
+      p.thr_iter->second->set_event_registered(false);
+      p.check_and_undo_context(p.thr_iter->first);
     }
+  }
 
   return true;
 }
-
 
 //!
 /*!  launchmon_base_t<> accessors
 
- 
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_tracer ( 
-                tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *t ) 
-{
-  tracer = t;  
+void launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_tracer(
+    tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *t) {
+  tracer = t;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> * 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_tracer ()
-{
+tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>
+    *launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_tracer() {
   return tracer;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_engine_state (int s)
-{
-  switch (s)
-    {
+void launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_engine_state(int s) {
+  switch (s) {
     case MPIR_DEBUG_SPAWNED:
       engine_state = mpir_spawned;
       break;
@@ -324,137 +288,131 @@ launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_engine_state (int s)
     default:
       engine_state = mpir_unknown;
       break;
-    }
+  }
 
   return;
 }
-
 
 //! invoke_handler:
 /*! launchmon_base_t<> invoke_handler
     dispatches a corresponding event handler.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::invoke_handler ( 
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, 
-	        const launchmon_event_e ev, 
-	        const int data)
-{
+launchmon_rc_e launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::invoke_handler(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, const launchmon_event_e ev,
+    const int data) {
   launchmon_rc_e rc = LAUNCHMON_FAILED;
 
-  switch ( ev ) {
+  switch (ev) {
+    //
+    // handles a first-exec-trap event.
+    //
+    case LM_STOP_AT_FIRST_EXEC:
+      rc = handle_trap_after_exec_event(p);
+      break;
 
-  //
-  // handles a first-exec-trap event.
-  // 
-  case LM_STOP_AT_FIRST_EXEC:
-    rc = handle_trap_after_exec_event (p);
-    break;
+    //
+    // handles an attach-trap event.
+    //
+    case LM_STOP_AT_FIRST_ATTACH:
+      rc = handle_trap_after_attach_event(p);
+      break;
 
-  //
-  // handles an attach-trap event.
-  //
-  case LM_STOP_AT_FIRST_ATTACH:
-    rc = handle_trap_after_attach_event (p);
-    break;
+    //
+    // handles a please_detach command.
+    //
+    case LM_STOP_FOR_DETACH:
+      rc = handle_detach_cmd_event(p);
+      break;
 
-  //
-  // handles a please_detach command.
-  //
-  case LM_STOP_FOR_DETACH:
-    rc = handle_detach_cmd_event (p);
-    break;
+    //
+    // handles a please_kill command.
+    //
+    case LM_STOP_FOR_KILL:
+      rc = handle_kill_cmd_event(p);
+      break;
 
-  //
-  // handles a please_kill command.
-  //
-  case LM_STOP_FOR_KILL:
-    rc = handle_kill_cmd_event (p);
-    break;
+    //
+    // handles a launch-breakpoint event.
+    //
+    case LM_STOP_AT_LAUNCH_BP:
+      rc = handle_launch_bp_event(p);
+      break;
 
-  //
-  // handles a launch-breakpoint event.
-  //
-  case LM_STOP_AT_LAUNCH_BP:
-    rc = handle_launch_bp_event (p);
-    break;
+    //
+    // handles a loader-breakpoint event.
+    //
+    case LM_STOP_AT_LOADER_BP:
+      rc = handle_loader_bp_event(p);
+      break;
 
-  //
-  // handles a loader-breakpoint event.
-  //
-  case LM_STOP_AT_LOADER_BP:
-    rc = handle_loader_bp_event (p);
-    break;
+    //
+    // handle a request to create a new thread data structure
+    //
+    case LM_REQUEST_NEW_THREAD:
+      rc = handle_thrcreate_request(p, data);
+      break;
 
-  //
-  // handle a request to create a new thread data structure
-  //
-  case LM_REQUEST_NEW_THREAD:
-    rc = handle_thrcreate_request (p, data);
-    break;
+    //
+    // handles a thread-creation event.
+    //
+    case LM_STOP_AT_THREAD_CREATION:
+      rc = handle_thrcreate_trap_event(p);
+      break;
 
-  //
-  // handles a thread-creation event.
-  //
-  case LM_STOP_AT_THREAD_CREATION:
-    rc = handle_thrcreate_trap_event (p);
-    break;
+    //
+    // handles a new thread pickup event.
+    //
+    case LM_STOP_NEW_THREAD_TRACE:
+      rc = handle_newthread_trace_event(p);
+      break;
 
-  //
-  // handles a new thread pickup event.
-  //
-  case LM_STOP_NEW_THREAD_TRACE:
-    rc = handle_newthread_trace_event (p);
-    break;
+    //
+    // handles a fork event.
+    //
+    case LM_STOP_NEW_FORKED_PROCESS:
+      rc = handle_newproc_forked_event(p);
+      break;
 
-  //
-  // handles a fork event.
-  //
-  case LM_STOP_NEW_FORKED_PROCESS:
-    rc = handle_newproc_forked_event(p);
-    break;
+    //
+    // handles a signal-relay event.
+    //
+    case LM_RELAY_SIGNAL:
+      rc = handle_relay_signal_event(p, data);
+      break;
 
-  //
-  // handles a signal-relay event.
-  //
-  case LM_RELAY_SIGNAL:
-    rc = handle_relay_signal_event (p, data);
-    break;
+    //
+    // handles an unknown stop event.
+    //
+    case LM_STOP_NOT_INTERESTED:
+      rc = handle_not_interested_event(p);
+      break;
 
-  //
-  // handles an unknown stop event.
-  //
-  case LM_STOP_NOT_INTERESTED:
-    rc = handle_not_interested_event (p);
-    break;
+    //
+    // handles a termination event,
+    // including a thread termination.
+    //
+    case LM_TERMINATED:
+      rc = handle_term_event(p);
+      break;
 
-  //
-  // handles a termination event, 
-  // including a thread termination.
-  //
-  case LM_TERMINATED:
-    rc = handle_term_event (p);
-    break;
+    //
+    // handles an exit event.
+    //
+    case LM_EXITED:
+      rc = handle_exit_event(p);
+      break;
 
-  //
-  // handles an exit event.
-  //
-  case LM_EXITED:
-    rc = handle_exit_event (p);
-    break;
-
-  //
-  // Oh well...
-  //
-  default:
-    rc = LAUNCHMON_FAILED;
-    break;
+    //
+    // Oh well...
+    //
+    default:
+      rc = LAUNCHMON_FAILED;
+      break;
   }
 
   return rc;
 }
-
 
 //! say_fetofe_msg:
 /*! launchmon_base_t<>::say_fetofe_msg
@@ -462,57 +420,45 @@ launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::invoke_handler (
     dispatches a corresponding event handler.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::say_fetofe_msg (
-                lmonp_fe_to_fe_msg_e msg_type )
-{
+launchmon_rc_e launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::say_fetofe_msg(
+    lmonp_fe_to_fe_msg_e msg_type) {
   lmonp_t msgheader;
-  
-  if ( !get_API_mode() ) 
+
+  if (!get_API_mode()) return LAUNCHMON_FAILED;
+
+  set_msg_header(&msgheader, lmonp_fetofe, (int)msg_type, 0, 0, 0, 0, 0, 0, 0);
+
+  if ((write_lmonp_long_msg(get_FE_sockfd(), &msgheader, sizeof(msgheader))) <
+      0) {
     return LAUNCHMON_FAILED;
+  }
 
-  set_msg_header ( &msgheader,
-  	           lmonp_fetofe,
-	           (int) msg_type,
-	           0,0,0,0,0,0,0 );
-  
-  if ( (write_lmonp_long_msg ( get_FE_sockfd(), 
-                               &msgheader, 
-                               sizeof ( msgheader ) )) < 0 )
-    {
-      return LAUNCHMON_FAILED; 
-    }
-
-  return LAUNCHMON_OK; 
+  return LAUNCHMON_OK;
 }
 
-
-//! launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_proctab_msg 
+//! launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_proctab_msg
 /*!
-    sends an lmonp_t packet with {msgclass=lmonp_fetofe: 
+    sends an lmonp_t packet with {msgclass=lmonp_fetofe:
     type.fetofe_type=lmonp_febe_proctab:
     lmon_payload_length=size of the proctable}
-    to the FE API stub.  
+    to the FE API stub.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_proctab_msg ( 
-                lmonp_fe_to_fe_msg_e t )
-{
+launchmon_rc_e launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_proctab_msg(
+    lmonp_fe_to_fe_msg_e t) {
   using namespace std;
 
   //
   // If the engine is not driven via the FE API, this method
   // returns LAUNCHMON_FAILED
   //
-  if ( !get_API_mode() )
-    {    
-      self_trace_t::trace ( LEVELCHK(level3), 
-	     MODULENAME, 0, 
-	     "standalone mode does not ship proctab via LMONP messages");  
-      return LAUNCHMON_FAILED;
-    }
-  
+  if (!get_API_mode()) {
+    self_trace_t::trace(
+        LEVELCHK(level3), MODULENAME, 0,
+        "standalone mode does not ship proctab via LMONP messages");
+    return LAUNCHMON_FAILED;
+  }
+
   map<string, unsigned int> execHostName;
   vector<char *> orderedEHName;
   map<string, vector<MPIR_PROCDESC_EXT *> >::const_iterator pos;
@@ -526,560 +472,464 @@ launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_proctab_msg (
   //
   // Establishing a map and an ordered vector to pack a string table
   //
-  for ( pos = proctable_copy.begin(); pos != proctable_copy.end(); ++pos )
-    {
-      for( vpos = pos->second.begin(); vpos != pos->second.end(); ++vpos )
-        {
-          map<string, unsigned int>::const_iterator finditer;
-          finditer = execHostName.find ( string((*vpos)->pd.executable_name) );
-	  if ( finditer == execHostName.end () )
-	    {
-	      execHostName[string((*vpos)->pd.executable_name)] = offset;
-	      orderedEHName.push_back( (*vpos)->pd.executable_name );
-	      num_unique_exec++;
-	      offset += ( strlen ( (*vpos)->pd.executable_name ) + 1 );
-	    }
+  for (pos = proctable_copy.begin(); pos != proctable_copy.end(); ++pos) {
+    for (vpos = pos->second.begin(); vpos != pos->second.end(); ++vpos) {
+      map<string, unsigned int>::const_iterator finditer;
+      finditer = execHostName.find(string((*vpos)->pd.executable_name));
+      if (finditer == execHostName.end()) {
+        execHostName[string((*vpos)->pd.executable_name)] = offset;
+        orderedEHName.push_back((*vpos)->pd.executable_name);
+        num_unique_exec++;
+        offset += (strlen((*vpos)->pd.executable_name) + 1);
+      }
 
-          finditer = execHostName.find (string((*vpos)->pd.host_name));
-	  if ( finditer == execHostName.end())
-	    {
-	      execHostName[string((*vpos)->pd.host_name)] = offset;
-	      orderedEHName.push_back ((*vpos)->pd.host_name);
-	      num_unique_hn++;
-	      offset += ( strlen ( (*vpos)->pd.host_name ) + 1 );
-	    }
-	}
+      finditer = execHostName.find(string((*vpos)->pd.host_name));
+      if (finditer == execHostName.end()) {
+        execHostName[string((*vpos)->pd.host_name)] = offset;
+        orderedEHName.push_back((*vpos)->pd.host_name);
+        num_unique_hn++;
+        offset += (strlen((*vpos)->pd.host_name) + 1);
+      }
     }
-
+  }
 
   //
   // This message can be rather long as the size is
-  // an lmonp header size + (N_Fields_MPIR_PROCDESC_EXT x sizeof(int) 
+  // an lmonp header size + (N_Fields_MPIR_PROCDESC_EXT x sizeof(int)
   // per-task entry for each task + the string table size.
-  // The fixed per-task entry consists of exec index, 
+  // The fixed per-task entry consists of exec index,
   // hostname index, pid, and rank, and cnodeid, each of which
   // is sizeof(int).
   //
-  msgsize = sizeof(lmonp_t) 
-            + N_Fields_MPIR_PROCDESC_EXT*sizeof(int)*pcount + offset;
-  lmonp_t *sendbuf = (lmonp_t *) malloc ( msgsize );
-  memset ( sendbuf, 0, msgsize );
-  if ( pcount < LMON_NTASKS_THRE) 
-    {
-      set_msg_header ((lmonp_t*) sendbuf, 
-		  lmonp_fetofe, 
-		  (int)t, 
-		  pcount, 
-		  0,
-		  num_unique_exec,
-		  num_unique_hn,
-		  0,
-		  (N_Fields_MPIR_PROCDESC_EXT*sizeof(int)*pcount)+offset,
-		  0);
-    }
-  else
-    {
-      set_msg_header ((lmonp_t*) sendbuf, 
-		  lmonp_fetofe, 
-		  (int)t, 
-		  LMON_NTASKS_THRE, 
-		  0,
-		  num_unique_exec,
-		  num_unique_hn,
-		  pcount,
-		  (N_Fields_MPIR_PROCDESC_EXT*sizeof(int)*pcount)+offset,
-		  0);
-    }
+  msgsize = sizeof(lmonp_t) +
+            N_Fields_MPIR_PROCDESC_EXT * sizeof(int) * pcount + offset;
+  lmonp_t *sendbuf = (lmonp_t *)malloc(msgsize);
+  memset(sendbuf, 0, msgsize);
+  if (pcount < LMON_NTASKS_THRE) {
+    set_msg_header((lmonp_t *)sendbuf, lmonp_fetofe, (int)t, pcount, 0,
+                   num_unique_exec, num_unique_hn, 0,
+                   (N_Fields_MPIR_PROCDESC_EXT * sizeof(int) * pcount) + offset,
+                   0);
+  } else {
+    set_msg_header((lmonp_t *)sendbuf, lmonp_fetofe, (int)t, LMON_NTASKS_THRE,
+                   0, num_unique_exec, num_unique_hn, pcount,
+                   (N_Fields_MPIR_PROCDESC_EXT * sizeof(int) * pcount) + offset,
+                   0);
+  }
 
-  char *payload_cp_ptr = get_lmonpayload_begin (sendbuf);
-
+  char *payload_cp_ptr = get_lmonpayload_begin(sendbuf);
 
   //
   // Serializing the process table into a send buffer.
   // Number of memcpy must be equal to N_Fields_MPIR_PROCDESC_EXT
   //
-  for ( pos = proctable_copy.begin(); 
-            pos != proctable_copy.end(); ++pos )
-    {
-      for(vpos = pos->second.begin(); 
-               vpos != pos->second.end(); ++vpos )
-        {
-	  memcpy ( (void *) payload_cp_ptr,
-                   (void *) &(execHostName[string((*vpos)->pd.host_name)]),
-		   sizeof ( unsigned int ) );
-	  payload_cp_ptr += sizeof ( unsigned int );
-	  
-	  memcpy ( (void *) payload_cp_ptr,
-                   (void *) &(execHostName[string((*vpos)->pd.executable_name)]),
-		   sizeof ( unsigned int ) );
-	  payload_cp_ptr += sizeof ( unsigned int );
-	  
-	  memcpy ( (void *) payload_cp_ptr,
-		   (void *) &((*vpos)->pd.pid),
-		   sizeof (int) );
-	  payload_cp_ptr += sizeof ( int );
-	  
-	  memcpy ( (void *) payload_cp_ptr,
-		   (void *) &((*vpos)->mpirank),
-		   sizeof ( int ) );
-	  payload_cp_ptr += sizeof ( int ); 
+  for (pos = proctable_copy.begin(); pos != proctable_copy.end(); ++pos) {
+    for (vpos = pos->second.begin(); vpos != pos->second.end(); ++vpos) {
+      memcpy((void *)payload_cp_ptr,
+             (void *)&(execHostName[string((*vpos)->pd.host_name)]),
+             sizeof(unsigned int));
+      payload_cp_ptr += sizeof(unsigned int);
 
-	  memcpy ( (void *) payload_cp_ptr,
-		   (void *) &((*vpos)->cnodeid),
-		   sizeof ( int ) );
-	  payload_cp_ptr += sizeof ( int ); 
-	}
+      memcpy((void *)payload_cp_ptr,
+             (void *)&(execHostName[string((*vpos)->pd.executable_name)]),
+             sizeof(unsigned int));
+      payload_cp_ptr += sizeof(unsigned int);
+
+      memcpy((void *)payload_cp_ptr, (void *)&((*vpos)->pd.pid), sizeof(int));
+      payload_cp_ptr += sizeof(int);
+
+      memcpy((void *)payload_cp_ptr, (void *)&((*vpos)->mpirank), sizeof(int));
+      payload_cp_ptr += sizeof(int);
+
+      memcpy((void *)payload_cp_ptr, (void *)&((*vpos)->cnodeid), sizeof(int));
+      payload_cp_ptr += sizeof(int);
     }
- 
-
-  //
-  // serializing the string table into the send buffer. 
-  //
-  for ( EHpos = orderedEHName.begin(); 
-              EHpos != orderedEHName.end(); ++EHpos )
-    {
-      int leng = strlen ((*EHpos)) + 1;
-      memcpy ( (void *) payload_cp_ptr, 
-               (void *) ( *EHpos ),
-	       leng );
-      payload_cp_ptr += leng;
-    }
-  
-  write_lmonp_long_msg ( get_FE_sockfd(),
-			 (lmonp_t*) sendbuf, 
-			 msgsize );
-
-  {    
-    self_trace_t::trace ( LEVELCHK(level2), 
-			  MODULENAME, 0, 
-     "a proctable message shipped out"); 
   }
-  
+
+  //
+  // serializing the string table into the send buffer.
+  //
+  for (EHpos = orderedEHName.begin(); EHpos != orderedEHName.end(); ++EHpos) {
+    int leng = strlen((*EHpos)) + 1;
+    memcpy((void *)payload_cp_ptr, (void *)(*EHpos), leng);
+    payload_cp_ptr += leng;
+  }
+
+  write_lmonp_long_msg(get_FE_sockfd(), (lmonp_t *)sendbuf, msgsize);
+
+  {
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "a proctable message shipped out");
+  }
+
   free(sendbuf);
 
   return LAUNCHMON_OK;
 }
 
-
 //! ship_resourcehandle_msg
 /*!
-    sends an lmonp_t packet with { msgclass=lmonp_fetofe, 
+    sends an lmonp_t packet with { msgclass=lmonp_fetofe,
     type.fetofe_type=lmonp_febe_proctab,
     lmon_payload_length=size of the proctable }
-    to the FE API stub.  
+    to the FE API stub.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_resourcehandle_msg ( 
-                lmonp_fe_to_fe_msg_e t, int rid )
-{
+launchmon_rc_e
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_resourcehandle_msg(
+    lmonp_fe_to_fe_msg_e t, int rid) {
   using namespace std;
 
   lmonp_t msg;
   int msgsize;
   char *sendbuf;
-  char *payload_cp_ptr;  
+  char *payload_cp_ptr;
 
   //
   // If the engine is not driven via the FE API, this method
   // returns LAUNCHMON_FAILED
-  //  
-  if ( !get_API_mode() )
-    {    
-      self_trace_t::trace ( LEVELCHK(level3), 
-	     MODULENAME, 0, 
-	     "standalone mode does not ship resource handle via LMONP");
-      return LAUNCHMON_FAILED;
-    }
+  //
+  if (!get_API_mode()) {
+    self_trace_t::trace(
+        LEVELCHK(level3), MODULENAME, 0,
+        "standalone mode does not ship resource handle via LMONP");
+    return LAUNCHMON_FAILED;
+  }
 
-  init_msg_header (&msg);
+  init_msg_header(&msg);
   msg.msgclass = lmonp_fetofe;
   msg.type.fetofe_type = t;
   msg.lmon_payload_length = sizeof(rid);
-  msgsize = sizeof(msg) + msg.lmon_payload_length + msg.usr_payload_length; 
-  sendbuf = (char*) malloc (msgsize); 
-  
+  msgsize = sizeof(msg) + msg.lmon_payload_length + msg.usr_payload_length;
+  sendbuf = (char *)malloc(msgsize);
+
   payload_cp_ptr = sendbuf;
-  memcpy (payload_cp_ptr, &msg, sizeof(msg));  
+  memcpy(payload_cp_ptr, &msg, sizeof(msg));
   payload_cp_ptr += sizeof(msg);
   memcpy(payload_cp_ptr, &rid, sizeof(rid));
-  
-  write_lmonp_long_msg ( get_FE_sockfd(),
-			 (lmonp_t*)sendbuf,
-			 msgsize );  
 
-  {    
-    self_trace_t::trace ( LEVELCHK(level2), 
-			  MODULENAME, 0, 
-     "a reshandle message shipped out"); 
+  write_lmonp_long_msg(get_FE_sockfd(), (lmonp_t *)sendbuf, msgsize);
+
+  {
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "a reshandle message shipped out");
   }
 
-  free(sendbuf);  
+  free(sendbuf);
 
   return LAUNCHMON_OK;
 }
 
-
 //! ship_resourcehandle_msg
 /*!
-    sends an lmonp_t packet with { msgclass=lmonp_fetofe, 
+    sends an lmonp_t packet with { msgclass=lmonp_fetofe,
     type.fetofe_type=lmonp_febe_proctab,
     lmon_payload_length=size of the proctable }
-    to the FE API stub.  
+    to the FE API stub.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_rminfo_msg ( 
-                lmonp_fe_to_fe_msg_e t, int rmpid, rm_catalogue_e rmtype)
-{
+launchmon_rc_e launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::ship_rminfo_msg(
+    lmonp_fe_to_fe_msg_e t, int rmpid, rm_catalogue_e rmtype) {
   lmonp_t msg;
   int msgsize;
   uint32_t rminfo_pair[2];
   char *sendbuf;
-  char *payload_cp_ptr;  
+  char *payload_cp_ptr;
 
   //
   // If the engine is not driven via the FE API, this method
   // returns LAUNCHMON_FAILED
-  //  
-  if ( !get_API_mode() )
-    {    
-      self_trace_t::trace ( LEVELCHK(level3), 
-	     MODULENAME, 0, 
-	     "standalone mode does not ship resource handle via LMONP");
-      return LAUNCHMON_FAILED;
-    }
+  //
+  if (!get_API_mode()) {
+    self_trace_t::trace(
+        LEVELCHK(level3), MODULENAME, 0,
+        "standalone mode does not ship resource handle via LMONP");
+    return LAUNCHMON_FAILED;
+  }
 
-  rminfo_pair[0] = (uint32_t) rmpid;
-  rminfo_pair[1] = (uint32_t) rmtype;
+  rminfo_pair[0] = (uint32_t)rmpid;
+  rminfo_pair[1] = (uint32_t)rmtype;
 
-  init_msg_header (&msg);
+  init_msg_header(&msg);
   msg.msgclass = lmonp_fetofe;
   msg.type.fetofe_type = t;
   msg.lmon_payload_length = sizeof(rminfo_pair);
-  msgsize = sizeof(msg) + msg.lmon_payload_length + msg.usr_payload_length; 
-  sendbuf = (char*) malloc (msgsize); 
-  
+  msgsize = sizeof(msg) + msg.lmon_payload_length + msg.usr_payload_length;
+  sendbuf = (char *)malloc(msgsize);
+
   payload_cp_ptr = sendbuf;
-  memcpy (payload_cp_ptr, &msg, sizeof(msg));  
+  memcpy(payload_cp_ptr, &msg, sizeof(msg));
   payload_cp_ptr += sizeof(msg);
   memcpy(payload_cp_ptr, rminfo_pair, sizeof(rminfo_pair));
-  
-  write_lmonp_long_msg ( get_FE_sockfd(),
-			 (lmonp_t *)sendbuf,
-			 msgsize );  
 
-  {    
-    self_trace_t::trace ( LEVELCHK(level2), 
-			  MODULENAME, 0, 
-     "a reshandle message shipped out"); 
+  write_lmonp_long_msg(get_FE_sockfd(), (lmonp_t *)sendbuf, msgsize);
+
+  {
+    self_trace_t::trace(LEVELCHK(level2), MODULENAME, 0,
+                        "a reshandle message shipped out");
   }
 
-  free(sendbuf);  
+  free(sendbuf);
 
   return LAUNCHMON_OK;
-
 }
-
 
 //! handle_incoming_socket_event
 /*!
-  handles an lmonp_t packet received from the FE API stub. 
+  handles an lmonp_t packet received from the FE API stub.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_rc_e 
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::handle_incoming_socket_event (
-                process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p )
-{  
-  try
-    {
-      struct pollfd fds[1];
-      int pollret;
-      int timeout = 0;
-      double timestamp;
+launchmon_rc_e
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::handle_incoming_socket_event(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) {
+  try {
+    struct pollfd fds[1];
+    int pollret;
+    int timeout = 0;
+    double timestamp;
 
-      if ( !get_API_mode() )
-	{    
-	  self_trace_t::trace ( LEVELCHK(level3), 
-	     MODULENAME, 0, 
-	     "standalone launchmon does not have to poll the FE socket"); 
- 
-	  return LAUNCHMON_OK;
-	}
+    if (!get_API_mode()) {
+      self_trace_t::trace(
+          LEVELCHK(level3), MODULENAME, 0,
+          "standalone launchmon does not have to poll the FE socket");
 
-      //
-      // poll should return positive ret code only when one or more messages 
-      // reported onto this file descriptor.
-      // 
-      fds[0].fd = get_FE_sockfd();
-      fds[0].events = POLLIN;
-      //fds[0].events = POLLRDBAND;
-
-      timestamp = gettimeofdayD ();
-      if ( timestamp > (last_seen + warm_period) )     
-        timeout = 10; /* 10 milisecond blocking if no event */
-
-      do {
-	pollret = poll ( fds, 1, timeout );
-      } while ( (pollret < 0) && (errno == EINTR) );
-	  
-      if ( pollret > 0 )
-	{
-#if VERBOSE
-	   self_trace_t::trace ( LEVELCHK(level1), 
-	   MODULENAME, 0, 
-	   "poll returned an event ");  
-#endif
-          if ( fds[0].revents & POLLIN) { 
-	    int numbytes;
-	    lmonp_t msg; 
-
-	    init_msg_header (&msg);
-	    numbytes = read_lmonp_msgheader ( get_FE_sockfd(), &msg);
-
-            //
-	    // First handle socket disconnection and oddly formed message
-	    //
-            if ( numbytes == -1)
-              {
-		//
-		// A.C.1. If the tool FE fails, the engine first detects the socket 
-                // disconnection, at which point it tries to kill  the  RM_daemon  
-		// process and detaches  from  the  RM_job  process.  However, 
-	        // if for some reason the engine also gets into trouble, the engine 
-	        // would perform  A.1  instead; obviously  in  this  case,  the failing 
-		// launchmon engine will keep the RM_daemon process running, and 
-                // won't be able to do A.1.3.
-		//
-	        // This attempts to stop all of the threads
-                // and mark "detach." If a kill/detach request has been already registered, 
-                // don't bother
-                self_trace_t::trace ( LEVELCHK(level1),
-                  MODULENAME,
-                  0,
-                  "The channel with front-end disconnected. Starting cleanup...");
-
-                request_detach(p, FE_disconnected); 
-                goto ret_ok;
-              } // if ( numbytes == -1)
-	    else if ( (numbytes != sizeof (msg))
-		      || ((numbytes == sizeof (msg))
-		          && (msg.msgclass != lmonp_fetofe)) )
-	      {
-	        self_trace_t::trace ( LEVELCHK(level1), 
-	          MODULENAME, 1, 
-		  "read_lmonp_msgheader pulled out a ill-formed message");  
-
-	        // FAILED is a misnomer in this case
-	        goto ret_fail;
-	      }
-
- 	    //
-	    // OK, FE socket is connected and we received a legit message 
-	    //
-	    //
-	    switch (msg.type.fetofe_type)
-              {
-	      case lmonp_detach:
-                {
-	          // This attempts to stop all of the threads
-                  // and mark "kill/detach." If a kill/detach request has been already registered, 
-                  // don't bother
-                  self_trace_t::trace ( LEVELCHK(level1),
-                    MODULENAME,
-                    0,
-                    "front-end requested detach...");
-                  request_detach ( p, FE_requested_detach );
-                  break;
-		}
-	      case lmonp_kill:
-	        {
-	          // This attempts to stop all of the threads
-                  // and mark "kill" If a kill/detach request has been already registered, 
-                  // don't bother
-                  self_trace_t::trace ( LEVELCHK(level1),
-                    MODULENAME,
-                    0,
-                    "front-end requested kill...");
-                  request_kill ( p, FE_requested_kill ); 
-                  break;
-                }  
-              case lmonp_shutdownbe:
-                {
-	          // This attempts to stop all of the threads
-                  // and mark "detach" If a kill/detach request has been already registered, 
-                  // don't bother
-                  self_trace_t::trace ( LEVELCHK(level1),
-                    MODULENAME,
-                    0,
-                    "front-end requested deamon shutdown...");
-                  request_detach ( p, FE_requested_shutdown_dmon );
-                  break;
-		}
-              case lmonp_cont_launch_bp:
-                {
-                  self_trace_t::trace ( LEVELCHK(level1),
-                    MODULENAME,
-                    0,
-                    "front-end requests unlocking the launcher from launch-bp...");
-                  request_cont_launch_bp ( p );
-                  break;
-                }
-              default:
-	        {
-                  self_trace_t::trace ( LEVELCHK(level1),
-                    MODULENAME, 1,
-                    "ill-formed msg");
-
-		  goto ret_fail; 
-	        }
-            } // switch	
-          }
-        } // if (pollret 
-
-ret_ok:
-      //
-      // this should cause the event loop to continue
-      //
       return LAUNCHMON_OK;
-ret_fail:
-      //
-      // this should cause the event loop to exit
-      //
-      return LAUNCHMON_FAILED;	
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e ) 
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
-}
 
+    //
+    // poll should return positive ret code only when one or more messages
+    // reported onto this file descriptor.
+    //
+    fds[0].fd = get_FE_sockfd();
+    fds[0].events = POLLIN;
+    // fds[0].events = POLLRDBAND;
+
+    timestamp = gettimeofdayD();
+    if (timestamp > (last_seen + warm_period))
+      timeout = 10; /* 10 milisecond blocking if no event */
+
+    do {
+      pollret = poll(fds, 1, timeout);
+    } while ((pollret < 0) && (errno == EINTR));
+
+    if (pollret > 0) {
+#if VERBOSE
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                          "poll returned an event ");
+#endif
+      if (fds[0].revents & POLLIN) {
+        int numbytes;
+        lmonp_t msg;
+
+        init_msg_header(&msg);
+        numbytes = read_lmonp_msgheader(get_FE_sockfd(), &msg);
+
+        //
+        // First handle socket disconnection and oddly formed message
+        //
+        if (numbytes == -1) {
+          //
+          // A.C.1. If the tool FE fails, the engine first detects the socket
+          // disconnection, at which point it tries to kill  the  RM_daemon
+          // process and detaches  from  the  RM_job  process.  However,
+          // if for some reason the engine also gets into trouble, the engine
+          // would perform  A.1  instead; obviously  in  this  case,  the
+          // failing
+          // launchmon engine will keep the RM_daemon process running, and
+          // won't be able to do A.1.3.
+          //
+          // This attempts to stop all of the threads
+          // and mark "detach." If a kill/detach request has been already
+          // registered,
+          // don't bother
+          self_trace_t::trace(
+              LEVELCHK(level1), MODULENAME, 0,
+              "The channel with front-end disconnected. Starting cleanup...");
+
+          request_detach(p, FE_disconnected);
+          goto ret_ok;
+        }  else if ((numbytes != sizeof(msg)) ||
+                    ((numbytes == sizeof(msg)) &&
+                    (msg.msgclass != lmonp_fetofe))) {
+          self_trace_t::trace(
+              LEVELCHK(level1), MODULENAME, 1,
+              "read_lmonp_msgheader pulled out a ill-formed message");
+
+          // FAILED is a misnomer in this case
+          goto ret_fail;
+        }
+
+        //
+        // OK, FE socket is connected and we received a legit message
+        //
+        //
+        switch (msg.type.fetofe_type) {
+          case lmonp_detach: {
+            // This attempts to stop all of the threads
+            // and mark "kill/detach." If a kill/detach request has been already
+            // registered,
+            // don't bother
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                                "front-end requested detach...");
+            request_detach(p, FE_requested_detach);
+            break;
+          }
+          case lmonp_kill: {
+            // This attempts to stop all of the threads
+            // and mark "kill" If a kill/detach request has been already
+            // registered,
+            // don't bother
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                                "front-end requested kill...");
+            request_kill(p, FE_requested_kill);
+            break;
+          }
+          case lmonp_shutdownbe: {
+            // This attempts to stop all of the threads
+            // and mark "detach" If a kill/detach request has been already
+            // registered,
+            // don't bother
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                                "front-end requested deamon shutdown...");
+            request_detach(p, FE_requested_shutdown_dmon);
+            break;
+          }
+          case lmonp_cont_launch_bp: {
+            self_trace_t::trace(
+                LEVELCHK(level1), MODULENAME, 0,
+                "front-end requests unlocking the launcher from launch-bp...");
+            request_cont_launch_bp(p);
+            break;
+          }
+          default: {
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                                "ill-formed msg");
+
+            goto ret_fail;
+          }
+        }  // switch
+      }
+    }  // if (pollret
+
+  ret_ok:
+    //
+    // this should cause the event loop to continue
+    //
+    return LAUNCHMON_OK;
+  ret_fail:
+    //
+    // this should cause the event loop to exit
+    //
+    return LAUNCHMON_FAILED;
+  } catch (symtab_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  }
+}
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 launchmon_rc_e
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::handle_daemon_exit_event
-                 ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p )
-{
-  try
-    {
-      // This attempts to stop all of the threads
-      // and mark "detach" If a kill/detach request has been already registered, 
-      // don't bother
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,
-        0,
-        "daemon exited...");
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::handle_daemon_exit_event(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) {
+  try {
+    // This attempts to stop all of the threads
+    // and mark "detach" If a kill/detach request has been already registered,
+    // don't bother
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0, "daemon exited...");
 
-      //
-      // Lower layer calls this handler when it gets notified of
-      // the status change (to exit) of the RM launcher process 
-      // that launched RM_daemons. Depending on
-      // RM types, this may or may not mean the RM_daemons are
-      // actually terminated or exited. So, we query the RM map
-      // layer to ask questions first.
-      //
-      if (p.rmgr()->is_fail_detect_sup())
-        {
-          request_detach(p, RM_BE_daemon_exited);
-        }
+    //
+    // Lower layer calls this handler when it gets notified of
+    // the status change (to exit) of the RM launcher process
+    // that launched RM_daemons. Depending on
+    // RM types, this may or may not mean the RM_daemons are
+    // actually terminated or exited. So, we query the RM map
+    // layer to ask questions first.
+    //
+    if (p.rmgr()->is_fail_detect_sup()) {
+      request_detach(p, RM_BE_daemon_exited);
+    }
 
-      set_last_seen (gettimeofdayD ());
-      return LAUNCHMON_OK;
-    }
-  catch ( symtab_exception_t e )
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
-  catch ( tracer_exception_t e )
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
-  catch ( machine_exception_t e )
-    {
-      e.report();
-      //
-      // when a symtab exception is thrown, we catch and report it  
-      // and return the failed code. So the caller must handle 
-      // this code.
-      //
-      return LAUNCHMON_FAILED;
-    }
+    set_last_seen(gettimeofdayD());
+    return LAUNCHMON_OK;
+  } catch (symtab_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  } catch (tracer_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  } catch (machine_exception_t e) {
+    e.report();
+    //
+    // when a symtab exception is thrown, we catch and report it
+    // and return the failed code. So the caller must handle
+    // this code.
+    //
+    return LAUNCHMON_FAILED;
+  }
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::validate_mpir_state_transition(int s)
-{
+bool launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>::validate_mpir_state_transition(
+    int s) {
   bool rc = false;
-  switch(s)
-    {
+  switch (s) {
     case MPIR_DEBUG_SPAWNED:
-      if ( (engine_state == mpir_start) 
-           || (engine_state == mpir_null) )
-        {
-          rc = true;
-        }
+      if ((engine_state == mpir_start) || (engine_state == mpir_null)) {
+        rc = true;
+      }
       break;
-    case MPIR_DEBUG_ABORTING: 
-      if ( (engine_state == mpir_start) 
-           || (engine_state == mpir_null) 
-           || (engine_state == mpir_spawned) )
-        {
-          rc = true;
-        }
-      break;  
+    case MPIR_DEBUG_ABORTING:
+      if ((engine_state == mpir_start) || (engine_state == mpir_null) ||
+          (engine_state == mpir_spawned)) {
+        rc = true;
+      }
+      break;
     case MPIR_NULL:
-      if ( (engine_state == mpir_start) 
-           || (engine_state == mpir_null) 
-           || (engine_state == mpir_spawned) )
-        {
-          rc = true;
-        }
+      if ((engine_state == mpir_start) || (engine_state == mpir_null) ||
+          (engine_state == mpir_spawned)) {
+        rc = true;
+      }
       break;
     default:
       break;
-    }
+  }
 
   return rc;
 }
 
-#endif // SDBG_BASE_LAUNCHMON_IMPL_HXX
+#endif  // SDBG_BASE_LAUNCHMON_IMPL_HXX
+
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_mach.hxx
+++ b/launchmon/src/sdbg_base_mach.hxx
@@ -1,40 +1,42 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_mach.hxx,v 1.7.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May 02 2018 ADG: Added aarch64 support
  *        Sep 02 2010 DHA: Added MPIR_attach_fifo support
- *        May 08 2008 DHA: Added an alias (is_master_thread) for get_master_thread
+ *        May 08 2008 DHA: Added an alias (is_master_thread)
+ *                         for get_master_thread
  *                         because the latter isn't entirely intuitive.
  *        Mar 18 2008 DHA: Added BlueGene support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
  *        May 22 2006 DHA: Added exception class for the machine layer..
  *        Jan 11 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_BASE_MACH_HXX
 #define SDBG_BASE_MACH_HXX 1
@@ -43,15 +45,13 @@
 #include <stack>
 #include <string>
 
-#include "sdbg_std.hxx"
-#include "sdbg_opt.hxx"
 #include "sdbg_base_bp.hxx"
-#include "sdbg_base_symtab.hxx"
 #include "sdbg_base_exception.hxx"
+#include "sdbg_base_symtab.hxx"
+#include "sdbg_opt.hxx"
+#include "sdbg_std.hxx"
 
 const int THREAD_KEY_INVALID = -1;
-
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -62,28 +62,24 @@ const int THREAD_KEY_INVALID = -1;
   exception class for machine layer
 
 */
-class machine_exception_t : public exception_base_t
-{
-public:  
+class machine_exception_t : public exception_base_t {
+ public:
+  machine_exception_t() {}
+  explicit machine_exception_t(const char *m) {
+    set_message(m);
+    set_type(std::string("SDBG_MACHINE_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
+  machine_exception_t(const std::string &m) {
+    set_message(m);
+    set_type(std::string("SDBG_MACHINE_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
 
-  machine_exception_t ()                          { }
-  explicit machine_exception_t ( const char* m )
-                      { set_message (m);
-                        set_type ( std::string ( "SDBG_MACHINE_ERROR" ) );
-                        set_fn ( std::string (__FILE__) );
-                        set_ln ( __LINE__ );
-                      }
-  machine_exception_t ( const std::string& m)  
-                      { set_message (m);
-                        set_type ( std::string ( "SDBG_MACHINE_ERROR" ) );
-                        set_fn ( std::string (__FILE__) );
-                        set_ln ( __LINE__ );
-                      }
-
-  virtual ~machine_exception_t()                  { }
-
+  virtual ~machine_exception_t() {}
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -91,65 +87,59 @@ public:
 
 //! class register_set_base_t
 /*!
-    register_set_t is the wrapper class for native register set 
-    data structure. Native register sets are typically 
-    defined in the system headers. For example, sys/user.h 
-    in the case of Linux. Users of this class first have to wrap 
-    those native register sets (FP register set and General 
+    register_set_t is the wrapper class for native register set
+    data structure. Native register sets are typically
+    defined in the system headers. For example, sys/user.h
+    in the case of Linux. Users of this class first have to wrap
+    those native register sets (FP register set and General
     register set) into this class.
  */
-template <typename NATIVE_RS,typename VA,typename WT>
-class register_set_base_t
-{
-
-public:
-
+template <typename NATIVE_RS, typename VA, typename WT>
+class register_set_base_t {
+ public:
   // constructors and destructor
   //
-  register_set_base_t ();
-  explicit register_set_base_t (const int offset);
-  register_set_base_t(const register_set_base_t<NATIVE_RS,VA,WT> &r);  
-  virtual ~register_set_base_t ();
-  register_set_base_t & operator=(
-    const register_set_base_t &r);
+  register_set_base_t();
+  explicit register_set_base_t(const int offset);
+  register_set_base_t(const register_set_base_t<NATIVE_RS, VA, WT> &r);
+  virtual ~register_set_base_t();
+  register_set_base_t &operator=(const register_set_base_t &r);
 
   //
-  // accessors 
+  // accessors
   //
-  int get_offset_in_user ( ) const           { return offset_in_user; }
-  WT * get_rs_ptr ()                         { return rs_ptr; }
-  NATIVE_RS const & get_native_rs() const    { return rs; }  
-  virtual VA const get_pc () const           { return 0; }
-  virtual VA const get_ret_addr() const      { return 0; }
-  virtual VA const get_memloc_for_ret_addr() const     
-			                     { return 0; }
-  unsigned int get_writable_mask()           { return writable_mask; }
-  void set_user_offset (int offset)          { offset_in_user = offset; }
-  void set_ptr_to_regset ()                  { rs_ptr = (WT*) &rs; }
-  void set_writable_mask (unsigned int m)    { writable_mask = m; }
-  virtual void set_pc (VA p)                 { }
- 
-  void inc_ptr_by_word ()                    { rs_ptr++; }
-  void write_word_to_ptr (WT w)              { (*rs_ptr) = w; }
-  unsigned int size_in_word ();
-  size_t size()                              { return sizeof(NATIVE_RS); }
+  int get_offset_in_user() const { return offset_in_user; }
+  WT *get_rs_ptr() { return rs_ptr; }
+  NATIVE_RS const &get_native_rs() const { return rs; }
+  virtual VA const get_pc() const { return 0; }
+  virtual VA const get_ret_addr() const { return 0; }
+  virtual VA const get_memloc_for_ret_addr() const { return 0; }
+  unsigned int get_writable_mask() { return writable_mask; }
+  void set_user_offset(int offset) { offset_in_user = offset; }
+  void set_ptr_to_regset() { rs_ptr = (WT *)&rs; }
+  void set_writable_mask(unsigned int m) { writable_mask = m; }
+  virtual void set_pc(VA p) {}
 
-protected:
-  // "rs" retains register set object in its native data structure. 
-  // "offset_in_user" contains info about what offset 
+  void inc_ptr_by_word() { rs_ptr++; }
+  void write_word_to_ptr(WT w) { (*rs_ptr) = w; }
+  unsigned int size_in_word();
+  size_t size() { return sizeof(NATIVE_RS); }
+
+ protected:
+  // "rs" retains register set object in its native data structure.
+  // "offset_in_user" contains info about what offset
   // in "USER" area does regset reside.
-  // "rs_ptr" is a temporary pointer which will be used 
+  // "rs_ptr" is a temporary pointer which will be used
   // in traversing USER area
-  // Some registers are not simply writtable. 
+  // Some registers are not simply writtable.
   // Need a mask(writable_mask).
   NATIVE_RS rs;
 
-private:
+ private:
   int offset_in_user;
   WT *rs_ptr;
-  unsigned int writable_mask; 
+  unsigned int writable_mask;
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -159,7 +149,7 @@ private:
 /*!
     enumerating process states, C++ class wrapper
 */
-enum debug_event_e { 
+enum debug_event_e {
   EV_EXITED,
   EV_TERMINATED,
   EV_STOPPED,
@@ -167,42 +157,38 @@ enum debug_event_e {
   EV_INVALID
 };
 
-enum eventing_entity_e {
-  EV_ENTITY_THREAD,
-  EV_ENTITY_PROCESS,
-  EV_ENTITY_NONE
-};
-
+enum eventing_entity_e { EV_ENTITY_THREAD, EV_ENTITY_PROCESS, EV_ENTITY_NONE };
 
 class debug_event_t {
+ public:
+  debug_event_t() {
+    ev = EV_INVALID;
+    u.exitcode = -1;
+  }
+  ~debug_event_t() {}
+  void set_ev(const enum debug_event_e e) { ev = e; }
+  void set_en(const enum eventing_entity_e t) { en = t; }
+  void set_signum(const int s) { u.signum = s; }
+  void set_exitcode(const int ec) { u.exitcode = ec; }
+  void set_rawstatus(const int st) { rawstatus = st; }
+  void set_id(const int i) { id = i; }
+  const debug_event_e get_ev() const { return ev; }
+  const eventing_entity_e get_en() const { return en; }
+  const int get_signum() const { return u.signum; }
+  const int get_exitcode() const { return u.exitcode; }
+  const int get_rawstatus() const { return rawstatus; }
+  const int get_id() const { return id; }
 
-public:
-  debug_event_t()                          { ev = EV_INVALID; u.exitcode = -1; }
-  ~debug_event_t()                         { }
-  void set_ev (const enum debug_event_e e) { ev = e; }
-  void set_en (const enum eventing_entity_e t) { en = t; }
-  void set_signum (const int s)            { u.signum = s; }
-  void set_exitcode (const int ec)         { u.exitcode = ec; }
-  void set_rawstatus (const int st)        { rawstatus = st; }
-  void set_id (const int i)                { id = i; }
-  const debug_event_e get_ev () const      { return ev; }
-  const eventing_entity_e get_en () const  { return en; }
-  const int get_signum () const            { return u.signum; }
-  const int get_exitcode () const          { return u.exitcode; }
-  const int get_rawstatus () const         { return rawstatus; }
-  const int get_id () const                { return id; }
-
-private:
+ private:
   debug_event_e ev;
   eventing_entity_e en;
   union {
     int signum;
     int exitcode;
-  } u; 
+  } u;
   int rawstatus;
   int id;
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -210,14 +196,14 @@ private:
 
 //! enum lwp_state_t
 /*!
-    Simple runtime state enumerator to model 
-    process states of a lightweight process. 
+    Simple runtime state enumerator to model
+    process states of a lightweight process.
     This should be mainly used by the tracer layer
     to determine legitimacy of a tracing operation.
     This should be used with a caveat that there is
-    a window of time the actual state of a lwp 
+    a window of time the actual state of a lwp
     and the modeled state is different: betwen the time
-    the lwp changed its actual state and  
+    the lwp changed its actual state and
     that event gets notified via the waitpid call
     within the poll process method.
 */
@@ -228,23 +214,19 @@ enum lwp_state_e {
   LMON_RM_EXITED
 };
 
-
 //! class thread_base_t
 /*!
     thread_base_t is the base thread class. Since each
-    thread has its own register set, it contains 
+    thread has its own register set, it contains
     gprset for General Purpose Register set and
     fprset for Floating Point Register set.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-class thread_base_t 
-{
-
-public:
-
+class thread_base_t {
+ public:
   // constructors and destructor
   //
-  thread_base_t();  
+  thread_base_t();
   virtual ~thread_base_t();
 
   // pure virtual method. A derived class must define this method,
@@ -253,44 +235,43 @@ public:
 
   // this implements waitpid for this thread
   // override this only when the generic sniff_debug_event isn't enough
-  //virtual bool sniff_debug_event ( debug_event_t& );
+  // virtual bool sniff_debug_event ( debug_event_t& );
 
   bool check_transition(lwp_state_e s);
 
   //
   // accessors
-  // 
-  NT& get_thread_info();
-  void copy_thread_info(const NT& ct);  
+  //
+  NT &get_thread_info();
+  void copy_thread_info(const NT &ct);
 
-  define_gset(bool,master_thread)
-  define_gset(bool,traced)
-  define_gset(bool,event_registered)
-  define_gset(pid_t,master_pid)
-  define_gset(lwp_state_e,state)
+  define_gset(bool, master_thread)
+  define_gset(bool, traced)
+  define_gset(bool, event_registered)
+  define_gset(pid_t, master_pid)
+  define_gset(lwp_state_e, state)
 
-  bool is_master_thread () { return get_master_thread(); }
-  register_set_base_t<GRS,VA,WT> * get_gprset();
-  void set_gprset(register_set_base_t<GRS,VA,WT> *g);
-  register_set_base_t<FRS,VA,WT> * get_fprset();
-  void set_fprset(register_set_base_t<FRS,VA,WT> *f);
+  bool is_master_thread() {
+    return get_master_thread();
+  }
+  register_set_base_t<GRS, VA, WT> *get_gprset();
+  void set_gprset(register_set_base_t<GRS, VA, WT> *g);
+  register_set_base_t<FRS, VA, WT> *get_fprset();
+  void set_fprset(register_set_base_t<FRS, VA, WT> *f);
 
-private:
-
+ private:
   thread_base_t(const thread_base_t &t);
-  thread_base_t & operator=(
-                  const thread_base_t &rhs); 
+  thread_base_t &operator=(const thread_base_t &rhs);
 
-  bool master_thread; // indicator for the master thread
-  bool traced;        // indicator that this thread has been attached
-  bool event_registered; // indicator that this thread has a pending event
-  pid_t master_pid;   // process id of the containing proc
-  NT thread_info;     // parameterized thread info
-  lwp_state_e state;  // thread's modeled state
-  register_set_base_t<GRS,VA,WT> *gprset; 
-  register_set_base_t<FRS,VA,WT> *fprset; 
+  bool master_thread;     // indicator for the master thread
+  bool traced;            // indicator that this thread has been attached
+  bool event_registered;  // indicator that this thread has a pending event
+  pid_t master_pid;       // process id of the containing proc
+  NT thread_info;         // parameterized thread info
+  lwp_state_e state;      // thread's modeled state
+  register_set_base_t<GRS, VA, WT> *gprset;
+  register_set_base_t<FRS, VA, WT> *fprset;
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -301,9 +282,9 @@ enum pcont_req_reason {
   RM_MW_daemon_exited,
   RM_JOB_exited,
   RM_JOB_mpir_aborting,
-  FE_requested_detach,  
+  FE_requested_detach,
   FE_requested_kill,
-  FE_requested_shutdown_dmon,	
+  FE_requested_shutdown_dmon,
   FE_disconnected,
   ENGINE_dying_wsignal,
   reserved_for_rent
@@ -311,104 +292,96 @@ enum pcont_req_reason {
 
 //! class process_base_t
 /*!
-    process_base_t is the base process class that models 
-    the target RM process. 
- 
+    process_base_t is the base process class that models
+    the target RM process.
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-class process_base_t 
-{
-
-public:
-  // 
+class process_base_t {
+ public:
+  //
   // constructors and destructor
   //
-  process_base_t ();
-  process_base_t (const std::string &mi,
-		  const std::string &md,
-      		  const std::string &mt,
-		  const std::string &mc );
-  virtual ~process_base_t (); 
+  process_base_t();
+  process_base_t(const std::string &mi, const std::string &md,
+                 const std::string &mt, const std::string &mc);
+  virtual ~process_base_t();
 
-  bool make_context (const int key);
-  lwp_state_e get_lwp_state (bool use_cxt);
-  bool set_lwp_state (lwp_state_e s, bool use_cxt); 
-  bool check_and_undo_context (const int key);
-  register_set_base_t<GRS,VA,WT>* get_gprset(bool context_sensitive);
-  register_set_base_t<FRS,VA,WT>* get_fprset(bool context_sensitive);
-  void debug_iter_thrlist ();
+  bool make_context(const int key);
+  lwp_state_e get_lwp_state(bool use_cxt);
+  bool set_lwp_state(lwp_state_e s, bool use_cxt);
+  bool check_and_undo_context(const int key);
+  register_set_base_t<GRS, VA, WT> *get_gprset(bool context_sensitive);
+  register_set_base_t<FRS, VA, WT> *get_fprset(bool context_sensitive);
+  void debug_iter_thrlist();
 
   //
   // accessors
   //
-  const pid_t get_master_thread_pid ();
-  const pid_t get_pid (bool context_sensitive);
-  std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr>& 
-    get_thrlist ();
-  typename std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr>::iterator 
-    thr_iter;
+  const pid_t get_master_thread_pid();
+  const pid_t get_pid(bool context_sensitive);
+  std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM> *, ltstr> &get_thrlist();
+  typename std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM> *,
+                    ltstr>::iterator thr_iter;
 
-  image_base_t<VA,EXECHANDLER> * get_myimage ();
-  image_base_t<VA,EXECHANDLER> * get_mydynloader_image ();
-  image_base_t<VA,EXECHANDLER> * get_mythread_lib_image ();
-  image_base_t<VA,EXECHANDLER> * get_mylibc_image();
-  image_base_t<VA,EXECHANDLER> * get_myrmso_image();
-  breakpoint_base_t<VA,IT> * get_launch_hidden_bp ();
-  breakpoint_base_t<VA,IT> * get_loader_hidden_bp ();
-  const symbol_base_t<VA> * get_sym_attach_fifo ();
+  image_base_t<VA, EXECHANDLER> *get_myimage();
+  image_base_t<VA, EXECHANDLER> *get_mydynloader_image();
+  image_base_t<VA, EXECHANDLER> *get_mythread_lib_image();
+  image_base_t<VA, EXECHANDLER> *get_mylibc_image();
+  image_base_t<VA, EXECHANDLER> *get_myrmso_image();
+  breakpoint_base_t<VA, IT> *get_launch_hidden_bp();
+  breakpoint_base_t<VA, IT> *get_loader_hidden_bp();
+  const symbol_base_t<VA> *get_sym_attach_fifo();
 
-  rc_rm_t * rmgr() { return myopts? myopts->get_my_rmconfig() : NULL; }
-  opts_args_t * get_myopts() { return myopts; }
+  rc_rm_t *rmgr() { return myopts ? myopts->get_my_rmconfig() : NULL; }
+  opts_args_t *get_myopts() { return myopts; }
 
-  void set_myimage (image_base_t<VA,EXECHANDLER> *i);
-  void set_mydynloader_image (image_base_t<VA,EXECHANDLER> *i);
-  void set_mythread_lib_image (image_base_t<VA,EXECHANDLER> *i);
-  void set_mylibc_image (image_base_t<VA,EXECHANDLER> *i);
-  void set_myrmso_image (image_base_t<VA,EXECHANDLER> *i);
-  void set_launch_hidden_bp(breakpoint_base_t<VA,IT> *b);
-  void set_loader_hidden_bp(breakpoint_base_t<VA,IT> *b);
+  void set_myimage(image_base_t<VA, EXECHANDLER> *i);
+  void set_mydynloader_image(image_base_t<VA, EXECHANDLER> *i);
+  void set_mythread_lib_image(image_base_t<VA, EXECHANDLER> *i);
+  void set_mylibc_image(image_base_t<VA, EXECHANDLER> *i);
+  void set_myrmso_image(image_base_t<VA, EXECHANDLER> *i);
+  void set_launch_hidden_bp(breakpoint_base_t<VA, IT> *b);
+  void set_loader_hidden_bp(breakpoint_base_t<VA, IT> *b);
   void set_myopts(opts_args_t *o) { myopts = o; }
   void set_sym_attach_fifo(symbol_base_t<VA> *o);
 
-  define_gset(bool,never_trapped)
+  define_gset(bool, never_trapped)
   define_gset(bool, please_detach)
   define_gset(bool, please_kill)
   define_gset(pcont_req_reason, reason)
-  define_gset(std::string,launch_breakpoint_sym)
-  define_gset(std::string,launch_being_debug)
-  define_gset(std::string,launch_debug_state)
-  define_gset(std::string,launch_debug_gate)
-  define_gset(std::string,launch_proctable)
-  define_gset(std::string,launch_proctable_size)  
-  define_gset(std::string,launch_acquired_premain)
-  define_gset(std::string,launch_exec_path)
-  define_gset(std::string,launch_server_args)
-  define_gset(std::string,launch_attach_fifo)
-  define_gset(std::string,loader_breakpoint_sym)
-  define_gset(std::string,loader_start_sym)
-  define_gset(std::string,loader_r_debug_sym)
-  define_gset(std::string,resource_handler_sym)
-  //define_gset(int,key_to_thread_context)
-  define_gset(int,rid)
-  define_gset(int,new_child_pid)
-  int get_cur_thread_ctx();  
- 
-protected:
-  bool protected_init ( const std::string &mi,
-			const std::string &md,
-			const std::string &mt,
-		        const std::string &mc );
+  define_gset(std::string, launch_breakpoint_sym)
+  define_gset(std::string, launch_being_debug)
+  define_gset(std::string, launch_debug_state)
+  define_gset(std::string, launch_debug_gate)
+  define_gset(std::string, launch_proctable)
+  define_gset(std::string, launch_proctable_size)
+  define_gset(std::string, launch_acquired_premain)
+  define_gset(std::string, launch_exec_path)
+  define_gset(std::string, launch_server_args)
+  define_gset(std::string, launch_attach_fifo)
+  define_gset(std::string, loader_breakpoint_sym)
+  define_gset(std::string, loader_start_sym)
+  define_gset(std::string, loader_r_debug_sym)
+  define_gset(std::string, resource_handler_sym)
+  // define_gset(int,key_to_thread_context)
+  define_gset(int, rid)
+  define_gset(int, new_child_pid)
+  int get_cur_thread_ctx();
 
-  bool protected_init ( const std::string& mi );
+ protected:
+  bool protected_init(const std::string &mi, const std::string &md,
+                      const std::string &mt, const std::string &mc);
 
-private:
+  bool protected_init(const std::string &mi);
+
+ private:
   process_base_t(const process_base_t &p);
-  process_base_t & operator=(
-                 const process_base_t &p); 
+  process_base_t &operator=(const process_base_t &p);
 
   // Has the process ever initally exec'ed and stopped ?
   bool never_trapped;
-  
+
   // anyone wants to detach?
   bool please_detach;
 
@@ -417,11 +390,11 @@ private:
 
   pcont_req_reason reason;
 
-  image_base_t<VA,EXECHANDLER> *myimage;
-  image_base_t<VA,EXECHANDLER> *mydynloader_image;
-  image_base_t<VA,EXECHANDLER> *mythread_lib_image;
-  image_base_t<VA,EXECHANDLER> *mylibc_image;
-  image_base_t<VA,EXECHANDLER> *myrmso_image;
+  image_base_t<VA, EXECHANDLER> *myimage;
+  image_base_t<VA, EXECHANDLER> *mydynloader_image;
+  image_base_t<VA, EXECHANDLER> *mythread_lib_image;
+  image_base_t<VA, EXECHANDLER> *mylibc_image;
+  image_base_t<VA, EXECHANDLER> *myrmso_image;
 
   opts_args_t *myopts;
 
@@ -430,13 +403,13 @@ private:
   //
   // hidden breakpoints
   //
-  breakpoint_base_t<VA,IT> *launch_hidden_bp;
-  breakpoint_base_t<VA,IT> *loader_hidden_bp;
+  breakpoint_base_t<VA, IT> *launch_hidden_bp;
+  breakpoint_base_t<VA, IT> *loader_hidden_bp;
 
   symbol_base_t<VA> *sym_attach_fifo;
 
   //
-  // launcher/debugger ABI symbols  
+  // launcher/debugger ABI symbols
   //
   std::string launch_breakpoint_sym;
   std::string launch_being_debug;
@@ -451,15 +424,18 @@ private:
   std::string loader_breakpoint_sym;
   std::string loader_start_sym;
   std::string loader_r_debug_sym;
-  std::string resource_handler_sym; 
+  std::string resource_handler_sym;
 
   // WARNING: Do not attempt to copy thrclist to another list
   // of the same type. It will copy the pointers but not pointees.
   // It is tricky to implement polymorphism using STL containers.
-  std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr> thrlist;
+  std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM> *, ltstr> thrlist;
   std::stack<int> thread_ctx_stack;
   int new_child_pid;
 };
 
-#endif // SDBG_BASE_MACH_HXX
+#endif  // SDBG_BASE_MACH_HXX
 
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_mach_impl.hxx
+++ b/launchmon/src/sdbg_base_mach_impl.hxx
@@ -1,41 +1,42 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_mach_impl.hxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Aug 10 2998 DHA: Added thread state transition check
- *        Mar 06 2008 DHA: Added delay symbol table parsing for libc 
+ *        Mar 06 2008 DHA: Added delay symbol table parsing for libc
  *                         and libpthread.
- *        Feb 09 2008 DHA: Added LLNS Copyright 
+ *        Feb 09 2008 DHA: Added LLNS Copyright
  *        May 22 2006 DHA: Added exception support for the machine layer
- *        Feb 06 2006 DHA: del support 
+ *        Feb 06 2006 DHA: del support
  *        Jan 11 2006 DHA: Created file.
  */
 
-#ifndef SDBG_BASE_MACH_IMPL_HXX 
+#ifndef SDBG_BASE_MACH_IMPL_HXX
 #define SDBG_BASE_MACH_IMPL_HXX 1
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -43,22 +44,21 @@
 #endif
 
 extern "C" {
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <sys/stat.h>
-#include <sys/user.h>
 #include <errno.h>
-#include <unistd.h>
 #include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/user.h>
+#include <sys/wait.h>
+#include <unistd.h>
 }
 
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
+#include "sdbg_base_mach.hxx"
 #include "sdbg_base_symtab.hxx"
 #include "sdbg_base_symtab_impl.hxx"
-#include "sdbg_base_mach.hxx"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -70,45 +70,33 @@ extern "C" {
 /*!
     Default constructor.
 */
-template <typename NATIVE_RS,typename VA,typename WT>
-register_set_base_t<NATIVE_RS,VA,WT>::register_set_base_t ()
-  :  offset_in_user(0), rs_ptr(0), writable_mask(0)
-{
+template <typename NATIVE_RS, typename VA, typename WT>
+register_set_base_t<NATIVE_RS, VA, WT>::register_set_base_t()
+    : offset_in_user(0), rs_ptr(0), writable_mask(0) {}
 
+template <typename NATIVE_RS, typename VA, typename WT>
+register_set_base_t<NATIVE_RS, VA, WT>::register_set_base_t(const int offset)
+    : rs_ptr(0), writable_mask(0) {
+  offset_in_user = offset;
 }
 
-
-template <typename NATIVE_RS,typename VA,typename WT>
-register_set_base_t<NATIVE_RS,VA,WT>::register_set_base_t 
-(const int offset) : rs_ptr(0), writable_mask(0)
-{
-  offset_in_user = offset; 
-}
-
-
-template <typename NATIVE_RS,typename VA,typename WT>
-register_set_base_t<NATIVE_RS,VA,WT>::register_set_base_t
-(const register_set_base_t<NATIVE_RS,VA,WT> &r)
-{
+template <typename NATIVE_RS, typename VA, typename WT>
+register_set_base_t<NATIVE_RS, VA, WT>::register_set_base_t(
+    const register_set_base_t<NATIVE_RS, VA, WT>& r) {
   memcpy(&rs, &(r.rs), sizeof(NATIVE_RS));
-  offset_in_user = r.offset_in_user;  
+  offset_in_user = r.offset_in_user;
   rs_ptr = &rs + (r.rs_ptr - &(r.rs));
-  writable_mask = r.writable_mask; 
+  writable_mask = r.writable_mask;
 }
 
-
-template <typename NATIVE_RS,typename VA,typename WT>
-register_set_base_t<NATIVE_RS,VA,WT>::~register_set_base_t ()
-{
+template <typename NATIVE_RS, typename VA, typename WT>
+register_set_base_t<NATIVE_RS, VA, WT>::~register_set_base_t() {
   // Nothing to destroy
-}  
+}
 
-
-template <typename NATIVE_RS,typename VA,typename WT>
-register_set_base_t<NATIVE_RS,VA,WT> & 
-register_set_base_t<NATIVE_RS,VA,WT>::operator=
-(const register_set_base_t<NATIVE_RS,VA,WT> &rhs)
-{
+template <typename NATIVE_RS, typename VA, typename WT>
+register_set_base_t<NATIVE_RS, VA, WT>& register_set_base_t<NATIVE_RS, VA, WT>::
+operator=(const register_set_base_t<NATIVE_RS, VA, WT>& rhs) {
   memcpy(&rs, &(rhs.rs), sizeof(NATIVE_RS));
   offset_in_user = rhs.offset_in_user;
   rs_ptr = &rs + (rhs.rs_ptr - &(rhs.rs));
@@ -117,17 +105,14 @@ register_set_base_t<NATIVE_RS,VA,WT>::operator=
   return *this;
 }
 
-
 //! PUBLIC:  size_in_word
 /*!
-   
-*/
-template <typename NATIVE_RS,typename VA,typename WT>
-unsigned int register_set_base_t<NATIVE_RS,VA,WT>::size_in_word()
-{
-  return (sizeof(NATIVE_RS)/sizeof(WT));
-}
 
+*/
+template <typename NATIVE_RS, typename VA, typename WT>
+unsigned int register_set_base_t<NATIVE_RS, VA, WT>::size_in_word() {
+  return (sizeof(NATIVE_RS) / sizeof(WT));
+}
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -137,31 +122,28 @@ unsigned int register_set_base_t<NATIVE_RS,VA,WT>::size_in_word()
 
 //! PRIVATE
 /*!
-    
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::thread_base_t(const thread_base_t &t)
-{
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::thread_base_t(const thread_base_t& t) {
   master_thread = t.master_thread;
   master_pid = t.master_pid;
   state = t.state;
   //
-  // Don't copy GPR/FPR set 
+  // Don't copy GPR/FPR set
   //
   gprset = NULL;
   fprset = NULL;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM> &
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
-(const thread_base_t &rhs)
-{
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>& thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::
+operator=(const thread_base_t& rhs) {
   master_thread = rhs.master_thread;
   master_pid = rhs.master_pid;
   state = rhs.state;
   //
-  // Don't copy GPR/FPR set 
+  // Don't copy GPR/FPR set
   //
   gprset = NULL;
   fprset = NULL;
@@ -177,147 +159,115 @@ thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
 
 //! PUBLIC: constructors and destructor
 /*!
-    
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::thread_base_t() 
-  : master_thread(false), 
-    traced(false),
-    event_registered(false),
-    master_pid(0),
-    state(LMON_RM_CREATED),
-    gprset(NULL), 
-    fprset(NULL)
-{
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::thread_base_t()
+    : master_thread(false),
+      traced(false),
+      event_registered(false),
+      master_pid(0),
+      state(LMON_RM_CREATED),
+      gprset(NULL),
+      fprset(NULL) {
   /* notice the newly created thread gets the LMON_RM_CREATED state */
   /* more init ? */
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::~thread_base_t() 
-{
-  if (gprset)
-    delete gprset;
- 
-  if (fprset)
-    delete fprset;
-}
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::~thread_base_t() {
+  if (gprset) delete gprset;
 
+  if (fprset) delete fprset;
+}
 
 //! PUBLIC: accessors
 /*!
-    
+
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-register_set_base_t<GRS,VA,WT>* 
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_gprset()
-{
+register_set_base_t<GRS, VA, WT>*
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_gprset() {
   return gprset;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_gprset
-( register_set_base_t<GRS,VA,WT>* g )
-{
+void thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_gprset(
+    register_set_base_t<GRS, VA, WT>* g) {
   gprset = g;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-register_set_base_t<FRS,VA,WT>* 
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_fprset()
-{
+register_set_base_t<FRS, VA, WT>*
+thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_fprset() {
   return fprset;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_fprset
-(register_set_base_t<FRS,VA,WT>* f)
-{
+void thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_fprset(
+    register_set_base_t<FRS, VA, WT>* f) {
   fprset = f;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-NT& 
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_thread_info()
-{
+NT& thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_thread_info() {
   return thread_info;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::copy_thread_info(const NT &ct)
-{
-  memcpy(&thread_info, &ct, sizeof(ct)); 
+void thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::copy_thread_info(const NT& ct) {
+  memcpy(&thread_info, &ct, sizeof(ct));
 }
 
 //! PUBLIC: check_transition:
 /*!
-    It checks the validity of the state transition: is valid to 
+    It checks the validity of the state transition: is valid to
     transition from the current state state to the new state e?
     Returns true if valid; otherwise false.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_transition(lwp_state_e s)
-{
+bool thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_transition(lwp_state_e s) {
   bool rc = false;
 
-  switch (state)
-    {
-    case LMON_RM_CREATED:
-      {
-        //
-        // if the state is CREATED, transition can go anywhere else
-        //
-        if (s != LMON_RM_CREATED)
-          rc = true;
+  switch (state) {
+    case LMON_RM_CREATED: {
+      //
+      // if the state is CREATED, transition can go anywhere else
+      //
+      if (s != LMON_RM_CREATED) rc = true;
 
-        break;
-      }
-    case LMON_RM_RUNNING:
-      {
-        //
-        // if the state is RUNNINGD, the transition should be either
-        // STOPPED or EXITED
-        //
-        if ((s == LMON_RM_STOPPED) || (s == LMON_RM_EXITED))
-          rc = true; 
-
-        break;
-      }
-    case LMON_RM_STOPPED:
-      {
-        //
-        // if the state is STOPPED, the transition should be either back to 
-        // RUNNING or EXITED
-        //
-        if ((s == LMON_RM_RUNNING) || (s == LMON_RM_EXITED))
-          rc = true; 
-
-        break; 
-      }
-    case LMON_RM_EXITED:
-      {
-        //
-        // if the state is EXITED, no transition should happened
-        //
-        rc = false;
-        break;
-      }
-    default:
-      {
-        rc = false;
-        break; 
-      }
+      break;
     }
+    case LMON_RM_RUNNING: {
+      //
+      // if the state is RUNNINGD, the transition should be either
+      // STOPPED or EXITED
+      //
+      if ((s == LMON_RM_STOPPED) || (s == LMON_RM_EXITED)) rc = true;
+
+      break;
+    }
+    case LMON_RM_STOPPED: {
+      //
+      // if the state is STOPPED, the transition should be either back to
+      // RUNNING or EXITED
+      //
+      if ((s == LMON_RM_RUNNING) || (s == LMON_RM_EXITED)) rc = true;
+
+      break;
+    }
+    case LMON_RM_EXITED: {
+      //
+      // if the state is EXITED, no transition should happened
+      //
+      rc = false;
+      break;
+    }
+    default: {
+      rc = false;
+      break;
+    }
+  }
 
   return rc;
 }
@@ -328,21 +278,18 @@ thread_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_transition(lwp_state_e s)
 //
 ///////////////////////////////////////////////////////////////////
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t 
-(const process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) 
-{
-  //making this private so that process object cannot be copied
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t(
+    const process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p) {
+  // making this private so that process object cannot be copied
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM> &
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
-(const process_base_t<SDBG_DEFAULT_TEMPLPARAM> &rhs) 
-{
-  //making this private so that process object cannot be copied
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>&
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=(
+    const process_base_t<SDBG_DEFAULT_TEMPLPARAM>& rhs) {
+  // making this private so that process object cannot be copied
   return *this;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -355,22 +302,21 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::operator=
     Default constructor.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t () 
-  : never_trapped(true), 
-    please_detach(false),
-    please_kill(false),
-    reason(reserved_for_rent),
-    myimage(NULL), 
-    mydynloader_image(NULL),  
-    mythread_lib_image(NULL),
-    mylibc_image(NULL),
-    myrmso_image(NULL),
-    myopts(NULL),
-    launch_hidden_bp(NULL),
-    loader_hidden_bp(NULL),
-    sym_attach_fifo(NULL),
-    new_child_pid(0) 
-{ 
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t()
+    : never_trapped(true),
+      please_detach(false),
+      please_kill(false),
+      reason(reserved_for_rent),
+      myimage(NULL),
+      mydynloader_image(NULL),
+      mythread_lib_image(NULL),
+      mylibc_image(NULL),
+      myrmso_image(NULL),
+      myopts(NULL),
+      launch_hidden_bp(NULL),
+      loader_hidden_bp(NULL),
+      sym_attach_fifo(NULL),
+      new_child_pid(0) {
   /* more init ? */
 }
 
@@ -379,11 +325,11 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t ()
     Default constructor with path info
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t 
-( const std::string &mi, const std::string &md,
-  const std::string &mt, const std::string &mc )
-{
-  protected_init( mi, md, mt, mc );
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t(const std::string& mi,
+                                                        const std::string& md,
+                                                        const std::string& mt,
+                                                        const std::string& mc) {
+  protected_init(mi, md, mt, mc);
 }
 
 //! PUBLIC: ~process_base_t
@@ -391,43 +337,32 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::process_base_t
     Destructor of the process_base_t class
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::~process_base_t ()
-{
-  if (myimage)
-    delete myimage;
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::~process_base_t() {
+  if (myimage) delete myimage;
 
-  if (mydynloader_image)
-    delete mydynloader_image;
+  if (mydynloader_image) delete mydynloader_image;
 
-  if (mythread_lib_image)
-    delete mythread_lib_image;
+  if (mythread_lib_image) delete mythread_lib_image;
 
-  if (mylibc_image)
-    delete mylibc_image;
+  if (mylibc_image) delete mylibc_image;
 
-  if (mylibc_image)
-    delete myrmso_image;
+  if (mylibc_image) delete myrmso_image;
 
-  if (launch_hidden_bp)
-    delete launch_hidden_bp;
+  if (launch_hidden_bp) delete launch_hidden_bp;
 
-  if (loader_hidden_bp)
-    delete loader_hidden_bp;	
+  if (loader_hidden_bp) delete loader_hidden_bp;
 
-  if (sym_attach_fifo)
-    delete sym_attach_fifo;
+  if (sym_attach_fifo) delete sym_attach_fifo;
 
-  if (!thrlist.empty())
-    {
-      //
-      // this should call destructors for each containing thread obj 
-      //
-      for (thr_iter = thrlist.begin(); thr_iter != thrlist.end(); ++thr_iter)
-        {
-          delete thr_iter->second;
-        }
-      thrlist.clear();
+  if (!thrlist.empty()) {
+    //
+    // this should call destructors for each containing thread obj
+    //
+    for (thr_iter = thrlist.begin(); thr_iter != thrlist.end(); ++thr_iter) {
+      delete thr_iter->second;
     }
+    thrlist.clear();
+  }
 }
 
 //! PUBLIC: process_base_t
@@ -436,25 +371,20 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::~process_base_t ()
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 std::map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr>&
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_thrlist()
-{
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_thrlist() {
   return thrlist;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-const pid_t 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_master_thread_pid()
-{
+const pid_t process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_master_thread_pid() {
   using namespace std;
 
-  typename
-    map<int,thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,ltstr>::const_iterator
-      tpos;
-  for (tpos=thrlist.begin(); tpos!=thrlist.end(); tpos++)
-    {
-      if (tpos->second->is_master_thread())
-	return (tpos->second->get_master_pid());
-    }
+  typename map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,
+               ltstr>::const_iterator tpos;
+  for (tpos = thrlist.begin(); tpos != thrlist.end(); tpos++) {
+    if (tpos->second->is_master_thread())
+      return (tpos->second->get_master_pid());
+  }
 
   //
   // this means, above operation couldn't find the master thread
@@ -462,143 +392,120 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_master_thread_pid()
   return -1;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::debug_iter_thrlist()
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::debug_iter_thrlist() {
   using namespace std;
-  int i=0;
-  typename
-    map<int,thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,ltstr>::const_iterator
-      tpos;
-  cout << "+++++++++++++++debug_iter_thrlist called" << endl; 
-  for (tpos=thrlist.begin(); tpos!=thrlist.end(); tpos++)
-    {
-      cout << "(" << i << ")" << endl;
-      if (tpos->second->is_master_thread())
-        {
-          cout << "Main thread" << endl; 
-        }
-      cout << "ti_lid: " << tpos->second->get_thread_info().ti_lid << "| ";
-      cout << "ti_pri: " << tpos->second->get_thread_info().ti_pri << "| ";
-      cout << "ti_ta_p: " << tpos->second->get_thread_info().ti_ta_p << "| ";
-      cout << "ti_tid: " << tpos->second->get_thread_info().ti_tid << "| ";
-      cout << "+++++++++++++++" << endl; 
-      i++;
+  int i = 0;
+  typename map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,
+               ltstr>::const_iterator tpos;
+  cout << "+++++++++++++++debug_iter_thrlist called" << endl;
+  for (tpos = thrlist.begin(); tpos != thrlist.end(); tpos++) {
+    cout << "(" << i << ")" << endl;
+    if (tpos->second->is_master_thread()) {
+      cout << "Main thread" << endl;
     }
-
+    cout << "ti_lid: " << tpos->second->get_thread_info().ti_lid << "| ";
+    cout << "ti_pri: " << tpos->second->get_thread_info().ti_pri << "| ";
+    cout << "ti_ta_p: " << tpos->second->get_thread_info().ti_ta_p << "| ";
+    cout << "ti_tid: " << tpos->second->get_thread_info().ti_tid << "| ";
+    cout << "+++++++++++++++" << endl;
+    i++;
+  }
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-image_base_t<VA,EXECHANDLER> * 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_myimage ()
-{
+image_base_t<VA, EXECHANDLER>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_myimage() {
   return myimage;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-image_base_t<VA,EXECHANDLER> * 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mydynloader_image ()
-{
+image_base_t<VA, EXECHANDLER>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mydynloader_image() {
   return mydynloader_image;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-image_base_t<VA,EXECHANDLER> * 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mythread_lib_image ()
-{
+image_base_t<VA, EXECHANDLER>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mythread_lib_image() {
   return mythread_lib_image;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-image_base_t<VA,EXECHANDLER> *
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mylibc_image ()
-{
+image_base_t<VA, EXECHANDLER>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_mylibc_image() {
   return mylibc_image;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-image_base_t<VA,EXECHANDLER> *
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_myrmso_image ()
-{
+image_base_t<VA, EXECHANDLER>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_myrmso_image() {
   return myrmso_image;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-breakpoint_base_t<VA,IT> * 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_launch_hidden_bp ()
-{
+breakpoint_base_t<VA, IT>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_launch_hidden_bp() {
   return launch_hidden_bp;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-breakpoint_base_t<VA,IT> * 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_loader_hidden_bp ()
-{
+breakpoint_base_t<VA, IT>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_loader_hidden_bp() {
   return loader_hidden_bp;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-const symbol_base_t<VA> *
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_sym_attach_fifo ()
-{
+const symbol_base_t<VA>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_sym_attach_fifo() {
   return sym_attach_fifo;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_myimage 
-(image_base_t<VA,EXECHANDLER>* i)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_myimage(
+    image_base_t<VA, EXECHANDLER>* i) {
   myimage = i;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mydynloader_image 
-(image_base_t<VA,EXECHANDLER>* i)
-{
-  mydynloader_image = i; 
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mydynloader_image(
+    image_base_t<VA, EXECHANDLER>* i) {
+  mydynloader_image = i;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mythread_lib_image 
-(image_base_t<VA,EXECHANDLER>* i)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mythread_lib_image(
+    image_base_t<VA, EXECHANDLER>* i) {
   mythread_lib_image = i;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mylibc_image
-(image_base_t<VA,EXECHANDLER>* i)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_mylibc_image(
+    image_base_t<VA, EXECHANDLER>* i) {
   mylibc_image = i;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_myrmso_image
-(image_base_t<VA,EXECHANDLER>* i)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_myrmso_image(
+    image_base_t<VA, EXECHANDLER>* i) {
   myrmso_image = i;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_launch_hidden_bp
-(breakpoint_base_t<VA,IT>* b)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_launch_hidden_bp(
+    breakpoint_base_t<VA, IT>* b) {
   launch_hidden_bp = b;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-  void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_loader_hidden_bp
-(breakpoint_base_t<VA,IT>* b)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_loader_hidden_bp(
+    breakpoint_base_t<VA, IT>* b) {
   loader_hidden_bp = b;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_sym_attach_fifo
-(symbol_base_t<VA>* o)
-{
+void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_sym_attach_fifo(
+    symbol_base_t<VA>* o) {
   sym_attach_fifo = o;
 }
 
@@ -609,46 +516,34 @@ void process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_sym_attach_fifo
     of the current focus thread; otherwise pid of the process.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-const pid_t
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_pid ( bool context_sensitive )
-{
+const pid_t process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_pid(
+    bool context_sensitive) {
   pid_t retpid = THREAD_KEY_INVALID;
-  if (context_sensitive) 
-    {
-      if (new_child_pid != 0)
-        {
-          retpid = new_child_pid;
-        }
-      else
-        {
-          if (thread_ctx_stack.empty())
-	    {
-	      retpid = THREAD_KEY_INVALID;
-	    }
+  if (context_sensitive) {
+    if (new_child_pid != 0) {
+      retpid = new_child_pid;
+    } else {
+      if (thread_ctx_stack.empty()) {
+        retpid = THREAD_KEY_INVALID;
+      }
 
-          if ( thrlist.find(thread_ctx_stack.top()) != thrlist.end() )
-	    {
-	      retpid = thrlist.find(thread_ctx_stack.top())->second->thr2pid();
-	    }
-        }
+      if (thrlist.find(thread_ctx_stack.top()) != thrlist.end()) {
+        retpid = thrlist.find(thread_ctx_stack.top())->second->thr2pid();
+      }
     }
-  else
-    {
-      retpid = get_master_thread_pid();
-    }
+  } else {
+    retpid = get_master_thread_pid();
+  }
 
   return retpid;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-int
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_cur_thread_ctx ()
-{
+int process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_cur_thread_ctx() {
   int rc = THREAD_KEY_INVALID;
-  if (!thread_ctx_stack.empty())
-    {
-      rc = thread_ctx_stack.top();
-    }
+  if (!thread_ctx_stack.empty()) {
+    rc = thread_ctx_stack.top();
+  }
 
   return rc;
 }
@@ -658,30 +553,24 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_cur_thread_ctx ()
     push a new thread context
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::make_context ( const int key )
-{
+bool process_base_t<SDBG_DEFAULT_TEMPLPARAM>::make_context(const int key) {
   using namespace std;
 
   bool rc = false;
   string e;
   string func = "[process_base_t::make_context]";
 
-  if ( thrlist.find(key) != thrlist.end() ) 
-    {
-      thread_ctx_stack.push(key);
-      rc = true;
-    }
-  else if ( new_child_pid == 0)
-    {
-      new_child_pid = key;
-    }
-  else
-    {
-      e = func + 
-	"no thread with the key value found and new child pid is already being used";
-      throw (machine_exception_t(e));
-    }
+  if (thrlist.find(key) != thrlist.end()) {
+    thread_ctx_stack.push(key);
+    rc = true;
+  } else if (new_child_pid == 0) {
+    new_child_pid = key;
+  } else {
+    e = func +
+        "no thread with the key value found and new child pid is already being "
+        "used";
+    throw(machine_exception_t(e));
+  }
 
   return rc;
 }
@@ -691,18 +580,16 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::make_context ( const int key )
     set the lwp state of the current focus thread
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-lwp_state_e
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_lwp_state (bool use_cxt)
-{
+lwp_state_e process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_lwp_state(
+    bool use_cxt) {
   lwp_state_e rstate = LMON_RM_EXITED;
 
   bool rc = true;
   int lwpid = get_pid(use_cxt);
 
-  if (thrlist.find(lwpid) != thrlist.end())
-    {
-      rstate = thrlist[lwpid]->get_state();
-    }
+  if (thrlist.find(lwpid) != thrlist.end()) {
+    rstate = thrlist[lwpid]->get_state();
+  }
 
   return rstate;
 }
@@ -712,21 +599,15 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_lwp_state (bool use_cxt)
     set the lwp state of the current focus thread
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lwp_state
-( lwp_state_e s, bool use_cxt )
-{
+bool process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lwp_state(lwp_state_e s,
+                                                            bool use_cxt) {
   bool rc = true;
   int lwpid = get_pid(use_cxt);
-  //std::cout << "about to make a transition" << std::endl;
-  if (thrlist.find(lwpid) != thrlist.end())
-    {
-      //std::cout << "this is from " << (int) thrlist[lwpid]->get_state() << " to " << (int) s << std::endl;
-      if (!thrlist[lwpid]->check_transition(s)) 
-        {
+  if (thrlist.find(lwpid) != thrlist.end()) {
+    if (!thrlist[lwpid]->check_transition(s)) {
 #if 0
           //
-          // many illegal transitions will be there because this 
+          // many illegal transitions will be there because this
           // processes the head event in the waitpid queue... which can be out of order
           //
           self_trace_t::trace ( true,
@@ -734,14 +615,11 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lwp_state
               "illegal transition of thread state for %d from %d to %d",
               lwpid, (int) thrlist[lwpid]->get_state(), (int)s);
 #endif
-        }
-      thrlist[lwpid]->set_state(s);
     }
-  else
-    {
-      //std::cout << "I can't find this thread" << std::endl;
-      rc = false;
-    }
+    thrlist[lwpid]->set_state(s);
+  } else {
+    rc = false;
+  }
 
   return rc;
 }
@@ -751,33 +629,25 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::set_lwp_state
     Pops the current thread context
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_and_undo_context ( const int key )
-{
+bool process_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_and_undo_context(
+    const int key) {
   using namespace std;
 
   bool rc = false;
   string e;
   string func = "[process_base_t::check_and_undo_context]";
-  if (new_child_pid == key)
-    {
-      new_child_pid = 0;
+  if (new_child_pid == key) {
+    new_child_pid = 0;
+    rc = true;
+  } else {
+    if (!thread_ctx_stack.empty() && (thread_ctx_stack.top() == key)) {
+      thread_ctx_stack.pop();
       rc = true;
+    } else {
+      e = func + "thread_ctx_stack.top() is different from the passed key";
+      throw(machine_exception_t(e));
     }
-  else
-    {
-      if (!thread_ctx_stack.empty() && (thread_ctx_stack.top() == key)) 
-        {
-          thread_ctx_stack.pop();
-          rc = true;
-        }
-      else 
-        {
-          e = func + 
-	    "thread_ctx_stack.top() is different from the passed key";
-          throw (machine_exception_t(e));
-        }
-    }
+  }
   return rc;
 }
 
@@ -786,36 +656,25 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::check_and_undo_context ( const int key 
     get_gprset
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-register_set_base_t<GRS,VA,WT>* 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_gprset
-( bool context_sensitive )
-{
+register_set_base_t<GRS, VA, WT>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_gprset(bool context_sensitive) {
   using namespace std;
-  typename
-    map<int,thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,ltstr>::const_iterator
-      tpos;
+  typename map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,
+               ltstr>::const_iterator tpos;
 
-  if (context_sensitive) 
-    {
-      if (thread_ctx_stack.empty()) 
-	{ 
-	  return NULL;
-	}
-      else if ( thrlist.find(thread_ctx_stack.top()) != thrlist.end() ) 
-	{
-	  return (thrlist.find(thread_ctx_stack.top())->second->get_gprset());
-	}
+  if (context_sensitive) {
+    if (thread_ctx_stack.empty()) {
+      return NULL;
+    } else if (thrlist.find(thread_ctx_stack.top()) != thrlist.end()) {
+      return (thrlist.find(thread_ctx_stack.top())->second->get_gprset());
     }
-  else 
-    {
-      for (tpos=thrlist.begin(); tpos!=thrlist.end(); tpos++) 
-	{
-	  if (tpos->second->is_master_thread()) 
-	    {
-	      return (tpos->second->get_gprset());
-	    }
-	}
+  } else {
+    for (tpos = thrlist.begin(); tpos != thrlist.end(); tpos++) {
+      if (tpos->second->is_master_thread()) {
+        return (tpos->second->get_gprset());
+      }
     }
+  }
 
   return NULL;
 }
@@ -825,38 +684,27 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_gprset
     get_gprset
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-register_set_base_t<FRS,VA,WT>* 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_fprset ( bool context_sensitive )
-{
+register_set_base_t<FRS, VA, WT>*
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_fprset(bool context_sensitive) {
   using namespace std;
 
-  typename
-    map<int,thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,ltstr>::const_iterator
-    tpos;
+  typename map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*,
+               ltstr>::const_iterator tpos;
 
-  if (context_sensitive) 
-    {
-      if ( thread_ctx_stack.empty() )
-        { 	
-	  return NULL;
-        }
-      else if ( thrlist.find(thread_ctx_stack.top()) != thrlist.end() )
-        {
-	  return (thrlist.find(thread_ctx_stack.top())->second->get_fprset());   
-        }
+  if (context_sensitive) {
+    if (thread_ctx_stack.empty()) {
+      return NULL;
+    } else if (thrlist.find(thread_ctx_stack.top()) != thrlist.end()) {
+      return (thrlist.find(thread_ctx_stack.top())->second->get_fprset());
     }
-  else 
-    {
-      for (tpos=thrlist.begin(); tpos!=thrlist.end(); tpos++) 
-	{
-	  if (tpos->second->is_master_thread())
-	    return (tpos->second->get_fprset());
-	}
+  } else {
+    for (tpos = thrlist.begin(); tpos != thrlist.end(); tpos++) {
+      if (tpos->second->is_master_thread()) return (tpos->second->get_fprset());
     }
+  }
 
   return NULL;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -864,91 +712,73 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::get_fprset ( bool context_sensitive )
 //
 ///////////////////////////////////////////////////////////////////
 
-//! PROTECTED: protected_init 
+//! PROTECTED: protected_init
 /*!
     DEPRECATED!
     protected_init: This should really be something that should
     be handled by this base layer. But we don't want
     a component other than its derived class calls this
-    to initialize things. Hence, protected. 
+    to initialize things. Hence, protected.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::protected_init 
-( const std::string &mi, const std::string &md,
-  const std::string &mt, const std::string &mc)
-{
-  try
-    {
-      bool rc = true;
+bool process_base_t<SDBG_DEFAULT_TEMPLPARAM>::protected_init(
+    const std::string& mi, const std::string& md, const std::string& mt,
+    const std::string& mc) {
+  try {
+    bool rc = true;
 
-      //
-      // init the main RM image 
-      //
-      if (myimage) 
-	{
-	  myimage->init();
-	  myimage->read_linkage_symbols();
-	}
-      else
-        {
-	  rc = false;
-        }
-
-      //
-      // init the dynamic linker image 
-      //
-      if (mydynloader_image) 
-	{
-	  mydynloader_image->init();
-	  mydynloader_image->read_linkage_symbols();
-	}
-      else
-        {
-	  rc = false;
-        }
-
-      //
-      // POSIX thread library image 
-      //
-      if (mythread_lib_image)	
-	{
-	  mythread_lib_image->init();
-	  mythread_lib_image->read_linkage_symbols();
-	}
-      else
-        {
-	  rc = false;
-        }
-
-      //
-      // LIBC library image 
-      //
-      if (mylibc_image) 
-	{
-	  mylibc_image->init();
-	  mylibc_image->read_linkage_symbols();
-	}
-      else
-        {
-	  rc = false;
-        } 
-
-
-      //
-      // If any of above failed, false is returned.
-      //
-      return rc;
+    //
+    // init the main RM image
+    //
+    if (myimage) {
+      myimage->init();
+      myimage->read_linkage_symbols();
+    } else {
+      rc = false;
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      //
-      // I don't know how to recover from a symtab exception... 
-      // aborting...
-      //
-      abort();
+
+    //
+    // init the dynamic linker image
+    //
+    if (mydynloader_image) {
+      mydynloader_image->init();
+      mydynloader_image->read_linkage_symbols();
+    } else {
+      rc = false;
     }
+
+    //
+    // POSIX thread library image
+    //
+    if (mythread_lib_image) {
+      mythread_lib_image->init();
+      mythread_lib_image->read_linkage_symbols();
+    } else {
+      rc = false;
+    }
+
+    //
+    // LIBC library image
+    //
+    if (mylibc_image) {
+      mylibc_image->init();
+      mylibc_image->read_linkage_symbols();
+    } else {
+      rc = false;
+    }
+
+    //
+    // If any of above failed, false is returned.
+    //
+    return rc;
+  } catch (symtab_exception_t e) {
+    e.report();
+    //
+    // I don't know how to recover from a symtab exception...
+    // aborting...
+    //
+    abort();
+  }
 }
 
 //! PROTECTED: process_base_t::protected_init
@@ -956,61 +786,52 @@ process_base_t<SDBG_DEFAULT_TEMPLPARAM>::protected_init
     protected_init: This should really be something that should
     be handled by this base layer. But we don't want
     a component other than its derived class calls this
-    to initialize things. Hence, protected. 
+    to initialize things. Hence, protected.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-process_base_t<SDBG_DEFAULT_TEMPLPARAM>::protected_init 
-( const std::string & mi )
-{
-  try
-    {
-      using namespace std;
+bool process_base_t<SDBG_DEFAULT_TEMPLPARAM>::protected_init(
+    const std::string& mi) {
+  try {
+    using namespace std;
 
-      bool rc = true;
-      string loader_loc;
-      bool found_interp = false;
+    bool rc = true;
+    string loader_loc;
+    bool found_interp = false;
 
-      //
-      // init the main RM image 
-      //
-      if (myimage) 
-	{
-	  myimage->init();
-	  myimage->read_linkage_symbols();
+    //
+    // init the main RM image
+    //
+    if (myimage) {
+      myimage->init();
+      myimage->read_linkage_symbols();
 
-	  myimage->fetch_DSO_info ( loader_loc, found_interp );
-	}
-      else
-        {
-	  rc = false;
-        }
-
-  
-      //
-      // init the dynamic linker image 
-      //
-      if (found_interp && mydynloader_image) 
-	{
-	  mydynloader_image->init(loader_loc);
-	  mydynloader_image->read_linkage_symbols();
-	}
-      else
-        {
-	  rc = false;
-        }
-
-      return rc;
+      myimage->fetch_DSO_info(loader_loc, found_interp);
+    } else {
+      rc = false;
     }
-  catch ( symtab_exception_t e ) 
-    {
-      e.report();
-      //
-      // I don't know how to recover from a symtab exception... 
-      // aborting...
-      //
-      abort();
+
+    //
+    // init the dynamic linker image
+    //
+    if (found_interp && mydynloader_image) {
+      mydynloader_image->init(loader_loc);
+      mydynloader_image->read_linkage_symbols();
+    } else {
+      rc = false;
     }
+
+    return rc;
+  } catch (symtab_exception_t e) {
+    e.report();
+    //
+    // I don't know how to recover from a symtab exception...
+    // aborting...
+    //
+    abort();
+  }
 }
-#endif // SDBG_BASE_MACH_IMPL_HXX
+#endif  // SDBG_BASE_MACH_IMPL_HXX
 
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_spawner.hxx
+++ b/launchmon/src/sdbg_base_spawner.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *
  *
  *  Update Log:
  *        Jul 02 2010 DHA: Created file.
@@ -33,142 +33,131 @@
 #ifndef SDBG_BASE_SPAWNER_HXX
 #define SDBG_BASE_SPAWNER_HXX 1
 
-#include "sdbg_std.hxx"
 #include <string>
 #include <vector>
+#include "sdbg_std.hxx"
 
-const char LMON_HOST_DELIM[]=":";
+const char LMON_HOST_DELIM[] = ":";
 
-class spawner_base_t
-{
-public:
+class spawner_base_t {
+ public:
   ////////////////////////////////////////////////////////////
   //
   //  Public Interfaces
   //
-  spawner_base_t()
-    {
-      // Empty
-    }
+  spawner_base_t() {
+    // Empty
+  }
 
   spawner_base_t(const std::string &rac,
-		 const std::vector<std::string> &racargs)
-    {
-      //
-      // Copy remote access command like rsh
-      //
-      remote_launch_cmd = rac;
+                 const std::vector<std::string> &racargs) {
+    //
+    // Copy remote access command like rsh
+    //
+    remote_launch_cmd = rac;
 
-      //
-      // Copy remote access command arguments
-      //
-      launch_cmd_args = racargs;
-    }
-
-  spawner_base_t(const std::string &rac,
-		 const std::vector<std::string> &racargs,
-		 const std::string &dpath,
-		 const std::vector<std::string> &dmonopts)
-    {
-      //
-      // Copy remote access command like rsh
-      //
-      remote_launch_cmd = rac;
-
-      //
-      // Copy remote access command arguments
-      //
-      launch_cmd_args = racargs;
-
-      //
-      // Copy daemon path
-      //
-      daemon_path = dpath;
-
-      //
-      // Copy daemon args
-      //
-      daemon_args = dmonopts;
-    }
+    //
+    // Copy remote access command arguments
+    //
+    launch_cmd_args = racargs;
+  }
 
   spawner_base_t(const std::string &rac,
-		 const std::vector<std::string> & racargs,
-		 const std::string &dpath,
-		 const std::vector<std::string> &dmonopts,
-		 const std::vector<std::string> &hosts)
-    {
-      //
-      // Copy remote access command like rsh
-      //
-      remote_launch_cmd = rac;
+                 const std::vector<std::string> &racargs,
+                 const std::string &dpath,
+                 const std::vector<std::string> &dmonopts) {
+    //
+    // Copy remote access command like rsh
+    //
+    remote_launch_cmd = rac;
 
-      //
-      // Copy remote access command arguments
-      //
-      launch_cmd_args = racargs;
+    //
+    // Copy remote access command arguments
+    //
+    launch_cmd_args = racargs;
 
-      //
-      // Copy daemon path
-      //
-      daemon_path = dpath;
+    //
+    // Copy daemon path
+    //
+    daemon_path = dpath;
 
-      //
-      // Copy daemon args
-      //
-      daemon_args = dmonopts;
+    //
+    // Copy daemon args
+    //
+    daemon_args = dmonopts;
+  }
 
-      //
-      // Copy hosts: the semantics of vector to vector assignment is deep copy.
-      // Note that though, a vector element is string which does "deep copy"
-      // on write so you may see the same c_str poiner addresses between src and dest.
-      // Bottom line: this is safe.
-      //
-      m_hosts = hosts;
+  spawner_base_t(const std::string &rac,
+                 const std::vector<std::string> &racargs,
+                 const std::string &dpath,
+                 const std::vector<std::string> &dmonopts,
+                 const std::vector<std::string> &hosts) {
+    //
+    // Copy remote access command like rsh
+    //
+    remote_launch_cmd = rac;
+
+    //
+    // Copy remote access command arguments
+    //
+    launch_cmd_args = racargs;
+
+    //
+    // Copy daemon path
+    //
+    daemon_path = dpath;
+
+    //
+    // Copy daemon args
+    //
+    daemon_args = dmonopts;
+
+    //
+    // Copy hosts: the semantics of vector to vector assignment is deep copy.
+    // Note that though, a vector element is string which does "deep copy"
+    // on write so you may see the same c_str poiner addresses between src and
+    // dest.
+    // Bottom line: this is safe.
+    //
+    m_hosts = hosts;
+  }
+
+  virtual ~spawner_base_t() {
+    if (!launch_cmd_args.empty()) {
+      launch_cmd_args.clear();
     }
 
-  virtual ~spawner_base_t()
-    {
-      if (!launch_cmd_args.empty())
-        {
-	  launch_cmd_args.clear();
-        }
-
-      if (daemon_args.empty())
-        {
-	  daemon_args.clear();
-        }
-
-      if (m_hosts.empty())
-        {
-	  m_hosts.clear();
-        }
+    if (daemon_args.empty()) {
+      daemon_args.clear();
     }
+
+    if (m_hosts.empty()) {
+      m_hosts.clear();
+    }
+  }
 
   //
   // Method that starts remote process spawning
   //  platform-specific derive class must implment this method.
-  //  Its role is simply spawn the daemon executable to a set of 
-  //  hosts -- a simple hostlist, colocation with BE daemons, 
+  //  Its role is simply spawn the daemon executable to a set of
+  //  hosts -- a simple hostlist, colocation with BE daemons,
   //           existing or newly-allocated set of hosts
-  virtual bool spawn()                                          = 0;
+  virtual bool spawn() = 0;
 
   //
   // Method that append my hosts to the combined hosts
   //
   //
-  virtual bool combineHosts(std::vector<std::string> &combHosts)
-    {
-      std::vector<std::string>::const_iterator iter;
-      int s = combHosts.size();
+  virtual bool combineHosts(std::vector<std::string> &combHosts) {
+    std::vector<std::string>::const_iterator iter;
+    int s = combHosts.size();
 
-      for (iter = m_hosts.begin(); iter != m_hosts.end(); ++iter)
-        {
-          combHosts.push_back((*iter));
-        }
-
-      return ((combHosts.size() - s) > 0)? true : false;
+    for (iter = m_hosts.begin(); iter != m_hosts.end(); ++iter) {
+      combHosts.push_back((*iter));
     }
 
+    return ((combHosts.size() - s) > 0) ? true : false;
+  }
 
   ////////////////////////////////////////////////////////////
   //
@@ -179,53 +168,41 @@ public:
   define_gset(std::string, command_str)
   define_gset(std::string, err_str)
 
-  std::vector<std::string> & get_hosts_vector()
-    {
-      return m_hosts;
-    }
+  std::vector<std::string> &get_hosts_vector() {
+    return m_hosts;
+  }
 
-  std::vector<std::string> & get_launch_cmd_args()
-    {
-      return launch_cmd_args;
-    }
+  std::vector<std::string> &get_launch_cmd_args() { return launch_cmd_args; }
 
-  std::vector<std::string> & get_daemon_args()
-    {
-      return daemon_args;
-    }
+  std::vector<std::string> &get_daemon_args() { return daemon_args; }
 
   //
   // Adds the hostlist (null-terminated list), hl, to my hostlist
   //   Returns the number of hosts in the hostlist
   //
-  int addHosts(const char *hl[])
-    {
-      int i;
-      int nhosts = m_hosts.size();
-      if (!hl)
-	{
-          return nhosts;
-	}
-
-      for (i=0; hl[i] != NULL; i++)
-        {
-          std::string tmph = hl[i];
-          m_hosts.push_back(tmph);
-        }
-
-      nhosts = m_hosts.size();
+  int addHosts(const char *hl[]) {
+    int i;
+    int nhosts = m_hosts.size();
+    if (!hl) {
       return nhosts;
     }
 
-private:
+    for (i = 0; hl[i] != NULL; i++) {
+      std::string tmph = hl[i];
+      m_hosts.push_back(tmph);
+    }
 
+    nhosts = m_hosts.size();
+    return nhosts;
+  }
+
+ private:
   //
   // Won't allow copying of this object
   //
-  explicit spawner_base_t (const spawner_base_t & s)
-    {
-      // does nothing
-    }
+  explicit spawner_base_t(const spawner_base_t &s) {
+    // does nothing
+  }
 
   std::string remote_launch_cmd;
   std::vector<std::string> launch_cmd_args;
@@ -236,4 +213,8 @@ private:
   std::string err_str;
 };
 
-#endif // SDBG_BASE_SPAWNER_HXX
+#endif  // SDBG_BASE_SPAWNER_HXX
+
+/*
+ * vi: ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_symtab.hxx
+++ b/launchmon/src/sdbg_base_symtab.hxx
@@ -1,55 +1,56 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_symtab.hxx,v 1.4.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
- *        Oct 27 2010 DHA: Added is_defined, is_globally_visible, 
+ *        Oct 27 2010 DHA: Added is_defined, is_globally_visible,
  *                         is_locally_visible virtual methods.
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Mar 30 2006 DHA: Added exception handling support
- *        Feb 08 2006 DHA: Seperated OS dependent components 
+ *        Feb 08 2006 DHA: Seperated OS dependent components
  *                         from this file
- *        Jan 10 2006 DHA: Created file.          
- */ 
+ *        Jan 10 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_BASE_SYMTAB_HXX
 #define SDBG_BASE_SYMTAB_HXX 1
 
 #include <iostream>
-#include <string>
 #include <map>
+#include <string>
 
-#include "sdbg_std.hxx"
-#include "sdbg_self_trace.hxx"
 #include "sdbg_base_exception.hxx"
+#include "sdbg_self_trace.hxx"
+#include "sdbg_std.hxx"
 
 #define BASE_SYMTAB_TEMPLATELIST typename VA
-#define BASE_SYMTAB_TEMPLPARAM   VA
-#define BASE_IMAGE_TEMPLATELIST  typename VA, typename EXECHANDLER
-#define BASE_IMAGE_TEMPLPARAM    VA,EXECHANDLER
+#define BASE_SYMTAB_TEMPLPARAM VA
+#define BASE_IMAGE_TEMPLATELIST typename VA, typename EXECHANDLER
+#define BASE_IMAGE_TEMPLPARAM VA, EXECHANDLER
 
 #if BIT64
 const u_int64_t SYMTAB_UNINIT_ADDR = 0xdeadbeefdeadbeefULL;
@@ -58,87 +59,76 @@ const u_int64_t SYMTAB_INIT_IMAGE_BASE = SYMTAB_UNINIT_ADDR;
 const u_int32_t SYMTAB_UNINIT_ADDR = 0xdeadbeef;
 const u_int32_t SYMTAB_INIT_IMAGE_BASE = SYMTAB_UNINIT_ADDR;
 #endif
-const char * const SYMTAB_UNINIT_STRING = "SDBG-NA";
-
+const char *const SYMTAB_UNINIT_STRING = "SDBG-NA";
 
 //! enum symtab_error_e
 /*!
-    error code enumerator for the symbol table layer. 
-    Populate this structure if you need finer granularity 
+    error code enumerator for the symbol table layer.
+    Populate this structure if you need finer granularity
     for the error detecting.
 */
-enum symtab_error_e {
-  SDBG_SYMTAB_OK,
-  SDBG_SYMTAB_FAILED
-};
- 
+enum symtab_error_e { SDBG_SYMTAB_OK, SDBG_SYMTAB_FAILED };
 
 //! class symtab_exception_t : public exception_base_t
 /*!
     The exception class for symbol table layer
 */
-class symtab_exception_t : public exception_base_t
-{
-public:
+class symtab_exception_t : public exception_base_t {
+ public:
+  symtab_exception_t() {}
+  symtab_exception_t(const char *m, symtab_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_SYMTAB_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
 
-  symtab_exception_t ()                          { }
-  symtab_exception_t ( const char *m, symtab_error_e e )
-                     { set_message (m); 
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_SYMTAB_ERROR" ) ); 
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ ); 
-                      }
-             
-  symtab_exception_t ( const std::string &m, symtab_error_e e )      
-                     { set_message (m); 
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_SYMTAB_ERROR" ) ); 
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ ); 
-                      }
-  virtual ~symtab_exception_t()                  { }
+  symtab_exception_t(const std::string &m, symtab_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_SYMTAB_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
+  virtual ~symtab_exception_t() {}
 
-private:
-  symtab_error_e error_code;  
+ private:
+  symtab_error_e error_code;
 };
-
 
 //! class symbol_base_t<>
 /*!
-    symbol_base_t is the base class from which all kinds of 
+    symbol_base_t is the base class from which all kinds of
     symbol class can be derived.
 */
 template <BASE_SYMTAB_TEMPLATELIST>
-class symbol_base_t
-{
-public:
-  
+class symbol_base_t {
+ public:
   //
   // constructosr & destructor
   //
-  symbol_base_t ();
+  symbol_base_t();
 
-  symbol_base_t ( const std::string &n, 
-		  const std::string &bln, 
-		  const VA rd=SYMTAB_UNINIT_ADDR,
-		  const VA rla=SYMTAB_UNINIT_ADDR);
+  symbol_base_t(const std::string &n, const std::string &bln,
+                const VA rd = SYMTAB_UNINIT_ADDR,
+                const VA rla = SYMTAB_UNINIT_ADDR);
 
-  symbol_base_t ( const symbol_base_t &sobj ); 
+  symbol_base_t(const symbol_base_t &sobj);
 
   virtual ~symbol_base_t();
 
   //
   // accessors
   //
-  void set_name (const std::string &n);
-  void set_base_lib_name (const std::string &bln);
-  void set_raw_address (const VA &ra);
-  void set_relocated_address (const VA &ra); 
-  const std::string & get_name() const;    
-  const std::string & get_base_lib_name() const; 
-  const VA & get_raw_address() const;
-  const VA & get_relocated_address() const;
+  void set_name(const std::string &n);
+  void set_base_lib_name(const std::string &bln);
+  void set_raw_address(const VA &ra);
+  void set_relocated_address(const VA &ra);
+  const std::string &get_name() const;
+  const std::string &get_base_lib_name() const;
+  const VA &get_raw_address() const;
+  const VA &get_relocated_address() const;
 
   virtual bool is_defined() const { return false; }
   virtual bool is_globally_visible() const { return false; }
@@ -147,116 +137,99 @@ public:
   //
   // overloading operator!
   //
-  friend bool operator!(const symbol_base_t<BASE_SYMTAB_TEMPLPARAM> &sym)
-    {
-      return ((sym.name == SYMTAB_UNINIT_STRING)? true : false);
-    }
+  friend bool operator!(const symbol_base_t<BASE_SYMTAB_TEMPLPARAM> &sym) {
+    return ((sym.name == SYMTAB_UNINIT_STRING) ? true : false);
+  }
 
-private:
+ private:
   std::string name;
   std::string base_lib_name;
   VA raw_address;
   VA relocated_address;
 };
 
-
 //! ltstr
 /*!
     Contains helper methods for sorting symbol list
 */
-struct ltstr
-{
-  bool operator() ( const std::string &s1, 
-		    const std::string &s2 ) const
-  {
-    return (s1 < s2); 
-  } 
-
-  bool operator() ( const int i1, 
-		    const int i2) const
-  {
-    return (i1 < i2);
+struct ltstr {
+  bool operator()(const std::string &s1, const std::string &s2) const {
+    return (s1 < s2);
   }
-};
 
+  bool operator()(const int i1, const int i2) const { return (i1 < i2); }
+};
 
 //!
 /*! image_base_t<>
     base class representing an image (executable or libraries)
 */
 template <BASE_IMAGE_TEMPLATELIST>
-class image_base_t
-{
-public:
-  
+class image_base_t {
+ public:
   //
   // constructors & destructor
   //
-  image_base_t ();
-  image_base_t ( const std::string &lib );
-  image_base_t ( const image_base_t<BASE_IMAGE_TEMPLPARAM> &im );
-  virtual ~image_base_t ();
+  image_base_t();
+  image_base_t(const std::string &lib);
+  image_base_t(const image_base_t<BASE_IMAGE_TEMPLPARAM> &im);
+  virtual ~image_base_t();
 
   //
   // accessors
   //
-  void set_base_image_name ( std::string &n );
-  void set_path ( std::string &n );
-  void set_image_base_address ( VA ba );
-  void set_native_exec_handler ( EXECHANDLER *h );
+  void set_base_image_name(std::string &n);
+  void set_path(std::string &n);
+  void set_image_base_address(VA ba);
+  void set_native_exec_handler(EXECHANDLER *h);
 
-  const std::string& get_base_image_name() const;
-  const std::string& get_path() const;
-  const VA& get_image_base_address() const;    
-  EXECHANDLER * get_native_exec_handler();  
-  const symbol_base_t<VA> & get_a_symbol 
-    ( const std::string &key ) const;
-  std::map<std::string, std::string, ltstr> & get_dso_list () 
-    { return dso_list; }
- 
-  
+  const std::string &get_base_image_name() const;
+  const std::string &get_path() const;
+  const VA &get_image_base_address() const;
+  EXECHANDLER *get_native_exec_handler();
+  const symbol_base_t<VA> &get_a_symbol(const std::string &key) const;
+  std::map<std::string, std::string, ltstr> &get_dso_list() { return dso_list; }
+
   //
   // OPs on symtabs
   //
-  void print_sorted_linkage_symtab();  
-  symtab_error_e compute_reloc()
-    throw ( symtab_exception_t );
-  //void print_sorted_debug_symtab();  
-  
+  void print_sorted_linkage_symtab();
+  symtab_error_e compute_reloc() throw(symtab_exception_t);
+  // void print_sorted_debug_symtab();
+
   //
   // pure virtual methods
   //
-  symtab_error_e init(const std::string &lib)
-    throw ( symtab_exception_t );
-  virtual symtab_error_e init() 
-    throw ( symtab_exception_t ) = 0;
-  virtual symtab_error_e read_linkage_symbols() 
-    throw (symtab_exception_t) = 0;
-  virtual symtab_error_e fetch_DSO_info (std::string&, bool&)
-    throw (symtab_exception_t) = 0;
+  symtab_error_e init(const std::string &lib) throw(symtab_exception_t);
+  virtual symtab_error_e init() throw(symtab_exception_t) = 0;
+  virtual symtab_error_e read_linkage_symbols() throw(symtab_exception_t) = 0;
+  virtual symtab_error_e fetch_DSO_info(std::string &,
+                                        bool &) throw(symtab_exception_t) = 0;
   // virtual symtab_error_e read_debug_symbols()
-  //   throw ( symtab_exception_t ) = 0; 
-
+  //   throw ( symtab_exception_t ) = 0;
 
   //
   // Some Util methods.
   //
-  virtual void decode_binding(int code, std::string &s) const     
-                          { s = std::string(SYMTAB_UNINIT_STRING); }
-  virtual void decode_visibility (int code, std::string &s) const
-                          { s = std::string(SYMTAB_UNINIT_STRING); }
-  virtual void decode_type(int code, std::string &s) const
-                          { s = std::string(SYMTAB_UNINIT_STRING); }
+  virtual void decode_binding(int code, std::string &s) const {
+    s = std::string(SYMTAB_UNINIT_STRING);
+  }
+  virtual void decode_visibility(int code, std::string &s) const {
+    s = std::string(SYMTAB_UNINIT_STRING);
+  }
+  virtual void decode_type(int code, std::string &s) const {
+    s = std::string(SYMTAB_UNINIT_STRING);
+  }
 
-protected:
-  std::map<std::string, symbol_base_t<VA>*, ltstr> linkage_symtab;
-  std::map<std::string, symbol_base_t<VA>*, ltstr> debug_symtab;
-  std::map<std::string, std::string, ltstr > dso_list;
+ protected:
+  std::map<std::string, symbol_base_t<VA> *, ltstr> linkage_symtab;
+  std::map<std::string, symbol_base_t<VA> *, ltstr> debug_symtab;
+  std::map<std::string, std::string, ltstr> dso_list;
 
-private:
-
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t().symtab_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t().symtab_module_trace.verbosity_level >= level);
+  }
 
   // For self tracing
   //
@@ -268,4 +241,8 @@ private:
   EXECHANDLER *native_exec_handler;
 };
 
-#endif // SDBG_BASE_SYMTAB_HXX
+#endif  // SDBG_BASE_SYMTAB_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_symtab_impl.hxx
+++ b/launchmon/src/sdbg_base_symtab_impl.hxx
@@ -1,35 +1,35 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_symtab_impl.hxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *						
  *
  *  Update Log:
  *        Feb  09 2008 DHA: Added LLNS Copyright
- *        Jan  10 2006 DHA: Created file.          
- */ 
+ *        Jan  10 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_BASE_SYMTAB_IMPL_HXX
 #define SDBG_BASE_SYMTAB_IMPL_HXX 1
@@ -39,16 +39,15 @@
 #endif
 
 extern "C" {
-#include <libgen.h>
 #include <assert.h>
+#include <libgen.h>
 }
 
+#include <limits.h>
 #include <iostream>
 #include <string>
-#include <limits.h>
 
 #include "sdbg_base_symtab.hxx"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -56,128 +55,93 @@ extern "C" {
 //
 //
 
-
 //!  symbol_base_t<> constructors
-/*!  
+/*!
      constructors
 */
 template <BASE_SYMTAB_TEMPLATELIST>
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t ()
-{
+symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t() {
   name = SYMTAB_UNINIT_STRING;
   base_lib_name = SYMTAB_UNINIT_STRING;
   raw_address = SYMTAB_UNINIT_ADDR;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t (
-		 const symbol_base_t& sobj )
-{
-  name = sobj.name; 
+symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t(
+    const symbol_base_t &sobj) {
+  name = sobj.name;
   base_lib_name = sobj.base_lib_name;
   raw_address = sobj.raw_address;
   relocated_address = sobj.relocated_address;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t (
-                 const std::string &n, 
-		 const std::string &bln, 
-		 const VA rd,
-		 const VA rla)
-{
+symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::symbol_base_t(const std::string &n,
+                                                     const std::string &bln,
+                                                     const VA rd,
+                                                     const VA rla) {
   name = n;
   base_lib_name = bln;
   raw_address = rd;
   relocated_address = rla;
 }
 
-
 //!  symbol_base_t<> destructor
-/*!  
+/*!
      destructor
 */
 template <BASE_SYMTAB_TEMPLATELIST>
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::~symbol_base_t ()
-{
+symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::~symbol_base_t() {
   // when the class contains allocable members, those should be
-  // deleted here 
+  // deleted here
 }
 
-
 //!  symbol_base_t<> accessors
-/*!  
+/*!
      accessors
 */
 template <BASE_SYMTAB_TEMPLATELIST>
-void 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_name (
-		 const std::string &n )
-{
+void symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_name(const std::string &n) {
   name = n;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-const std::string & 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_name () const
-{
+const std::string &symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_name() const {
   return name;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-void 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_base_lib_name ( 
-                 const std::string &bln )
-{
+void symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_base_lib_name(
+    const std::string &bln) {
   base_lib_name = bln;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-const std::string & 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_base_lib_name () const
-{
-  return base_lib_name ;
+const std::string &symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_base_lib_name()
+    const {
+  return base_lib_name;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-void 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_raw_address (
-                 const VA &ra)
-{
+void symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_raw_address(const VA &ra) {
   raw_address = ra;
-} 
-
+}
 
 template <BASE_SYMTAB_TEMPLATELIST>
-const VA & 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_raw_address () const
-{
+const VA &symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_raw_address() const {
   return raw_address;
 }
 
-
 template <BASE_SYMTAB_TEMPLATELIST>
-void 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_relocated_address ( 
-                 const VA &ra )
-{
+void symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::set_relocated_address(
+    const VA &ra) {
   relocated_address = ra;
-} 
-
-
-template <BASE_SYMTAB_TEMPLATELIST>
-const VA & 
-symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_relocated_address () const
-{
-  return relocated_address;
 }
 
+template <BASE_SYMTAB_TEMPLATELIST>
+const VA &symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_relocated_address() const {
+  return relocated_address;
+}
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -190,38 +154,30 @@ symbol_base_t<BASE_SYMTAB_TEMPLPARAM>::get_relocated_address () const
     constructors
 */
 template <BASE_IMAGE_TEMPLATELIST>
-image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t () 
-  : image_base_address(SYMTAB_INIT_IMAGE_BASE),
-    native_exec_handler(NULL)
-{ 
+image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t()
+    : image_base_address(SYMTAB_INIT_IMAGE_BASE), native_exec_handler(NULL) {
   path = SYMTAB_UNINIT_STRING;
   base_image_name = SYMTAB_UNINIT_STRING;
   MODULENAME = self_trace_t::self_trace().symtab_module_trace.module_name;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t 
-(const std::string &lib) 
-  : image_base_address(SYMTAB_INIT_IMAGE_BASE),
-    native_exec_handler(NULL)
-{
+image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t(const std::string &lib)
+    : image_base_address(SYMTAB_INIT_IMAGE_BASE), native_exec_handler(NULL) {
   char tempstr[PATH_MAX];
-  
+
   sprintf(tempstr, "%s", lib.c_str());
   path = lib;
   //
   // some memory checkers complain about basename...
-  //  
-  base_image_name = basename((char*) tempstr);
+  //
+  base_image_name = basename((char *)tempstr);
   MODULENAME = self_trace_t::self_trace().symtab_module_trace.module_name;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t 
-( const image_base_t<BASE_IMAGE_TEMPLPARAM> &im) 
-{
+image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t(
+    const image_base_t<BASE_IMAGE_TEMPLPARAM> &im) {
   base_image_name = im.base_image_name;
   path = im.base_path_name;
   //
@@ -230,216 +186,168 @@ image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t
   //
   image_base_address = im.image_base_address;
   native_exec_handler = im.native_exec_handler;
-  
+
   MODULENAME = im.MODULENAME;
 }
-
 
 //! PUBLIC: image_base_t<> destructor
 /*!
     destructor
 */
 template <BASE_IMAGE_TEMPLATELIST>
-image_base_t<BASE_IMAGE_TEMPLPARAM>::~image_base_t()
-{
-  if (native_exec_handler)   
-    {
-      native_exec_handler->finalize();
-      delete native_exec_handler;
-      native_exec_handler = NULL;
-    }
+image_base_t<BASE_IMAGE_TEMPLPARAM>::~image_base_t() {
+  if (native_exec_handler) {
+    native_exec_handler->finalize();
+    delete native_exec_handler;
+    native_exec_handler = NULL;
+  }
 
-  if (!(linkage_symtab.empty()))
-    {
-      typename std::map<std::string, symbol_base_t<VA>*, ltstr>::iterator iter;
-      for (iter = linkage_symtab.begin(); iter != linkage_symtab.end(); ++iter)
-        {
-          delete iter->second;
-          iter->second = NULL;
-        }
-      linkage_symtab.clear(); 
+  if (!(linkage_symtab.empty())) {
+    typename std::map<std::string, symbol_base_t<VA> *, ltstr>::iterator iter;
+    for (iter = linkage_symtab.begin(); iter != linkage_symtab.end(); ++iter) {
+      delete iter->second;
+      iter->second = NULL;
     }
-  if (!(debug_symtab.empty()))
-    {
-      typename std::map<std::string, symbol_base_t<VA>*, ltstr>::iterator iter;
-      for (iter = debug_symtab.begin(); iter != debug_symtab.end(); ++iter)
-        {
-          delete iter->second;
-          iter->second = NULL;
-        }
-      debug_symtab.clear();
+    linkage_symtab.clear();
+  }
+  if (!(debug_symtab.empty())) {
+    typename std::map<std::string, symbol_base_t<VA> *, ltstr>::iterator iter;
+    for (iter = debug_symtab.begin(); iter != debug_symtab.end(); ++iter) {
+      delete iter->second;
+      iter->second = NULL;
     }
+    debug_symtab.clear();
+  }
 }
 
-
 //!  PUBLIC: image_base_t<> accessors
-/*!  
+/*!
      accessors
 */
 template <BASE_IMAGE_TEMPLATELIST>
-void
-image_base_t<BASE_IMAGE_TEMPLPARAM>::set_image_base_address(VA ba)
-{
-  image_base_address = ba; 
+void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_image_base_address(VA ba) {
+  image_base_address = ba;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-const VA &
-image_base_t<BASE_IMAGE_TEMPLPARAM>::get_image_base_address() const
-{
+const VA &image_base_t<BASE_IMAGE_TEMPLPARAM>::get_image_base_address() const {
   return image_base_address;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_base_image_name
-(std::string &n)
-{
+void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_base_image_name(std::string &n) {
   base_image_name = n;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-const std::string& 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::get_base_image_name() const
-{
+const std::string &image_base_t<BASE_IMAGE_TEMPLPARAM>::get_base_image_name()
+    const {
   return base_image_name;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_path
-(std::string &n)
-{
+void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_path(std::string &n) {
   path = n;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-const std::string& 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::get_path() const
-{
+const std::string &image_base_t<BASE_IMAGE_TEMPLPARAM>::get_path() const {
   return path;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_native_exec_handler
-(EXECHANDLER *h)
-{
-  assert ( h != NULL );  
-  native_exec_handler = h;  
+void image_base_t<BASE_IMAGE_TEMPLPARAM>::set_native_exec_handler(
+    EXECHANDLER *h) {
+  assert(h != NULL);
+  native_exec_handler = h;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-EXECHANDLER * 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::get_native_exec_handler()
-{
+EXECHANDLER *image_base_t<BASE_IMAGE_TEMPLPARAM>::get_native_exec_handler() {
   return native_exec_handler;
 }
 
-
-//! PUBLIC: image_base_t<VA>::get_a_symbol 
-/*!   
+//! PUBLIC: image_base_t<VA>::get_a_symbol
+/*!
     returns the matching linkage symbol object
  */
 template <BASE_IMAGE_TEMPLATELIST>
-const symbol_base_t<BASE_SYMTAB_TEMPLPARAM> & 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::get_a_symbol 
-( const std::string& key ) const 
-{ 
-  symbol_base_t<BASE_SYMTAB_TEMPLPARAM>* rsym = NULL; 
-  
-  if ( linkage_symtab.find(key.c_str()) != linkage_symtab.end() ) 
-    {
-      rsym = linkage_symtab.find(key.c_str())->second;
-    }
-  else 
-    {
-      rsym = new symbol_base_t<BASE_SYMTAB_TEMPLPARAM>();
-    }
-  return (*rsym); 
+const symbol_base_t<BASE_SYMTAB_TEMPLPARAM>
+    &image_base_t<BASE_IMAGE_TEMPLPARAM>::get_a_symbol(
+        const std::string &key) const {
+  symbol_base_t<BASE_SYMTAB_TEMPLPARAM> *rsym = NULL;
+
+  if (linkage_symtab.find(key.c_str()) != linkage_symtab.end()) {
+    rsym = linkage_symtab.find(key.c_str())->second;
+  } else {
+    rsym = new symbol_base_t<BASE_SYMTAB_TEMPLPARAM>();
+  }
+  return (*rsym);
 }
 
-
-//! PUBLIC: compute_reloc 
+//! PUBLIC: compute_reloc
 /*!
     computes the relocated address for each symbol
 */
 template <BASE_IMAGE_TEMPLATELIST>
-symtab_error_e 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::compute_reloc()
-  throw ( symtab_exception_t)
-{
+symtab_error_e image_base_t<BASE_IMAGE_TEMPLPARAM>::compute_reloc() throw(
+    symtab_exception_t) {
   using namespace std;
   string e;
   string func = "[image_base_t::compute_reloc]";
-  typename map<string, symbol_base_t<VA>*, ltstr>::iterator ir;
+  typename map<string, symbol_base_t<VA> *, ltstr>::iterator ir;
 
-  if ( image_base_address == SYMTAB_INIT_IMAGE_BASE ) 
-    {
-      e = func +
-	" image base address has not been resolved.";
-      throw symtab_exception_t (e, SDBG_SYMTAB_FAILED);
-    } 
+  if (image_base_address == SYMTAB_INIT_IMAGE_BASE) {
+    e = func + " image base address has not been resolved.";
+    throw symtab_exception_t(e, SDBG_SYMTAB_FAILED);
+  }
 
-  for(ir = linkage_symtab.begin(); ir != linkage_symtab.end(); ++ir) 
-    {
-      ir->second->set_relocated_address ( ir->second->get_raw_address() 
-					  + image_base_address);
-    }
+  for (ir = linkage_symtab.begin(); ir != linkage_symtab.end(); ++ir) {
+    ir->second->set_relocated_address(ir->second->get_raw_address() +
+                                      image_base_address);
+  }
 
   return SDBG_SYMTAB_OK;
 }
 
-
 //! PUBLIC: print_sorted_linkage_symtab --
-/*! 
+/*!
     iterates over linkage symbol table and print them out; chiefly
     debug routine.
 */
 template <BASE_IMAGE_TEMPLATELIST>
-void 
-image_base_t<BASE_IMAGE_TEMPLPARAM>::print_sorted_linkage_symtab () 
-{
+void image_base_t<BASE_IMAGE_TEMPLPARAM>::print_sorted_linkage_symtab() {
   using namespace std;
 
-  typename map<std::string, symbol_base_t<VA>*, ltstr>::iterator ir;
+  typename map<std::string, symbol_base_t<VA> *, ltstr>::iterator ir;
 
-  cout << "SDBG: size, " 
-       << linkage_symtab.size() 
-       << endl; 
+  cout << "SDBG: size, " << linkage_symtab.size() << endl;
 
-  for(ir = linkage_symtab.begin(); ir != linkage_symtab.end(); ++ir) 
-    {
-      symbol_base_t<VA>& tobj = *(ir->second);
-      printf("SDBG: %55s, 0x%8x, %40s, %40s, %s\n", 
-	     ir->first.c_str(), 
-	     ir->second->get_raw_address(), 
-	     ir->second->get_binding().c_str(),
-	     ir->second->get_type().c_str(),
-	     ir->second->get_visibility().c_str());
-    }
+  for (ir = linkage_symtab.begin(); ir != linkage_symtab.end(); ++ir) {
+    symbol_base_t<VA> &tobj = *(ir->second);
+    printf("SDBG: %55s, 0x%8x, %40s, %40s, %s\n", ir->first.c_str(),
+           ir->second->get_raw_address(), ir->second->get_binding().c_str(),
+           ir->second->get_type().c_str(),
+           ir->second->get_visibility().c_str());
+  }
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-symtab_error_e
-image_base_t<BASE_IMAGE_TEMPLPARAM>::init ( const std::string &lib )
-  throw ( symtab_exception_t ) 
-{
+symtab_error_e image_base_t<BASE_IMAGE_TEMPLPARAM>::init(
+    const std::string &lib) throw(symtab_exception_t) {
   char tempstr[PATH_MAX];
-  
+
   sprintf(tempstr, "%s", lib.c_str());
   path = lib;
-  base_image_name = basename((char*) tempstr);
+  base_image_name = basename((char *)tempstr);
   //
   // some memory checkers complain about basename...
-  //  
+  //
   return (init());
 }
 
+#endif  // SDBG_BASE_SYMTAB_IMPL_HXX
 
-#endif // SDBG_BASE_SYMTAB_IMPL_HXX
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_base_tracer.hxx
+++ b/launchmon/src/sdbg_base_tracer.hxx
@@ -1,51 +1,52 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_base_tracer.hxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jul 31 2012 DHA: Added setoptions/unsetoptions
  *        Oct 26 2010 DHA: Changed method names from insert|pullout_breakpoint
  *                         to enable|disable_breakpoint. Slight linux
  *                         implementation change as part of refactoring in
- *                         the breakpoint_base_t class. 
+ *                         the breakpoint_base_t class.
  *        May 08 2008 DHA: Added comments for the "use_cxt" argument
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Mar 31 2006 DHA: Added tracer_read_string.
  *        Mar 30 2006 DHA: Added exception handling support.
  *        Feb 06 2006 DHA: Populated tracer_error_e enumerator.
- *        Jan 10 2006 DHA: Created file.          
- */ 
+ *        Jan 10 2006 DHA: Created file.
+ */
 
 #ifndef SDBG_BASE_TRACER_HXX
 #define SDBG_BASE_TRACER_HXX
 
 #include <iostream>
-#include "sdbg_base_mach.hxx"
 #include "sdbg_base_bp.hxx"
 #include "sdbg_base_exception.hxx"
+#include "sdbg_base_mach.hxx"
 
 //! enumerator tracer_error_e
 /*!
@@ -81,7 +82,6 @@ enum tracer_error_e {
   SDBG_TRACE_FAILED
 };
 
-
 ////////////////////////////////////////////////////////////////////////////
 //
 //
@@ -92,31 +92,28 @@ enum tracer_error_e {
   exception class for tracer layer
 
 */
-class tracer_exception_t : public exception_base_t
-{
-
-public:
+class tracer_exception_t : public exception_base_t {
+ public:
   tracer_error_e error_code;
 
-  tracer_exception_t ()                          { }
-  tracer_exception_t ( const char* m, tracer_error_e e)
-                     { set_message (m);
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_TRACER_ERROR" ) );
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ );
-                      }
-  tracer_exception_t( const std::string& m, tracer_error_e e)      
-                     { set_message (m);
-                       error_code = e;
-                       set_type ( std::string ( "SDBG_TRACER_ERROR" ) );
-                       set_fn ( std::string (__FILE__) );
-                       set_ln ( __LINE__ );
-                      }
+  tracer_exception_t() {}
+  tracer_exception_t(const char *m, tracer_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_TRACER_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
+  tracer_exception_t(const std::string &m, tracer_error_e e) {
+    set_message(m);
+    error_code = e;
+    set_type(std::string("SDBG_TRACER_ERROR"));
+    set_fn(std::string(__FILE__));
+    set_ln(__LINE__);
+  }
 
-  virtual ~tracer_exception_t()                  { }
+  virtual ~tracer_exception_t() {}
 };
-
 
 ////////////////////////////////////////////////////////////////////////////
 //
@@ -124,8 +121,8 @@ public:
 
 //! class tracer_base_t
 /*!
-    tracer_base_t is a pure abstract class which defines 
-    virtual methods for process tracing operations. 
+    tracer_base_t is a pure abstract class which defines
+    virtual methods for process tracing operations.
     Its sub-calsses must implement those methods.
 
     Template parameters:
@@ -137,15 +134,12 @@ public:
     NT:  Native thread info type
 */
 
-template <SDBG_DEFAULT_TEMPLATE_WIDTH> 
-class tracer_base_t 
-{
-
-public:
-  tracer_base_t() { }
-  tracer_base_t(const tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) { }
+template <SDBG_DEFAULT_TEMPLATE_WIDTH>
+class tracer_base_t {
+ public:
+  tracer_base_t() {}
+  tracer_base_t(const tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> &p) {}
   virtual ~tracer_base_t() {}
-
 
   ////////////////////////////////////////////////////////////
   //
@@ -153,109 +147,102 @@ public:
   //
   //  "use_cxt" determines whether the process control operations
   //  apply to the main thread of the target process (use_cxt=false)
-  //  or the active target thread context within that process, which 
+  //  or the active target thread context within that process, which
   //  the upper layer can set. This is to simplify the arguments
-  //  into the process control operations at the expense of having 
-  //  the upper layer to set the active target thread in case it 
-  //  wants to use a "context-sensitive" operation.  
+  //  into the process control operations at the expense of having
+  //  the upper layer to set the active target thread in case it
+  //  wants to use a "context-sensitive" operation.
   //
   //
-  virtual tracer_error_e tracer_setregs    
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt ) 
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_setregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_getregs    
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt ) 
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_getregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_setfpregs  
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_setfpregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_getfpregs  
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_getfpregs(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_read
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, void* buf, int size, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_read(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_read_string
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, void* buf, int size, bool use_cxt )
-    throw (tracer_exception_t)                                 =0; 
+  virtual tracer_error_e tracer_read_string(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_get_event_msg
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, void* buf, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_get_event_msg(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_write      
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      VA addr, const void* buf, int size, bool use_cxt) 
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_write(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, const void *buf,
+      int size, bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_continue   
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_continue(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_deliver_signal
-  ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_deliver_signal(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_stop
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt)=0;
+  virtual tracer_error_e tracer_stop(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                                     bool use_cxt) = 0;
 
-  virtual tracer_error_e tracer_kill
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_kill(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_singlestep 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_singlestep(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_syscall
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_syscall(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+      bool use_cxt) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_detach
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt)=0;
+  virtual tracer_error_e tracer_detach(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt) = 0;
 
-  virtual tracer_error_e tracer_setoptions
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt, pid_t newtid )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_setoptions(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_unsetoptions
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt, pid_t newtid )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_unsetoptions(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_attach
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt, pid_t newtid )
-    throw (tracer_exception_t)                                 =0;
- 
-  virtual tracer_error_e status
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt)=0;
+  virtual tracer_error_e tracer_attach(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
+      pid_t newtid) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e tracer_trace_me   ()
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e status(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
+                                bool use_cxt) = 0;
 
-  virtual tracer_error_e enable_breakpoint 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-      breakpoint_base_t<VA, IT>& bp, bool use_cxt, bool change_state=true )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e tracer_trace_me() throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e disable_breakpoint 
-    ( process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-      breakpoint_base_t<VA, IT>& bp, bool use_cxt, bool change_state=true ) 
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e enable_breakpoint(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
+      bool use_cxt, bool change_state = true) throw(tracer_exception_t) = 0;
 
-  virtual tracer_error_e convert_error_code ( int err )
-    throw (tracer_exception_t)                                 =0;
+  virtual tracer_error_e disable_breakpoint(
+      process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
+      bool use_cxt, bool change_state = true) throw(tracer_exception_t) = 0;
 
+  virtual tracer_error_e convert_error_code(int err) throw(
+      tracer_exception_t) = 0;
 };
 
-#endif //SDBG_BASE_TRACER_HXX
+#endif  // SDBG_BASE_TRACER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_event_manager.hxx
+++ b/launchmon/src/sdbg_event_manager.hxx
@@ -1,100 +1,97 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_event_manager.hxx,v 1.5.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jul 04 2006 DHA: Added self tracing support
  *        Jan 12 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_EVENT_MANAGER_HXX
 #define SDBG_EVENT_MANAGER_HXX 1
 
 #include <vector>
-#include "sdbg_base_mach.hxx"
 #include "sdbg_base_launchmon.hxx"
-
+#include "sdbg_base_mach.hxx"
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-class monitor_proc_thread_t
-{
+class monitor_proc_thread_t {
+ public:
+  monitor_proc_thread_t();
+  monitor_proc_thread_t(const monitor_proc_thread_t &m);
+  ~monitor_proc_thread_t();
 
-public:
-  monitor_proc_thread_t ();
-  monitor_proc_thread_t (const monitor_proc_thread_t &m);
-  ~monitor_proc_thread_t ();
-  
-  bool wait_for_all (debug_event_t& rc);
+  bool wait_for_all(debug_event_t &rc);
 };
-
 
 //! event_manager_t
 /*!
-    The class sniffs debug events from each process and  
-    invokes a correspondig handler that is registered through 
+    The class sniffs debug events from each process and
+    invokes a correspondig handler that is registered through
     the launchmon_base_t object.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-class event_manager_t 
-{
+class event_manager_t {
+ public:
+  event_manager_t();
+  event_manager_t(const event_manager_t &e);
+  virtual ~event_manager_t();
 
-public:
-  
-  event_manager_t ();
-  event_manager_t (const event_manager_t &e);
-  virtual ~event_manager_t ();
-  
-  bool multiplex_events ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &proc,
-		          launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm );
-  bool poll_processes ( process_base_t<SDBG_DEFAULT_TEMPLPARAM>& proc,
-		          launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm );
-  bool poll_FE_socket ( process_base_t<SDBG_DEFAULT_TEMPLPARAM> &proc,
-		        launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm );
+  bool multiplex_events(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &proc,
+                        launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm);
+  bool poll_processes(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &proc,
+                      launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm);
+  bool poll_FE_socket(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &proc,
+                      launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm);
 
-private:
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().event_module_trace.verbosity_level >=
+            level);
+  }
 
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().event_module_trace.verbosity_level >= level); }
-
- 
   //
   // WARNING: do not attempt to copy proclist to another list
   // of the same type. It will copy the pointers, not pointees.
-  // It is just tricky and time consuming to implement 
+  // It is just tricky and time consuming to implement
   // polymorphism using STL containers.
   // proclist not yet used
-  //std::list <process_base_t<SDBG_DEFAULT_TEMPLPARAM>* > proclist;
+  // std::list <process_base_t<SDBG_DEFAULT_TEMPLPARAM>* > proclist;
   monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM> *ev_monitor;
 
   //
   // For self tracing
   //
-  std::string MODULENAME; 
+  std::string MODULENAME;
 };
 
-#endif // SDBG_EVENT_MANAGER_HXX
+#endif  // SDBG_EVENT_MANAGER_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_event_manager_impl.hxx
+++ b/launchmon/src/sdbg_event_manager_impl.hxx
@@ -1,46 +1,46 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_event_manager_impl.hxx,v 1.8.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *						
  *
  *  Update Log:
  *        Sep 24 2008 DHA: Enforced the error handling semantics
  *                         defined in README.ERROR_HANDLING.
  *        Feb 09 2008 DHA: Added LLNS Copyright
- *        Jul 30 2006 DHA: Fixed a subtle bug: when thread gets 
- *                         an "exit: event while the thread list 
- *                         is being traversed in the event manager, 
- *                         the argument into check_and_undo_context 
- *                         can contain garbage. This occurs very 
+ *        Jul 30 2006 DHA: Fixed a subtle bug: when thread gets
+ *                         an "exit: event while the thread list
+ *                         is being traversed in the event manager,
+ *                         the argument into check_and_undo_context
+ *                         can contain garbage. This occurs very
  *                         rarely. The fix is basically to copy the
  *                         thread id into a local variable before
- *                         the beginning of thread list traversing. 
+ *                         the beginning of thread list traversing.
  *        Jul 04 2006 DHA: Added self tracing support
  *        Feb 02 2006 DHA: Created file.
- */ 
+ */
 
 #ifndef SDBG_EVENT_MANAGER_IMPL_HXX
 #define SDBG_EVENT_MANAGER_IMPL_HXX 1
@@ -51,35 +51,33 @@
 
 extern "C" {
 #if HAVE_SYS_TYPES_H
-# include <sys/types.h>
+#include <sys/types.h>
 #else
-# error sys/types.h is required
+#error sys/types.h is required
 #endif
 
-
 #if HAVE_SYS_WAIT_H
-# include <sys/wait.h>
+#include <sys/wait.h>
 #else
-# error sys/wait.h is required
+#error sys/wait.h is required
 #endif
 }
 
 #if HAVE_MAP
-# include <map>
+#include <map>
 #else
-# error map is required
+#error map is required
 #endif
 
 #if HAVE_VECTOR
-# include <vector>
+#include <vector>
 #else
-# error vector is required
+#error vector is required
 #endif
 
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_mach_impl.hxx"
 #include "sdbg_event_manager.hxx"
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -92,26 +90,14 @@ extern "C" {
 
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::monitor_proc_thread_t()
-{
-
-}
-
+monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::monitor_proc_thread_t() {}
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::monitor_proc_thread_t
-(const monitor_proc_thread_t &m)
-{
-
-}
-
+monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::monitor_proc_thread_t(
+    const monitor_proc_thread_t& m) {}
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::~monitor_proc_thread_t()
-{
-
-}
-
+monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::~monitor_proc_thread_t() {}
 
 //! PUBLIC: monitor_proc_thread_t::wait_for_all
 /*!
@@ -121,72 +107,58 @@ monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::~monitor_proc_thread_t()
     and write platform-specific class inherit it.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::wait_for_all (
-                 debug_event_t& rc)
-{
+bool monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::wait_for_all(
+    debug_event_t& rc) {
   pid_t rpid;
   int status;
   bool rs = false;
   eventing_entity_e entity = EV_ENTITY_THREAD;
 
-  rpid = waitpid (-1, &status, WNOHANG | WUNTRACED);
-  if (rpid <= 0) 
-    { 
-      rpid =  waitpid (-1, &status, WNOHANG | __WCLONE);
-    }
-  else 
-    {
-      entity = EV_ENTITY_PROCESS;
-    }
+  rpid = waitpid(-1, &status, WNOHANG | WUNTRACED);
+  if (rpid <= 0) {
+    rpid = waitpid(-1, &status, WNOHANG | __WCLONE);
+  } else {
+    entity = EV_ENTITY_PROCESS;
+  }
 
-  if ( rpid <= 0 )
-    {
-      rc.set_ev(EV_NOCHILD);
-      rc.set_en (EV_ENTITY_NONE);
-      rc.set_id (rpid);
-      return rs;
-    }
+  if (rpid <= 0) {
+    rc.set_ev(EV_NOCHILD);
+    rc.set_en(EV_ENTITY_NONE);
+    rc.set_id(rpid);
+    return rs;
+  }
 
-  rc.set_en (entity);
-  rc.set_id (rpid);
+  rc.set_en(entity);
+  rc.set_id(rpid);
 
-  if (WIFEXITED(status)) 
-    {
-      rc.set_ev (EV_EXITED);
-      rc.set_exitcode (WEXITSTATUS(status));
-      rc.set_rawstatus (status);
-      rs = true;
-    }
-  else if (WIFSIGNALED(status)) 
-    {
-      //
-      // Child terminiated with a signal 
-      //
-      rc.set_ev (EV_TERMINATED);
-      rc.set_signum (WTERMSIG(status));
-      rc.set_rawstatus (status);
-      rs = true;	
-    }
-  else if (WIFSTOPPED(status)) 
-    {
-      //
-      // Child stopped w/ signal
-      // Thread note: when a new thread is created, the parent must get 
-      // SIGTRAP
-      rc.set_ev (EV_STOPPED);
-      rc.set_signum (WSTOPSIG(status));
-      rc.set_rawstatus (status);
-      rs = true;
-    }
-  else
-    {
-      rc.set_rawstatus (status);
-    }
+  if (WIFEXITED(status)) {
+    rc.set_ev(EV_EXITED);
+    rc.set_exitcode(WEXITSTATUS(status));
+    rc.set_rawstatus(status);
+    rs = true;
+  } else if (WIFSIGNALED(status)) {
+    //
+    // Child terminiated with a signal
+    //
+    rc.set_ev(EV_TERMINATED);
+    rc.set_signum(WTERMSIG(status));
+    rc.set_rawstatus(status);
+    rs = true;
+  } else if (WIFSTOPPED(status)) {
+    //
+    // Child stopped w/ signal
+    // Thread note: when a new thread is created, the parent must get
+    // SIGTRAP
+    rc.set_ev(EV_STOPPED);
+    rc.set_signum(WSTOPSIG(status));
+    rc.set_rawstatus(status);
+    rs = true;
+  } else {
+    rc.set_rawstatus(status);
+  }
 
   return rs;
 }
-
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -199,173 +171,144 @@ monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>::wait_for_all (
 
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::event_manager_t () 
-{
-  ev_monitor = new monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>(); 
+event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::event_manager_t() {
+  ev_monitor = new monitor_proc_thread_t<SDBG_DEFAULT_TEMPLPARAM>();
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::event_manager_t 
-(const event_manager_t &e) 
-{
+event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::event_manager_t(
+    const event_manager_t& e) {
   ev_monitor = e.ev_monitor;
   MODULENAME = e.MODULENAME;
 }
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::~event_manager_t ()
-{
-  if (ev_monitor)
-    delete ev_monitor;
+event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::~event_manager_t() {
+  if (ev_monitor) delete ev_monitor;
 }
-
 
 //! PUBLIC: poll_processes
 /*!
 
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::poll_processes (
-		 process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-                 launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> &lm ) 
-{
+bool event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::poll_processes(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
+    launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>& lm) {
   using namespace std;
 
   debug_event_t event;
-  pid_t rpid; 
-  launchmon_rc_e rc = LAUNCHMON_OK;  
+  pid_t rpid;
+  launchmon_rc_e rc = LAUNCHMON_OK;
   launchmon_event_e ev;
 
-  if ( ev_monitor->wait_for_all ( event ) ) 
-    { 
-      if ( event.get_en() == EV_ENTITY_PROCESS )
-        {
+  if (ev_monitor->wait_for_all(event)) {
+    if (event.get_en() == EV_ENTITY_PROCESS) {
+      //
+      // A process event is reported
+      //
+      if (event.get_id() == p.get_pid(false)) {
+        //
+        // The target RM_process reported
+        //
+        p.make_context(event.get_id());
+        ev = lm.decipher_an_event(p, event);
+        rc = lm.invoke_handler(p, ev, event.get_signum());
+        p.check_and_undo_context(event.get_id());
+      } else if (event.get_id() == lm.get_toollauncherpid()) {
+        // RM_process that launched tool daemons reported
+        // error handling semantics for C.2
+        //
+        if ((event.get_ev() == EV_EXITED) ||
+            (event.get_ev() == EV_TERMINATED)) {
           //
-          // A process event is reported
+          // this means that back-end daemons have exited
+          // Enforcing C.2 error handling semantics.
           //
-          if ( event.get_id() == p.get_pid(false) )
-            {
-              //
-              // The target RM_process reported
-              //
-              p.make_context ( event.get_id());
-              ev = lm.decipher_an_event ( p, event );
-              rc = lm.invoke_handler ( p, ev, event.get_signum() );
-              p.check_and_undo_context ( event.get_id() );
-            }
-          else if ( event.get_id() == lm.get_toollauncherpid () )
-            {
-              // RM_process that launched tool daemons reported
-              // error handling semantics for C.2
-              //
-              if ( ( event.get_ev () == EV_EXITED )
-                   || ( event.get_ev () == EV_TERMINATED ))
-                {
-                  //
-                  // this means that back-end daemons have exited
-                  // Enforcing C.2 error handling semantics.
-                  //
-                  rc = lm.handle_daemon_exit_event (p);
-                }
-              //
-              // in this case rpid won't be part of the thread list 
-              // so that the following loop body won't be executed.
-              //
-            }
-          else
-            {
-              //
-              // a unknown new process reported 
-              //
-              if (event.get_ev() == EV_STOPPED)
-                {
-                  p.make_context (event.get_id());
-                  rc = lm.invoke_handler ( p, 
-                                           LM_STOP_NEW_FORKED_PROCESS,
-                                           event.get_id() );
-                  p.check_and_undo_context (event.get_id());
-                }
-            }  
+          rc = lm.handle_daemon_exit_event(p);
         }
-      else if ( event.get_en() == EV_ENTITY_THREAD ) 
-        {
-          //
-          // A thread of the target RM_process reported
-          //
-	  map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr>& tl 
-	    = p.get_thrlist();
+        //
+        // in this case rpid won't be part of the thread list
+        // so that the following loop body won't be executed.
+        //
+      } else {
+        //
+        // a unknown new process reported
+        //
+        if (event.get_ev() == EV_STOPPED) {
+          p.make_context(event.get_id());
+          rc = lm.invoke_handler(p, LM_STOP_NEW_FORKED_PROCESS, event.get_id());
+          p.check_and_undo_context(event.get_id());
+        }
+      }
+    } else if (event.get_en() == EV_ENTITY_THREAD) {
+      //
+      // A thread of the target RM_process reported
+      //
+      map<int, thread_base_t<SDBG_DEFAULT_TEMPLPARAM>*, ltstr>& tl =
+          p.get_thrlist();
 
-          if (tl.find(event.get_id()) == tl.end())
-            {
-              //
-              // Possibly an unknown thread to pick up
-              //
-              if (event.get_ev() == EV_STOPPED)
-                { 
-                  rc = lm.invoke_handler ( p, 
-                                           LM_REQUEST_NEW_THREAD, 
-                                           event.get_id() );
-                }
-            }
- 
-          if (tl.find(event.get_id()) != tl.end())
-            {
-              p.make_context(event.get_id());
-              ev = lm.decipher_an_event(p, event); 
-              rc = lm.invoke_handler ( p, ev, event.get_signum ());
-              p.check_and_undo_context(event.get_id());
-            }
+      if (tl.find(event.get_id()) == tl.end()) {
+        //
+        // Possibly an unknown thread to pick up
+        //
+        if (event.get_ev() == EV_STOPPED) {
+          rc = lm.invoke_handler(p, LM_REQUEST_NEW_THREAD, event.get_id());
         }
+      }
+
+      if (tl.find(event.get_id()) != tl.end()) {
+        p.make_context(event.get_id());
+        ev = lm.decipher_an_event(p, event);
+        rc = lm.invoke_handler(p, ev, event.get_signum());
+        p.check_and_undo_context(event.get_id());
+      }
     }
-  return ( ( rc==LAUNCHMON_OK ) ? true : false );
+  }
+  return ((rc == LAUNCHMON_OK) ? true : false);
 }
-
 
 //! PUBLIC: poll_FE_socket
 /*!
 
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::poll_FE_socket ( 
-		 process_base_t<SDBG_DEFAULT_TEMPLPARAM>& proc,
-		 launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>& lm )
-{
+bool event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::poll_FE_socket(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM>& proc,
+    launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>& lm) {
   bool rc = true;
 
-  if ( lm.handle_incoming_socket_event ( proc ) != LAUNCHMON_OK )
-    {
-      rc = false;
-    }
+  if (lm.handle_incoming_socket_event(proc) != LAUNCHMON_OK) {
+    rc = false;
+  }
 
   return rc;
 }
-
 
 //! PUBLIC: multiplex_events
 /*!
 
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-bool 
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::multiplex_events (
-	         process_base_t<SDBG_DEFAULT_TEMPLPARAM>& proc,
-                 launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>& lm ) 
-{
+bool event_manager_t<SDBG_DEFAULT_TEMPLPARAM>::multiplex_events(
+    process_base_t<SDBG_DEFAULT_TEMPLPARAM>& proc,
+    launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>& lm) {
   bool rc = true;
 
-  rc = poll_FE_socket ( proc, lm );
-  if (rc)
-    {
-      //
-      // We only poll when poll_FE_socket returns the true code.
-      // poll_FE_socket always returns true for standalone launchmon mode 
-      //
-      rc = poll_processes ( proc, lm );
-    }
+  rc = poll_FE_socket(proc, lm);
+  if (rc) {
+    //
+    // We only poll when poll_FE_socket returns the true code.
+    // poll_FE_socket always returns true for standalone launchmon mode
+    //
+    rc = poll_processes(proc, lm);
+  }
 
   return (rc);
 }
-#endif // SDBG_EVENT_MANAGER_IMPL_HXX
+#endif  // SDBG_EVENT_MANAGER_IMPL_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */
 

--- a/launchmon/src/sdbg_opt.cxx
+++ b/launchmon/src/sdbg_opt.cxx
@@ -1,30 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_opt.cxx,v 1.9.2.4 2008/03/06 00:13:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *	
  *
  *  Update Log:
  *        Apr 22 2014 DHA: Applied a patch to store RM args/opts into
@@ -34,7 +34,7 @@
  *        Oct 07 2010 DHA: Dynamic resource manager detection support
  *        Jun 30 2010 DHA: Added faster engine parsing error detection support
  *                         Deprecated option_sanity_check();
- *        Jun 10 2010 DHA: Added RM MAP support. Removed Linux-specific getexec 
+ *        Jun 10 2010 DHA: Added RM MAP support. Removed Linux-specific getexec
  *                         from here
  *        Mar 16 2009 DHA: Added COBO support
  *                         Added 2010 to copyright
@@ -51,35 +51,30 @@
  *                         for attaching case.
  *        Jun 08 2006 DHA: Added attach-to-a-running-job support
  *        Jun 06 2006 DHA: File created
- */ 
+ */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
 #include "config.h"
 #endif
 
-#include <lmon_api/common.h>
 #include <limits.h>
+#include <lmon_api/common.h>
+#include "lmon_api/lmon_say_msg.hxx"
 #include "sdbg_opt.hxx"
 #include "sdbg_rm_map.hxx"
-#include "lmon_api/lmon_say_msg.hxx"
 #include "sdbg_self_trace.hxx"
 
-
-const std::string software_name
-   = PACKAGE_NAME;
-const std::string version
-   = PACKAGE_VERSION;
-const std::string copyright 
-   = "Copyright (C) 2008-2012, "
-     "Lawrence Livermore National Security, LLC.";
-const std::string produced 
-   = "Produced at Lawrence Livermore National Laboratory.";
-const std::string right 
-   = "LLNL-CODE-409469 All rights reserved.";
-const std::string LAUNCHMON_COPYRIGHT 
-   = software_name + " " +  version + "\n" + copyright 
-       + "\n" + produced + "\n" + right + "\n";
-
+const std::string software_name = PACKAGE_NAME;
+const std::string version = PACKAGE_VERSION;
+const std::string copyright =
+    "Copyright (C) 2008-2012, "
+    "Lawrence Livermore National Security, LLC.";
+const std::string produced =
+    "Produced at Lawrence Livermore National Laboratory.";
+const std::string right = "LLNL-CODE-409469 All rights reserved.";
+const std::string LAUNCHMON_COPYRIGHT = software_name + " " + version + "\n" +
+                                        copyright + "\n" + produced + "\n" +
+                                        right + "\n";
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -87,14 +82,12 @@ const std::string LAUNCHMON_COPYRIGHT
 //
 ///////////////////////////////////////////////////////////////////
 
-
 //!
 /*!  opt_args_t constructor
 
 
 */
-opts_args_t::opts_args_t ()
-{
+opts_args_t::opts_args_t() {
   my_opt = new opt_struct_t();
   my_opt->verbose = 0;
   my_opt->attach = false;
@@ -114,15 +107,13 @@ opts_args_t::opts_args_t ()
   MODULENAME = self_trace_t::self_trace().opt_module_trace.module_name;
 }
 
-
 //!
 /*!  opt_args_t destructor
 
 
 */
-opts_args_t::~opts_args_t()
-{
-  if(my_opt) {
+opts_args_t::~opts_args_t() {
+  if (my_opt) {
     delete my_opt;
   }
   my_opt = NULL;
@@ -130,18 +121,15 @@ opts_args_t::~opts_args_t()
   if (my_rmconfig) {
     delete my_rmconfig;
   }
- my_rmconfig = NULL;
+  my_rmconfig = NULL;
 }
-
 
 //!
 /*!  opt_args_t::process_args
 
 
 */
-bool 
-opts_args_t::process_args ( int *argc, char ***argv )
-{ 
+bool opts_args_t::process_args(int *argc, char ***argv) {
   using std::string;
 
   bool fin_parsing = false;
@@ -155,313 +143,291 @@ opts_args_t::process_args ( int *argc, char ***argv )
   int i = 1;
   self_trace_verbosity ver = quiet;
 
-  if ((*argc) < 2) 
-    {
-      print_usage();
-      return false;
-    }
+  if ((*argc) < 2) {
+    print_usage();
+    return false;
+  }
 
   my_opt->remote = false;
 
-  for (i=1; (i < (*argc)) && !fin_parsing ; i++) 
-    {
-      if (nargv[i][0] == '-') 
-	{
-	  c = nargv[i][1];
-	  if ( c == '-') 
-	    {
-	      if ( string(&nargv[i][2]) == string("verbose"))
-		c = 'v';
-	      else if ( string(&nargv[i][2]) == string("help"))
-		c = 'h';
-	      else if ( string(&nargv[i][2]) == string("daemonpath"))
-		c = 'd';
-	      else if ( string(&nargv[i][2]) == string("selftrace"))
-		c = 'x';
-	      else if ( string(&nargv[i][2]) == string("daemonopts"))
-		c = 't';
-	      else if ( string(&nargv[i][2]) == string("pid"))
-		c = 'p';
-	      else if ( string(&nargv[i][2]) == string("traceout"))
-		c = 'o';
-	      else if ( string(&nargv[i][2]) == string("remote"))
-		c = 'r';
-	      else if ( string(&nargv[i][2]) == string("lmonsec"))	
-	        c = 's';
-	    }
+  for (i = 1; (i < (*argc)) && !fin_parsing; i++) {
+    if (nargv[i][0] == '-') {
+      c = nargv[i][1];
+      if (c == '-') {
+        if (string(&nargv[i][2]) == string("verbose"))
+          c = 'v';
+        else if (string(&nargv[i][2]) == string("help"))
+          c = 'h';
+        else if (string(&nargv[i][2]) == string("daemonpath"))
+          c = 'd';
+        else if (string(&nargv[i][2]) == string("selftrace"))
+          c = 'x';
+        else if (string(&nargv[i][2]) == string("daemonopts"))
+          c = 't';
+        else if (string(&nargv[i][2]) == string("pid"))
+          c = 'p';
+        else if (string(&nargv[i][2]) == string("traceout"))
+          c = 'o';
+        else if (string(&nargv[i][2]) == string("remote"))
+          c = 'r';
+        else if (string(&nargv[i][2]) == string("lmonsec"))
+          c = 's';
+      }
 
-	  switch (c)
-	    {
+      switch (c) {
+        case 'a':
+          if (debugtarget) {
+            nargv[i] = debugtarget;
+            my_opt->remaining = &(nargv[i]);
+          } else {
+            has_parse_error = true;
+            rv = false;
+          }
+          fin_parsing = true;
+          break;
 
-	    case 'a':
-	      if(debugtarget)
-	        {
-		  nargv[i] = debugtarget;
-	          my_opt->remaining = &(nargv[i]);
-                }
-	      else
- 	        {
-		  has_parse_error = true;
-		  rv = false;
-	        }
-	      fin_parsing = true;
-	      break;
+        case 'o':
+          self_trace_t::tracefptr = fopen(nargv[i + 1], "w+");
+          assert(self_trace_t::tracefptr != NULL);
+          i++;
+          break;
 
-	    case 'o':
-	      self_trace_t::tracefptr = fopen (nargv[i+1], "w+");
-	      assert ( self_trace_t::tracefptr != NULL);
-	      i++;
-	      break;
+        case 'v':
+          my_opt->verbose = atoi(nargv[i + 1]);
 
-	    case 'v':
-	      my_opt->verbose = atoi(nargv[i+1]);
+          if (my_opt->verbose == 0)
+            ver = quiet;
+          else if (my_opt->verbose == 1)
+            ver = level1;
+          else if (my_opt->verbose == 2)
+            ver = level2;
+          else
+            my_opt->verbose = 1;
 
-	      if (my_opt->verbose == 0)
-		ver = quiet;
-	      else if (my_opt->verbose == 1 )
-		ver = level1;
-	      else if (my_opt->verbose == 2 )
-		ver = level2;
-	      else
-		my_opt->verbose = 1;
-
-	      self_trace_t::self_trace().launchmon_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().tracer_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().symtab_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().event_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().driver_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().machine_module_trace.verbosity_level = ver;
-	      self_trace_t::self_trace().opt_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().launchmon_module_trace.verbosity_level =
+              ver;
+          self_trace_t::self_trace().tracer_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().symtab_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().event_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().driver_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().machine_module_trace.verbosity_level = ver;
+          self_trace_t::self_trace().opt_module_trace.verbosity_level = ver;
           self_trace_t::self_trace().rm_module_trace.verbosity_level = ver;
 
-	      i++;
-	      break;
+          i++;
+          break;
 
-	    case 'h':
-	      print_usage();
-	      break;
+        case 'h':
+          print_usage();
+          break;
 
-	    case 'd':
-              {
-	        my_opt->tool_daemon =  nargv[i+1];
-                string dtar(nargv[i+1]);
-	        if (!check_path(dtar, my_opt->tool_daemon))
-		  {
-		    //
-	            // tool daemon nonexistent
-		    //
-		    has_parse_error = true;
-		    fin_parsing = true;
-		    rv = false;
-		  }
-	        i++;
-	        break;
-	      }
-	    case 't': {
-               int num_args = atoi(nargv[i+1]);
-               int j=0;
-               for (j = 0; j < num_args; j++) 
-               {
-                  my_opt->tool_daemon_opts.push_back(nargv[i+j+2]);
-               }
-               i += num_args + 1;
-               break;
-            }
+        case 'd': {
+          my_opt->tool_daemon = nargv[i + 1];
+          string dtar(nargv[i + 1]);
+          if (!check_path(dtar, my_opt->tool_daemon)) {
+            //
+            // tool daemon nonexistent
+            //
+            has_parse_error = true;
+            fin_parsing = true;
+            rv = false;
+          }
+          i++;
+          break;
+        }
+        case 't': {
+          int num_args = atoi(nargv[i + 1]);
+          int j = 0;
+          for (j = 0; j < num_args; j++) {
+            my_opt->tool_daemon_opts.push_back(nargv[i + j + 2]);
+          }
+          i += num_args + 1;
+          break;
+        }
 
-	    case 'p':
-	      my_opt->launcher_pid = (pid_t)atoi(nargv[i+1]);
-	      if (LMON_get_execpath(my_opt->launcher_pid, my_opt->debugtarget) <  0)
-                {
-		  has_parse_error = true;
-		  fin_parsing = true;
-		  rv = false;
-                }
-	      my_opt->attach = true;
-	      i++;
-	      break;
+        case 'p':
+          my_opt->launcher_pid = (pid_t)atoi(nargv[i + 1]);
+          if (LMON_get_execpath(my_opt->launcher_pid, my_opt->debugtarget) <
+              0) {
+            has_parse_error = true;
+            fin_parsing = true;
+            rv = false;
+          }
+          my_opt->attach = true;
+          i++;
+          break;
 
-	    case 'r':
-	      my_opt->remote = true;
-	      my_opt->remote_info = nargv[i+1]; // it should have hostname:port
-	      i++;
-	      break;
+        case 'r':
+          my_opt->remote = true;
+          my_opt->remote_info = nargv[i + 1];  // it should have hostname:port
+          i++;
+          break;
 
- 	    case 's':
-	      my_opt->lmon_sec_info = nargv[i+1];
-	      i++;
-	      break;	
+        case 's':
+          my_opt->lmon_sec_info = nargv[i + 1];
+          i++;
+          break;
 
-	    case 'x':
-	      //
-	      // this is a hidden option for self-tracing
-	      //
-	      tracingmodule = strdup(nargv[i+1]);
-	      modulename = strtok(tracingmodule, ":");
-	      level = atoi(strtok(NULL, ":"));;
+        case 'x':
+          //
+          // this is a hidden option for self-tracing
+          //
+          tracingmodule = strdup(nargv[i + 1]);
+          modulename = strtok(tracingmodule, ":");
+          level = atoi(strtok(NULL, ":"));
+          ;
 
-	      if (level == 0)
-		ver = quiet;
-	      else if (level == 1 )
-		ver = level1;
-	      else if (level == 2 )
-		ver = level2;
-	      else if (level == 3 )
-		ver = level3;
-	      else if (level == 4 )
-		ver = level4;
-	      else
-		ver = level1;
+          if (level == 0)
+            ver = quiet;
+          else if (level == 1)
+            ver = level1;
+          else if (level == 2)
+            ver = level2;
+          else if (level == 3)
+            ver = level3;
+          else if (level == 4)
+            ver = level4;
+          else
+            ver = level1;
 
-	      if ( modulename== self_trace_t::self_trace().launchmon_module_trace.module_symbol )
-		self_trace_t::self_trace().launchmon_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().tracer_module_trace.module_symbol )
-		self_trace_t::self_trace().tracer_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().symtab_module_trace.module_symbol )
-		self_trace_t::self_trace().symtab_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().machine_module_trace.module_symbol )
-		self_trace_t::self_trace().machine_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().event_module_trace.module_symbol )
-		self_trace_t::self_trace().event_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().driver_module_trace.module_symbol )
-		self_trace_t::self_trace().driver_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().opt_module_trace.module_symbol )
-		self_trace_t::self_trace().opt_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().rm_module_trace.module_symbol )
-		self_trace_t::self_trace().rm_module_trace.verbosity_level = ver;
-	      else if ( modulename
-			== self_trace_t::self_trace().sighandler_module_trace.module_symbol )
-		self_trace_t::self_trace().sighandler_module_trace.verbosity_level = ver;
+          if (modulename ==
+              self_trace_t::self_trace().launchmon_module_trace.module_symbol)
+            self_trace_t::self_trace().launchmon_module_trace.verbosity_level =
+                ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().tracer_module_trace.module_symbol)
+            self_trace_t::self_trace().tracer_module_trace.verbosity_level =
+                ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().symtab_module_trace.module_symbol)
+            self_trace_t::self_trace().symtab_module_trace.verbosity_level =
+                ver;
+          else if (modulename ==
+                   self_trace_t::self_trace()
+                       .machine_module_trace.module_symbol)
+            self_trace_t::self_trace().machine_module_trace.verbosity_level =
+                ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().event_module_trace.module_symbol)
+            self_trace_t::self_trace().event_module_trace.verbosity_level = ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().driver_module_trace.module_symbol)
+            self_trace_t::self_trace().driver_module_trace.verbosity_level =
+                ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().opt_module_trace.module_symbol)
+            self_trace_t::self_trace().opt_module_trace.verbosity_level = ver;
+          else if (modulename ==
+                   self_trace_t::self_trace().rm_module_trace.module_symbol)
+            self_trace_t::self_trace().rm_module_trace.verbosity_level = ver;
+          else if (modulename ==
+                   self_trace_t::self_trace()
+                       .sighandler_module_trace.module_symbol)
+            self_trace_t::self_trace().sighandler_module_trace.verbosity_level =
+                ver;
 
-	      i++;
-	      break;
+          i++;
+          break;
 
-	    default:
-	      print_usage();
-	      rv = false;
-	      break;
-	    }
-	}
-      else 
-	{
-	  debugtarget = nargv[i];
-	  my_opt->debugtarget = nargv[i];
-          string dtar(debugtarget);
-	  if (!check_path(dtar, my_opt->debugtarget))
-            {
-	      //
-	      // job launcher path nonexistent
-	      //
-	      has_parse_error = true;
-	      rv = false;	
-	    }
-	}
+        default:
+          print_usage();
+          rv = false;
+          break;
+      }
+    } else {
+      debugtarget = nargv[i];
+      my_opt->debugtarget = nargv[i];
+      string dtar(debugtarget);
+      if (!check_path(dtar, my_opt->debugtarget)) {
+        //
+        // job launcher path nonexistent
+        //
+        has_parse_error = true;
+        rv = false;
+      }
     }
-
+  }
 
   //
   // alternative way to set the engine's verbose level
   //
   char *l;
-  if ( (l = getenv("LMON_ENGINE_VERBOSE_LEVEL")) != NULL )
-    {
-      int il = atoi(l);
-      self_trace_verbosity verbo;
+  if ((l = getenv("LMON_ENGINE_VERBOSE_LEVEL")) != NULL) {
+    int il = atoi(l);
+    self_trace_verbosity verbo;
 
-      switch (il)
-        {
-        case 0:
-          verbo = quiet;
-          break;
-        case 1:
-          verbo = level1;
-          break;
-        case 2:
-          verbo = level2;
-          break;
-        case 3:
-          verbo = level3;
-          break;
-        default:
-          verbo = quiet;
-          break;
-
-        }
-
-      self_trace_t::self_trace().launchmon_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().tracer_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().symtab_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().event_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().driver_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().machine_module_trace.verbosity_level = verbo;
-      self_trace_t::self_trace().opt_module_trace.verbosity_level = verbo;
+    switch (il) {
+      case 0:
+        verbo = quiet;
+        break;
+      case 1:
+        verbo = level1;
+        break;
+      case 2:
+        verbo = level2;
+        break;
+      case 3:
+        verbo = level3;
+        break;
+      default:
+        verbo = quiet;
+        break;
     }
 
-  if ( !has_parse_error && !construct_rm_map() )
-    {
-      if ( my_opt->remote && (my_opt->verbose == 0 ))
-        has_parse_error = true;
-      else
-        print_usage();
+    self_trace_t::self_trace().launchmon_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().tracer_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().symtab_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().event_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().driver_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().machine_module_trace.verbosity_level = verbo;
+    self_trace_t::self_trace().opt_module_trace.verbosity_level = verbo;
+  }
 
-      rv = false;
-    }
+  if (!has_parse_error && !construct_rm_map()) {
+    if (my_opt->remote && (my_opt->verbose == 0))
+      has_parse_error = true;
+    else
+      print_usage();
 
-  if ( !(my_opt->remote && (my_opt->verbose == 0 )) )
-    print_copyright();
+    rv = false;
+  }
+
+  if (!(my_opt->remote && (my_opt->verbose == 0))) print_copyright();
 
   return rv;
 }
 
-
 //!  opts_args_t::construct_rm_map()
 /*!
- 
-*/
-bool
-opts_args_t::construct_rm_map ()
-{
-  if (!my_opt) 
-    {
-      {
-	self_trace_t::trace ( true, 
-	  MODULENAME,
-	  1,
-	  "options and arguments have not been parsed ");
-      }
 
-      return false;
+*/
+bool opts_args_t::construct_rm_map() {
+  if (!my_opt) {
+    {
+      self_trace_t::trace(true, MODULENAME, 1,
+                          "options and arguments have not been parsed ");
     }
+
+    return false;
+  }
 
   bool initc = my_rmconfig->init(std::string(TARGET_OS_ISA_STRING));
 
-  if(!initc)
-    {
-      self_trace_t::trace ( true,
-        MODULENAME,
-        1,
-        "unable to initialize the RM map object ");
+  if (!initc) {
+    self_trace_t::trace(true, MODULENAME, 1,
+                        "unable to initialize the RM map object ");
 
-      return false;
-    }
+    return false;
+  }
 
   return true;
 }
 
-
 //!  opts_args_t::print_usage()
-/*!  
+/*!
      prints the usage
 */
-void 
-opts_args_t::print_usage()
-{
+void opts_args_t::print_usage() {
   using std::cerr;
   using std::endl;
 
@@ -472,39 +438,37 @@ opts_args_t::print_usage()
   cerr << "options:" << endl;
   cerr << "\t\t-v, --verbose 0~2           sets the verbosity level." << endl;
   cerr << "\t\t-h, --help                  prints this message." << endl;
-  cerr << "\t\t-r, --remote ip:port        invokes launchmon in API mode." << endl;
-  cerr << "\t\t-d, --daemonpath path       sets the tool daemon path." << endl;
-  cerr << "\t\t-t, --daemonopts \"opts\"     sets the tool daemon option set." << endl;
-  cerr << "\t\t-p, --pid pid               attaches to pid, the pid of running parallel "
-       << "job launcher process." << endl; 
-  cerr << "\t\t-a  args                    pass all subsequent arguments to the parallel job launcher. "
-       << endl << endl;
-  cerr << "example: launchmon -v 1 -d tooldaemon -t \"-k -r\" "
-       << "srun -a -n 4 -N 2 -ppdebug ./code"
+  cerr << "\t\t-r, --remote ip:port        invokes launchmon in API mode."
        << endl;
-  cerr << "         launchmon --daemonpath tooldaemon -pid 1234" 
-       << endl << endl;
+  cerr << "\t\t-d, --daemonpath path       sets the tool daemon path." << endl;
+  cerr << "\t\t-t, --daemonopts \"opts\"     sets the tool daemon option set."
+       << endl;
+  cerr << "\t\t-p, --pid pid               attaches to pid, the pid of running "
+          "parallel "
+       << "job launcher process." << endl;
+  cerr << "\t\t-a  args                    pass all subsequent arguments to "
+          "the parallel job launcher. "
+       << endl
+       << endl;
+  cerr << "example: launchmon -v 1 -d tooldaemon -t \"-k -r\" "
+       << "srun -a -n 4 -N 2 -ppdebug ./code" << endl;
+  cerr << "         launchmon --daemonpath tooldaemon -pid 1234" << endl
+       << endl;
 
-  exit(-1); 
+  exit(-1);
 }
-
 
 //!  opts_args_t::print_copyright()
 /*!
      print the copyright
 */
-void 
-opts_args_t::print_copyright()
-{
+void opts_args_t::print_copyright() {
   {
-     self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,
-        0,
-        my_opt->copyright.c_str());
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 0,
+                        my_opt->copyright.c_str());
   }
   std::cout << my_opt->copyright << std::endl;
 }
-
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -512,14 +476,11 @@ opts_args_t::print_copyright()
 //
 ///////////////////////////////////////////////////////////////////
 
-
 //!  opts_args_t::check_path
 /*!
 
 */
-bool
-opts_args_t::check_path ( std::string &base, std::string &path )
-{
+bool opts_args_t::check_path(std::string &base, std::string &path) {
   using namespace std;
 
   char *pth = NULL;
@@ -531,44 +492,35 @@ opts_args_t::check_path ( std::string &base, std::string &path )
   mypath = strdup(getenv("PATH"));
   mypathstart = mypath;
 
-  while ( stat( path.c_str(), &pathchk ) != 0 )
-    {
-      pth = strtok(mypathstart, ":");
-      if ( (base[0] != '/') && pth != NULL )
-	{
-	  string dt = string(pth) + string("/") +  string(base);
-	  path = dt;
-	}
-      else
-        {
-	  {
-	    self_trace_t::trace ( LEVELCHK(quiet),
-	    MODULENAME,
-	    1,
-	    "the path[%s] does not exit.",
-	    base.c_str());
-	  }
-	  rc = false;
-	  break;
-        }
-      mypathstart = NULL;	
+  while (stat(path.c_str(), &pathchk) != 0) {
+    pth = strtok(mypathstart, ":");
+    if ((base[0] != '/') && pth != NULL) {
+      string dt = string(pth) + string("/") + string(base);
+      path = dt;
+    } else {
+      {
+        self_trace_t::trace(LEVELCHK(quiet), MODULENAME, 1,
+                            "the path[%s] does not exit.", base.c_str());
+      }
+      rc = false;
+      break;
     }
+    mypathstart = NULL;
+  }
 
   free(mypath);
 
   return rc;
 }
 
-
 //!
 /*!  opt_args_t copy constructor
      the only member it doesn't do the deep copy is "remaining"
 
-     Jun 09 2010, move this copy ctor to the private area to 
+     Jun 09 2010, move this copy ctor to the private area to
      prevent this object from being copied
 */
-opts_args_t::opts_args_t ( const opts_args_t& o )
-{
+opts_args_t::opts_args_t(const opts_args_t &o) {
   if (o.my_opt != NULL) {
     my_opt = new opt_struct_t();
     my_opt->verbose = o.my_opt->verbose;
@@ -587,3 +539,7 @@ opts_args_t::opts_args_t ( const opts_args_t& o )
     MODULENAME = o.MODULENAME;
   }
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_opt.hxx
+++ b/launchmon/src/sdbg_opt.hxx
@@ -1,30 +1,30 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_opt.hxx,v 1.6.2.3 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *
  *
  *  Update Log:
  *        Apr 22 2014 DHA: Applied a patch to store RM args/opts into
@@ -47,75 +47,75 @@
 
 #ifndef SDBG_OPT_HXX
 #define SDBG_OPT_HXX 1
- 
+
 #include <lmon_api/common.h>
- 
+
 extern "C" {
+#include <assert.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/stat.h>
-#include <assert.h>
 }
 
 #include <iostream>
-#include <string>
 #include <map>
+#include <string>
 
-#include "sdbg_std.hxx"
 #include "sdbg_rm_map.hxx"
 #include "sdbg_self_trace.hxx"
+#include "sdbg_std.hxx"
 
 //! struct opt_struct_t
 /*!
     Structure capturing optionset. Look at comments on each member
 */
 struct opt_struct_t {
-  int         verbose;          // verbose level
-  bool        attach;           // is this attach-to-a-running job case?
-  bool        remote;           // is this remote case? 
-  std::string tool_daemon;      // path to the lightweight debug engine
-  std::string debugtarget;      // parallel job launcher
-  std::string copyright;        // copy right for this project
-  std::string launchstring;     // launch string to be expanded
-  std::list<std::string>   tool_daemon_opts; // options to the lightweight debug engine
-  std::string remote_info;      // ip:port
-  std::string lmon_sec_info;    // shared secret:randomID
-  pid_t       launcher_pid;     // the pid of a running parallel launcher process
-  char      **remaining;        // options and arguments to be passed 
+  int verbose;               // verbose level
+  bool attach;               // is this attach-to-a-running job case?
+  bool remote;               // is this remote case?
+  std::string tool_daemon;   // path to the lightweight debug engine
+  std::string debugtarget;   // parallel job launcher
+  std::string copyright;     // copy right for this project
+  std::string launchstring;  // launch string to be expanded
+  std::list<std::string>
+      tool_daemon_opts;      // options to the lightweight debug engine
+  std::string remote_info;   // ip:port
+  std::string lmon_sec_info; // shared secret:randomID
+  pid_t launcher_pid;        // the pid of a running parallel launcher process
+  char **remaining;          // options and arguments to be passed
   std::map<std::string, std::string> envMap;
 };
 
-
 //! class opt_struct_t
 /*!
-    constructor allocates my_opt. process_args parses options and arguments 
+    constructor allocates my_opt. process_args parses options and arguments
     filling my_opt.
 */
 class opts_args_t {
-
-public:
+ public:
   opts_args_t();
-  ~opts_args_t();  
+  ~opts_args_t();
 
-  define_gset(opt_struct_t*, my_opt)
-  define_gset(rc_rm_t*, my_rmconfig)
+  define_gset(opt_struct_t *, my_opt)
+  define_gset(rc_rm_t *, my_rmconfig)
   define_gset(bool, has_parse_error)
 
-  bool process_args (int *argc, char ***argv);
+  bool process_args(int *argc, char ***argv);
   void print_usage();
   bool construct_rm_map();
   void print_copyright();
 
-
-private:
-  bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().opt_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().opt_module_trace.verbosity_level >=
+            level);
+  }
 
   bool check_path(std::string &base, std::string &pth);
 
   bool has_parse_error;
 
-  // move the copy ctor in the private area preventing an object 
+  // move the copy ctor in the private area preventing an object
   // of this class copied
   opts_args_t(const opts_args_t &o);
 
@@ -127,4 +127,8 @@ private:
   std::string MODULENAME;
 };
 
-#endif // SDBG_OPT_HXX
+#endif  // SDBG_OPT_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_rm_map.cxx
+++ b/launchmon/src/sdbg_rm_map.cxx
@@ -1,29 +1,31 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
  *
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
  *        Apr 01 2015 ADG: Added Cray CTI support.
@@ -39,21 +41,21 @@
 
 #include <lmon_api/common.h>
 
-#include <string>
 #include <limits.h>
-#include <sstream>
 #include <fstream>
-#include <map>
-#include <vector>
 #include <list>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
 
-// Jun 07 2012 DHA TODO: We need to check boost/tokenizer.hpp; 
+// Jun 07 2012 DHA TODO: We need to check boost/tokenizer.hpp;
 // doing so generates whole lot of errors on some platforms
-// so I'm skipping that check for now. We need to 
+// so I'm skipping that check for now. We need to
 // revisit that issue.
-// Effectively, the following currently assumes that boost is ubiquitious 
+// Effectively, the following currently assumes that boost is ubiquitious
 //#if HAVE_BOOST_TOKENIZER_HPP
-# include <boost/tokenizer.hpp>
+#include <boost/tokenizer.hpp>
 //#else
 //# error boost/tokenizer is required; no alternative tokenizer
 //#endif
@@ -62,13 +64,11 @@
 
 #include "sdbg_rm_map.hxx"
 
-
 ///////////////////////////////////////////////////////////////////
 //                                                               //
 //                 PUBLIC INTERFACES                             //
 //                                                               //
 ///////////////////////////////////////////////////////////////////
-
 
 ///////////////////////////////////////////////////////////////////
 //                                                               //
@@ -76,77 +76,53 @@
 //                                                               //
 ///////////////////////////////////////////////////////////////////
 
-
 rm_id_t::rm_id_t()
-    : from (from_unknown_source),
-      method(unknown_method),
-      dtype(unknown_type)
-{
+    : from(from_unknown_source), method(unknown_method), dtype(unknown_type) {
   id.symbol_name = NULL;
 }
 
-
-rm_id_t::rm_id_t(const rm_id_t &o)
-{
+rm_id_t::rm_id_t(const rm_id_t &o) {
   from = o.from;
   method = o.method;
   dtype = o.dtype;
 
-  if ((o.method == symbol) && o.id.symbol_name)
-    {
-      id.symbol_name = strdup(o.id.symbol_name);
-    }
-  else
-    {
-      memcpy(&id, &(o.id), sizeof(id));
-    }
+  if ((o.method == symbol) && o.id.symbol_name) {
+    id.symbol_name = strdup(o.id.symbol_name);
+  } else {
+    memcpy(&id, &(o.id), sizeof(id));
+  }
 }
 
-
-rm_id_t::~rm_id_t()
-{
-  if ((method == symbol) && id.symbol_name)
-    {
-      free(id.symbol_name);
-    }
+rm_id_t::~rm_id_t() {
+  if ((method == symbol) && id.symbol_name) {
+    free(id.symbol_name);
+  }
 }
 
-
-rm_id_t &
-rm_id_t::operator=(const rm_id_t & rhs)
-{
+rm_id_t &rm_id_t::operator=(const rm_id_t &rhs) {
   from = rhs.from;
   method = rhs.method;
   dtype = rhs.dtype;
-  if ((rhs.method == symbol) && rhs.id.symbol_name)
-    {
-      id.symbol_name = strdup(rhs.id.symbol_name);
-    }
-  else
-    {
-      memcpy(&id, &(rhs.id), sizeof(id));
-    }
+  if ((rhs.method == symbol) && rhs.id.symbol_name) {
+    id.symbol_name = strdup(rhs.id.symbol_name);
+  } else {
+    memcpy(&id, &(rhs.id), sizeof(id));
+  }
 
   return *this;
 }
 
-
 resource_manager_t::resource_manager_t()
-  : rm(RC_none),
-    mpir(x_none),
-    fail_detection_supported(false),
-    launch_string(""),
-    expanded_launch_string(""),
-    has_launcher_so(false),
-    launcher_so_name(""),
-    attach_fifo_path("")
-{
+    : rm(RC_none),
+      mpir(x_none),
+      fail_detection_supported(false),
+      launch_string(""),
+      expanded_launch_string(""),
+      has_launcher_so(false),
+      launcher_so_name(""),
+      attach_fifo_path("") {}
 
-}
-
-
-resource_manager_t::resource_manager_t(const resource_manager_t &r)
-{
+resource_manager_t::resource_manager_t(const resource_manager_t &r) {
   rm = r.rm;
   mpir = r.mpir;
   launchers = r.launchers;
@@ -162,24 +138,17 @@ resource_manager_t::resource_manager_t(const resource_manager_t &r)
   attach_fifo_path = r.attach_fifo_path;
 }
 
+resource_manager_t::~resource_manager_t() {
+  if (!launchers.empty()) {
+    launchers.clear();
+  }
 
-resource_manager_t::~resource_manager_t()
-{
-  if (!launchers.empty())
-    {
-       launchers.clear();
-    }
-
-  if (!kill_signals.empty())
-    {
-       launchers.clear();
-    }
+  if (!kill_signals.empty()) {
+    launchers.clear();
+  }
 }
 
-
-resource_manager_t &
-resource_manager_t::operator=(const resource_manager_t &r)
-{
+resource_manager_t &resource_manager_t::operator=(const resource_manager_t &r) {
   rm = r.rm;
   mpir = r.mpir;
   launchers = r.launchers;
@@ -195,118 +164,66 @@ resource_manager_t::operator=(const resource_manager_t &r)
   attach_fifo_path = r.attach_fifo_path;
 }
 
-
-const std::vector<rm_id_t>& 
-resource_manager_t::get_const_launcher_ids() const
-{
+const std::vector<rm_id_t> &resource_manager_t::get_const_launcher_ids() const {
   return launcher_ids;
 }
 
-
-const std::vector<std::string>& 
-resource_manager_t::get_const_launchers() const
-{
+const std::vector<std::string> &resource_manager_t::get_const_launchers()
+    const {
   return launchers;
 }
 
-
-void
-resource_manager_t::fill_rm_type(const std::string &v)
-{
-  if (v == std::string("alps"))
-    {
-      rm = RC_alps;
-    }
-  else if (v == std::string("bglrm"))
-    {
-      rm = RC_bglrm;
-    }
-  else if (v == std::string("bgprm"))
-    {
-      rm = RC_bgprm;
-    }
-  else if (v == std::string("bgqrm"))
-    {
-      rm = RC_bgqrm;
-    }
-  else if (v == std::string("bgq_slurm"))
-    {
-      rm = RC_bgq_slurm;
-    }
-  else if (v == std::string("cray"))
-    {
-      rm = RC_cray;
-    }
-  else if (v == std::string("modelchecker"))
-    {
-      rm = RC_mchecker_rm;
-    }
-  else if (v == std::string("openrte"))
-    {
-      rm = RC_orte;
-    }
-  else if (v == std::string("slurm"))
-    {
-      rm = RC_slurm;
-    }
-  else if (v == std::string("mpiexec_hydra"))
-    {
-      rm = RC_mpiexec_hydra;
-    }
-  else if (v == std::string("gupc"))
-    {
-      rm = RC_gupc;
-    }
-  else
-    {
-      rm = RC_none;
-    }
+void resource_manager_t::fill_rm_type(const std::string &v) {
+  if (v == std::string("alps")) {
+    rm = RC_alps;
+  } else if (v == std::string("bglrm")) {
+    rm = RC_bglrm;
+  } else if (v == std::string("bgprm")) {
+    rm = RC_bgprm;
+  } else if (v == std::string("bgqrm")) {
+    rm = RC_bgqrm;
+  } else if (v == std::string("bgq_slurm")) {
+    rm = RC_bgq_slurm;
+  } else if (v == std::string("cray")) {
+    rm = RC_cray;
+  } else if (v == std::string("modelchecker")) {
+    rm = RC_mchecker_rm;
+  } else if (v == std::string("openrte")) {
+    rm = RC_orte;
+  } else if (v == std::string("slurm")) {
+    rm = RC_slurm;
+  } else if (v == std::string("mpiexec_hydra")) {
+    rm = RC_mpiexec_hydra;
+  } else if (v == std::string("gupc")) {
+    rm = RC_gupc;
+  } else {
+    rm = RC_none;
+  }
 }
 
-
-void
-resource_manager_t::fill_mpir_type(const std::string &v)
-{
-  if (v == std::string("STD"))
-    {
-      mpir = standard;
-    }
-  else if (v == std::string("STD_CRAY"))
-    {
-      mpir = x_cray;
-    }
-  else if (v == std::string("STD_COLOC"))
-    {
-      mpir = x_coloc;
-    }
-  else if (v == std::string("STD_FIFO"))
-    {
-      mpir = x_fifo;
-    }
-  else if (v == std::string("STD_COLOC_FIFO"))
-    {
-      mpir = x_coloc_fifo;
-    }
-  else
-    {
-      mpir = x_none;
-    }
+void resource_manager_t::fill_mpir_type(const std::string &v) {
+  if (v == std::string("STD")) {
+    mpir = standard;
+  } else if (v == std::string("STD_CRAY")) {
+    mpir = x_cray;
+  } else if (v == std::string("STD_COLOC")) {
+    mpir = x_coloc;
+  } else if (v == std::string("STD_FIFO")) {
+    mpir = x_fifo;
+  } else if (v == std::string("STD_COLOC_FIFO")) {
+    mpir = x_coloc_fifo;
+  } else {
+    mpir = x_none;
+  }
 }
 
-
-void
-resource_manager_t::fill_launchers(const std::vector<std::string> &vect)
-{
-  if (!vect.empty())
-    {
-      launchers = vect;
-    }
+void resource_manager_t::fill_launchers(const std::vector<std::string> &vect) {
+  if (!vect.empty()) {
+    launchers = vect;
+  }
 }
 
-
-void
-resource_manager_t::fill_id(rm_id_t &target_id, const std::string &v)
-{
+void resource_manager_t::fill_id(rm_id_t &target_id, const std::string &v) {
   std::string na("na");
   std::string key = na;
   std::string method = na;
@@ -314,194 +231,132 @@ resource_manager_t::fill_id(rm_id_t &target_id, const std::string &v)
   std::string dt = na;
 
   size_t ix = v.find_first_of("|", 0);
-  if (ix != std::string::npos)
-    {
-      key = v.substr(0, ix);
-      size_t ix2 = v.find_first_of("|", ix+1);
-      if (ix2 != std::string::npos)
-        {
-          method = v.substr(ix+1, ix2-(ix+1));
-          size_t ix3 = v.find_first_of("|", ix2+1);
-          if (ix3 != std::string::npos)
-            {
-              id = v.substr(ix2+1, ix3-(ix2+1));
-              dt = v.substr(ix3+1, std::string::npos);
-            }
-          else
-            {
-              id = v.substr(ix2+1, std::string::npos);
-            }
-        }
-      else
-        {
-           method = v.substr(ix+1, std::string::npos);
-        }
+  if (ix != std::string::npos) {
+    key = v.substr(0, ix);
+    size_t ix2 = v.find_first_of("|", ix + 1);
+    if (ix2 != std::string::npos) {
+      method = v.substr(ix + 1, ix2 - (ix + 1));
+      size_t ix3 = v.find_first_of("|", ix2 + 1);
+      if (ix3 != std::string::npos) {
+        id = v.substr(ix2 + 1, ix3 - (ix2 + 1));
+        dt = v.substr(ix3 + 1, std::string::npos);
+      } else {
+        id = v.substr(ix2 + 1, std::string::npos);
+      }
+    } else {
+      method = v.substr(ix + 1, std::string::npos);
     }
+  }
 
-  if (key == std::string("RM_launcher"))
-    {
-      target_id.from = from_launcher;
-    }
-  else
-    {
-      target_id.from = from_unknown_source;
-    }
+  if (key == std::string("RM_launcher")) {
+    target_id.from = from_launcher;
+  } else {
+    target_id.from = from_unknown_source;
+  }
 
-  if (method == std::string("sym"))
-    {
-      target_id.method = symbol;
-      target_id.id.symbol_name = strdup(id.c_str());
-      if (dt == std::string("string"))
-        {
-          target_id.dtype = cstring;
-        }
-      else if ((dt == std::string("int32"))
-               || (dt == std::string("integer")))
-        {
-          target_id.dtype = integer32;
-        }
-      else if (dt == std::string("int64"))
-        {
-          target_id.dtype = integer64;
-        }
-      else
-        {
-          target_id.dtype = unknown_type;
-        }
+  if (method == std::string("sym")) {
+    target_id.method = symbol;
+    target_id.id.symbol_name = strdup(id.c_str());
+    if (dt == std::string("string")) {
+      target_id.dtype = cstring;
+    } else if ((dt == std::string("int32")) || (dt == std::string("integer"))) {
+      target_id.dtype = integer32;
+    } else if (dt == std::string("int64")) {
+      target_id.dtype = integer64;
+    } else {
+      target_id.dtype = unknown_type;
     }
-  else if (method == std::string("pid"))
-    {
-      target_id.method = pid;
-      target_id.id.process_id = 0;
-    }
-  else
-    {
-      target_id.method = unknown_method;
-    }
+  } else if (method == std::string("pid")) {
+    target_id.method = pid;
+    target_id.id.process_id = 0;
+  } else {
+    target_id.method = unknown_method;
+  }
 }
 
-
-void
-resource_manager_t::fill_job_id(const std::string &v)
-{
+void resource_manager_t::fill_job_id(const std::string &v) {
   fill_id(job_id, v);
 }
 
-
-void
-resource_manager_t::fill_launcher_id(const std::vector<std::string> &vect)
-{
+void resource_manager_t::fill_launcher_id(
+    const std::vector<std::string> &vect) {
   std::vector<std::string>::const_iterator c_i;
-  for (c_i = vect.begin(); c_i != vect.end(); c_i++)
-    {
-      rm_id_t  a_launcher_id;
-      fill_id(a_launcher_id, (*c_i));
-      launcher_ids.push_back(a_launcher_id);
-    }
-
+  for (c_i = vect.begin(); c_i != vect.end(); c_i++) {
+    rm_id_t a_launcher_id;
+    fill_id(a_launcher_id, (*c_i));
+    launcher_ids.push_back(a_launcher_id);
+  }
 }
 
-
-void
-resource_manager_t::fill_launcher_so(const std::string &v)
-{
+void resource_manager_t::fill_launcher_so(const std::string &v) {
   has_launcher_so = true;
   launcher_so_name = v;
 }
 
-
-void
-resource_manager_t::fill_kill_singals(const std::string &v)
-{
+void resource_manager_t::fill_kill_singals(const std::string &v) {
   int signal_type = 0;
   size_t ix = 0;
   size_t ix2 = 0;
 
-  while ( (ix2 = v.find_first_of("|", ix)) != std::string::npos)
-    {
-       signal_type = resolve_signal(v.substr(ix, ix2));
-       kill_signals.push_back(signal_type);
-       ix = ix2+1;
-    }
+  while ((ix2 = v.find_first_of("|", ix)) != std::string::npos) {
+    signal_type = resolve_signal(v.substr(ix, ix2));
+    kill_signals.push_back(signal_type);
+    ix = ix2 + 1;
+  }
 
   signal_type = resolve_signal(v.substr(ix, ix2));
   kill_signals.push_back(signal_type);
 }
 
-
-void
-resource_manager_t::fill_fail_detection(const std::string &v)
-{
+void resource_manager_t::fill_fail_detection(const std::string &v) {
   fail_detection_supported = false;
 
-  if (v == std::string("true"))
-    {
-      fail_detection_supported = true;
-    }
-
+  if (v == std::string("true")) {
+    fail_detection_supported = true;
+  }
 }
 
-
-void
-resource_manager_t::fill_launch_helper(const std::string &v)
-{
-  if (v == std::string("mpir"))
-    {
-      launch_helper.launch_method = mpir_coloc;
-    }
-  else
-    {
-      launch_helper.launch_method = launch_helper_method;
-      // Some RMs will package their launch helper with launchmon. If v is not
-      // found, then we will test to see if it is included with launchmon.
-      std::string v2 = v;
-      if (access(v.c_str(), R_OK) < 0)
-        {
-          char *pref;
-          //
-          // FIXME: DHA May 6 2016. This probably won't work with the
-          // new in-tree testing support introduced with PR #12.
-          //
-          if (pref = getenv("LMON_PREFIX"))
-            {
-              v2.clear();
-              v2 = std::string(pref) + std::string("/bin/") + v;
-              // Check for packaged launch helper, if it is not found then we
-              // assume that v is found in PATH.
-              if (access(v2.c_str(), R_OK) < 0)
-                {
-                  // reset back to v, it is in PATH.
-                  v2.clear();
-                  v2 = v;
-                }
-            }
+void resource_manager_t::fill_launch_helper(const std::string &v) {
+  if (v == std::string("mpir")) {
+    launch_helper.launch_method = mpir_coloc;
+  } else {
+    launch_helper.launch_method = launch_helper_method;
+    // Some RMs will package their launch helper with launchmon. If v is not
+    // found, then we will test to see if it is included with launchmon.
+    std::string v2 = v;
+    if (access(v.c_str(), R_OK) < 0) {
+      char *pref;
+      //
+      // FIXME: DHA May 6 2016. This probably won't work with the
+      // new in-tree testing support introduced with PR #12.
+      //
+      if (pref = getenv("LMON_PREFIX")) {
+        v2.clear();
+        v2 = std::string(pref) + std::string("/bin/") + v;
+        // Check for packaged launch helper, if it is not found then we
+        // assume that v is found in PATH.
+        if (access(v2.c_str(), R_OK) < 0) {
+          // reset back to v, it is in PATH.
+          v2.clear();
+          v2 = v;
         }
-      launch_helper.launcher_command = v2;
+      }
     }
+    launch_helper.launcher_command = v2;
+  }
 }
 
-
-void
-resource_manager_t::fill_launch_string(const std::string &v)
-{
+void resource_manager_t::fill_launch_string(const std::string &v) {
   launch_string = v;
 }
 
-
-void
-resource_manager_t::fill_expanded_launch_string(const std::string &v)
-{
+void resource_manager_t::fill_expanded_launch_string(const std::string &v) {
   expanded_launch_string = v;
 }
 
-
-void
-resource_manager_t::fill_attach_fifo_path(const std::string &v)
-{
+void resource_manager_t::fill_attach_fifo_path(const std::string &v) {
   attach_fifo_path = v;
 }
-
-
 
 ///////////////////////////////////////////////////////////////////
 //                                                               //
@@ -509,124 +364,89 @@ resource_manager_t::fill_attach_fifo_path(const std::string &v)
 //                                                               //
 ///////////////////////////////////////////////////////////////////
 
-
-rc_rm_t::rc_rm_t()
-{
+rc_rm_t::rc_rm_t() {
   MODULENAME = self_trace_t::self_trace().rm_module_trace.module_name;
 }
 
-
-rc_rm_t::rc_rm_t(const rc_rm_t &o)
-{
+rc_rm_t::rc_rm_t(const rc_rm_t &o) {
   resource_manager = o.resource_manager;
   coloc_paramset = o.coloc_paramset;
 }
 
-
-rc_rm_t &
-rc_rm_t::operator=(const rc_rm_t &rhs)
-{
+rc_rm_t &rc_rm_t::operator=(const rc_rm_t &rhs) {
   resource_manager = rhs.resource_manager;
   coloc_paramset = rhs.coloc_paramset;
 }
 
+rc_rm_t::~rc_rm_t() {
+  if (coloc_paramset.sharedsec) free(coloc_paramset.sharedsec);
 
-rc_rm_t::~rc_rm_t()
-{
-  if (coloc_paramset.sharedsec)
-    free(coloc_paramset.sharedsec);
+  if (coloc_paramset.randomid) free(coloc_paramset.randomid);
 
-  if (coloc_paramset.randomid)
-    free(coloc_paramset.randomid);
+  if (coloc_paramset.hnfilename) free(coloc_paramset.hnfilename);
 
-  if (coloc_paramset.hnfilename)
-    free(coloc_paramset.hnfilename);
-
-  if (!supported_rms.empty())
-    {
-      supported_rms.clear();
-    }
+  if (!supported_rms.empty()) {
+    supported_rms.clear();
+  }
 }
 
-
-bool
-rc_rm_t::init(const std::string &os_isa_string)
-{
+bool rc_rm_t::init(const std::string &os_isa_string) {
   char *pref;
   bool found_supported_rm = false;
   std::vector<std::string> supported_rm_fnames;
   std::string rm_info_conf_path(RM_INFO_CONFIG);
   std::string config_dir = std::string("/etc/");
 
-  if (pref = getenv("LMON_PREFIX"))
-    {
-      config_dir = std::string(pref) + config_dir;
-      rm_info_conf_path = config_dir + rm_info_conf_path;
-    }
-  else if (pref = getenv("LMON_RM_CONFIG_DIR"))
-    {
-      config_dir = std::string(pref) + std::string("/");
-      rm_info_conf_path = config_dir + rm_info_conf_path;
-    }
-  else
-    {
-      config_dir = std::string(LMON_PREFIX) + config_dir;
-      rm_info_conf_path = config_dir + rm_info_conf_path;
-    }
+  if (pref = getenv("LMON_PREFIX")) {
+    config_dir = std::string(pref) + config_dir;
+    rm_info_conf_path = config_dir + rm_info_conf_path;
+  } else if (pref = getenv("LMON_RM_CONFIG_DIR")) {
+    config_dir = std::string(pref) + std::string("/");
+    rm_info_conf_path = config_dir + rm_info_conf_path;
+  } else {
+    config_dir = std::string(LMON_PREFIX) + config_dir;
+    rm_info_conf_path = config_dir + rm_info_conf_path;
+  }
 
-  if (!read_supported_rm_confs(os_isa_string,
-                               rm_info_conf_path,
-                               supported_rm_fnames))
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "read_supported_rm_confs returned false.");
+  if (!read_supported_rm_confs(os_isa_string, rm_info_conf_path,
+                               supported_rm_fnames)) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "read_supported_rm_confs returned false.");
 
-      return found_supported_rm;
-    }
+    return found_supported_rm;
+  }
 
-  if (supported_rm_fnames.empty())
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "supported rm files not found.");
+  if (supported_rm_fnames.empty()) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "supported rm files not found.");
 
-      return found_supported_rm;
-    }
+    return found_supported_rm;
+  }
 
   found_supported_rm = true;
   std::vector<std::string>::const_iterator c_i;
   resource_manager_t target_rm;
 
-  for (c_i = supported_rm_fnames.begin();
-           c_i != supported_rm_fnames.end(); c_i++)
-    {
-      resource_manager_t a_rm;
-      std::string c_path = config_dir + (*c_i);
-      parse_and_fill_rm(c_path,  a_rm);
-      supported_rms.push_back(a_rm);
-    }
+  for (c_i = supported_rm_fnames.begin(); c_i != supported_rm_fnames.end();
+       c_i++) {
+    resource_manager_t a_rm;
+    std::string c_path = config_dir + (*c_i);
+    parse_and_fill_rm(c_path, a_rm);
+    supported_rms.push_back(a_rm);
+  }
 
   return found_supported_rm;
 }
 
+bool rc_rm_t::set_paramset(int n_nodes, int n_daemons, char *secret,
+                           char *ran_id, int resource_id,
+                           char *host_file_name) {
+  if (!secret || !ran_id) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "shared secret or random id null.");
 
-bool
-rc_rm_t::set_paramset (int n_nodes,
-                       int n_daemons,
-                       char *secret,
-                       char *ran_id,
-                       int resource_id,
-                       char *host_file_name)
-{
-  if (!secret || !ran_id)
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "shared secret or random id null.");
-
-      return false;
-    }
+    return false;
+  }
 
   coloc_paramset.nnodes = n_nodes;
   coloc_paramset.ndaemons = n_daemons;
@@ -634,18 +454,15 @@ rc_rm_t::set_paramset (int n_nodes,
   coloc_paramset.randomid = strdup(ran_id);
   coloc_paramset.resourceid = resource_id;
 
-  if (host_file_name)
-    {
-      coloc_paramset.hnfilename= strdup(host_file_name);
-    }
+  if (host_file_name) {
+    coloc_paramset.hnfilename = strdup(host_file_name);
+  }
 
   return true;
 }
 
-
-const std::list<std::string>
-rc_rm_t::expand_launch_string(std::string &expanded_string)
-{
+const std::list<std::string> rc_rm_t::expand_launch_string(
+    std::string &expanded_string) {
   std::string tmp_lstr = resource_manager.get_launch_string();
   launch_method_e mth = resource_manager.get_launch_helper().launch_method;
   std::list<std::string> tokens;
@@ -653,281 +470,192 @@ rc_rm_t::expand_launch_string(std::string &expanded_string)
   size_t ix = 0;
   size_t ix2 = 0;
 
-  if (mth == launch_helper_method)
-    {
-      if ( getenv("LMON_DEBUG_BES") 
-           &&  resource_manager.get_launch_helper().launcher_command 
-               != std::string("LMON_REMOTE_LOGIN"))
-        {
-          //
-          // Can't support debugging if the launch method is LMON_REMOTE_LOGIN
-          //
-          tokens.push_back(std::string(TVCMD));
-          tokens.push_back(resource_manager.get_launch_helper().launcher_command);
-          tokens.push_back(std::string("-a"));
+  if (mth == launch_helper_method) {
+    if (getenv("LMON_DEBUG_BES") &&
+        resource_manager.get_launch_helper().launcher_command !=
+            std::string("LMON_REMOTE_LOGIN")) {
+      //
+      // Can't support debugging if the launch method is LMON_REMOTE_LOGIN
+      //
+      tokens.push_back(std::string(TVCMD));
+      tokens.push_back(resource_manager.get_launch_helper().launcher_command);
+      tokens.push_back(std::string("-a"));
+    } else {
+      if (resource_manager.get_launch_helper().launcher_command ==
+          std::string("LMON_REMOTE_LOGIN")) {
+        char *rmthd = getenv("LMON_REMOTE_LOGIN");
+        if (rmthd) {
+          tokens.push_back(std::string(rmthd));
+        } else {
+          tokens.push_back(std::string(SSHCMD));
         }
-      else
-        {
-          if ( resource_manager.get_launch_helper().launcher_command 
-              == std::string("LMON_REMOTE_LOGIN") )
-            {
-              char *rmthd = getenv("LMON_REMOTE_LOGIN");
-              if (rmthd)
-                {
-                   tokens.push_back(std::string(rmthd));
-                }
-              else
-                {
-                  tokens.push_back(std::string(SSHCMD));
-                }
-            }
-         else
-           {
-             tokens.push_back(resource_manager.get_launch_helper().launcher_command);
-           }
-        }
+      } else {
+        tokens.push_back(resource_manager.get_launch_helper().launcher_command);
+      }
     }
+  }
 
-  while ( (ix2 = tmp_lstr.find_first_of(" ", ix)) != std::string::npos)
-    {
-      token = tmp_lstr.substr(ix, ix2-ix);
-      tokens.push_back(token);
-      ix = ix2+1;
-    }
+  while ((ix2 = tmp_lstr.find_first_of(" ", ix)) != std::string::npos) {
+    token = tmp_lstr.substr(ix, ix2 - ix);
+    tokens.push_back(token);
+    ix = ix2 + 1;
+  }
 
-  if (ix != std::string::npos)
-    {
-      token = tmp_lstr.substr(ix, ix2-ix);
-      tokens.push_back(token);
-    }
+  if (ix != std::string::npos) {
+    token = tmp_lstr.substr(ix, ix2 - ix);
+    tokens.push_back(token);
+  }
 
-  if (tokens.empty())
-    {
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "ill-formed RM_launch_str?");
+  if (tokens.empty()) {
+    self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                        "ill-formed RM_launch_str?");
 
-      return tokens;
-    }
+    return tokens;
+  }
 
   std::list<std::string>::iterator itr;
 
-  for (itr=tokens.begin(); itr != tokens.end(); itr++)
-    {
-      size_t perc_sign_ix = (*itr).find_first_of("%", 0);
-      if ((perc_sign_ix < std::string::npos)
-           && ((perc_sign_ix+1) < (*itr).size()))
-        {
-          bool split_case = false;
-          std::string exp_substr = expand_a_letter((*itr)[perc_sign_ix+1], 
-                                                   &split_case);
-          if (exp_substr != std::string("na"))
-            {
-              (*itr).replace(perc_sign_ix, 2, exp_substr);
-            }
+  for (itr = tokens.begin(); itr != tokens.end(); itr++) {
+    size_t perc_sign_ix = (*itr).find_first_of("%", 0);
+    if ((perc_sign_ix < std::string::npos) &&
+        ((perc_sign_ix + 1) < (*itr).size())) {
+      bool split_case = false;
+      std::string exp_substr =
+          expand_a_letter((*itr)[perc_sign_ix + 1], &split_case);
+      if (exp_substr != std::string("na")) {
+        (*itr).replace(perc_sign_ix, 2, exp_substr);
+      }
 
-          if (split_case) 
-            {
-              std::string sep1("");
-              std::string sep2(" ");
-              std::string sep3("\"\'");
-              boost::escaped_list_separator<char> esc(sep1,sep2,sep3);
-              boost::tokenizer<boost::escaped_list_separator<char> > boost_token((*itr), esc); 
-              boost::tokenizer<boost::escaped_list_separator<char> >::iterator boost_itr;
-              std::list<std::string> sub_list; 
-              for (boost_itr = boost_token.begin(); 
-                     boost_itr != boost_token.end(); boost_itr++)
-                {
-                  sub_list.push_back(*boost_itr);
-                }
-
-              if (sub_list.size() > 1) 
-                {
-                  // insert the new sublist into the master list
-                  tokens.splice(itr, sub_list);
-                  // erase the current element and make sure
-                  // to update the itr to its previous iter so that
-                  // current for-loop can progress.
-                  tokens.erase(itr--);
-                }
-            }
+      if (split_case) {
+        std::string sep1("");
+        std::string sep2(" ");
+        std::string sep3("\"\'");
+        boost::escaped_list_separator<char> esc(sep1, sep2, sep3);
+        boost::tokenizer<boost::escaped_list_separator<char> > boost_token(
+            (*itr), esc);
+        boost::tokenizer<boost::escaped_list_separator<char> >::iterator
+            boost_itr;
+        std::list<std::string> sub_list;
+        for (boost_itr = boost_token.begin(); boost_itr != boost_token.end();
+             boost_itr++) {
+          sub_list.push_back(*boost_itr);
         }
+
+        if (sub_list.size() > 1) {
+          // insert the new sublist into the master list
+          tokens.splice(itr, sub_list);
+          // erase the current element and make sure
+          // to update the itr to its previous iter so that
+          // current for-loop can progress.
+          tokens.erase(itr--);
+        }
+      }
     }
+  }
 
   tokens.remove(std::string(""));
 
   expanded_string = "";
-  if (!tokens.empty())
-    {
-      int i;
-      for (itr=tokens.begin(); itr != tokens.end(); itr++)
-        {
-          expanded_string += (*itr);
-          if (itr != tokens.end())
-            {
-              expanded_string += " ";
-            }
-        }
+  if (!tokens.empty()) {
+    int i;
+    for (itr = tokens.begin(); itr != tokens.end(); itr++) {
+      expanded_string += (*itr);
+      if (itr != tokens.end()) {
+        expanded_string += " ";
+      }
     }
+  }
 
   resource_manager.fill_expanded_launch_string(expanded_string);
   return tokens;
 }
 
-
-const std::string &
-rc_rm_t::get_expanded_launch_string()
-{
+const std::string &rc_rm_t::get_expanded_launch_string() {
   return resource_manager.get_expanded_launch_string();
 }
 
-
-const std::vector<resource_manager_t> &
-rc_rm_t::get_supported_rms()
-{
+const std::vector<resource_manager_t> &rc_rm_t::get_supported_rms() {
   return supported_rms;
 }
 
-
-bool
-rc_rm_t::graceful_rmkill(int pid)
-{
-  if (pid < 0)
-    {
-      return false;
-    }
+bool rc_rm_t::graceful_rmkill(int pid) {
+  if (pid < 0) {
+    return false;
+  }
 
   std::vector<int>::iterator i;
-  for (i=resource_manager.get_kill_signals().begin();
-         i != resource_manager.get_kill_signals().end(); i++)
-    {
-      kill(pid, *i);
-      usleep (GracePeriodBNSignals);
-    }
+  for (i = resource_manager.get_kill_signals().begin();
+       i != resource_manager.get_kill_signals().end(); i++) {
+    kill(pid, *i);
+    usleep(GracePeriodBNSignals);
+  }
 
   return true;
 }
 
-
-bool
-rc_rm_t::need_check_launcher_so()
-{
+bool rc_rm_t::need_check_launcher_so() {
   return resource_manager.get_has_launcher_so();
 }
 
-
-bool
-rc_rm_t::is_modelchecker()
-{
+bool rc_rm_t::is_modelchecker() {
   return (resource_manager.get_rm() == RC_mchecker_rm);
 }
 
-
-bool
-rc_rm_t::is_coloc_sup()
-{
-  return ((resource_manager.get_mpir() == x_coloc)
-          || (resource_manager.get_mpir() == x_coloc_fifo));
+bool rc_rm_t::is_coloc_sup() {
+  return ((resource_manager.get_mpir() == x_coloc) ||
+          (resource_manager.get_mpir() == x_coloc_fifo));
 }
 
-
-bool
-rc_rm_t::is_attfifo_sup()
-{
-  return ((resource_manager.get_mpir() == x_fifo)
-          || (resource_manager.get_mpir() == x_coloc_fifo));
+bool rc_rm_t::is_attfifo_sup() {
+  return ((resource_manager.get_mpir() == x_fifo) ||
+          (resource_manager.get_mpir() == x_coloc_fifo));
 }
 
-
-bool
-rc_rm_t::is_cont_on_att()
-{
+bool rc_rm_t::is_cont_on_att() {
   return (resource_manager.get_mpir() == x_cray);
 }
 
-
-bool
-rc_rm_t::is_rid_sup()
-{
+bool rc_rm_t::is_rid_sup() {
   return (resource_manager.get_job_id().from != from_unknown_source);
 }
 
-
-bool
-rc_rm_t::is_fail_detect_sup()
-{
+bool rc_rm_t::is_fail_detect_sup() {
   return resource_manager.get_fail_detection_supported();
 }
 
-
-bool
-rc_rm_t::is_rid_via_symbol()
-{
+bool rc_rm_t::is_rid_via_symbol() {
   return (resource_manager.get_job_id().method == symbol);
 }
 
-
-bool
-rc_rm_t::is_rid_via_pid()
-{
+bool rc_rm_t::is_rid_via_pid() {
   return (resource_manager.get_job_id().method == pid);
 }
 
+resource_manager_t &rc_rm_t::get_resource_manager() { return resource_manager; }
 
-resource_manager_t & 
-rc_rm_t::get_resource_manager()
-{
-  return resource_manager;
-}
+coloc_str_param_t &rc_rm_t::get_coloc_paramset() { return coloc_paramset; }
 
-
-coloc_str_param_t & 
-rc_rm_t::get_coloc_paramset()
-{
+const coloc_str_param_t &rc_rm_t::get_const_coloc_paramset() {
   return coloc_paramset;
 }
 
+const char *rc_rm_t::get_hostnames_fn() { return coloc_paramset.hnfilename; }
 
-const coloc_str_param_t & 
-rc_rm_t::get_const_coloc_paramset()
-{
-  return coloc_paramset;
-}
-
-const char *
-rc_rm_t::get_hostnames_fn()
-{
-  return coloc_paramset.hnfilename;
-}
-
-
-const std::string & 
-rc_rm_t::get_launcher_so_name()
-{
+const std::string &rc_rm_t::get_launcher_so_name() {
   return resource_manager.get_launcher_so_name();
 }
 
-
-const std::string &
-rc_rm_t::get_attach_fifo_path()
-{
+const std::string &rc_rm_t::get_attach_fifo_path() {
   return resource_manager.get_attach_fifo_path();
 }
 
-
-void
-rc_rm_t::set_attach_fifo_path(const std::string &fifo_path)
-{
+void rc_rm_t::set_attach_fifo_path(const std::string &fifo_path) {
   resource_manager.fill_attach_fifo_path(fifo_path);
 }
 
-
-void
-rc_rm_t::set_resource_manager(const resource_manager_t &rmgr)
-{
+void rc_rm_t::set_resource_manager(const resource_manager_t &rmgr) {
   resource_manager = rmgr;
 }
-
 
 ///////////////////////////////////////////////////////////////////
 //
@@ -935,30 +663,21 @@ rc_rm_t::set_resource_manager(const resource_manager_t &rmgr)
 //
 ///////////////////////////////////////////////////////////////////
 
-
-int
-resource_manager_t::resolve_signal(const std::string &v)
-{
+int resource_manager_t::resolve_signal(const std::string &v) {
   int ret_sig = -1;
 
-  if (v == std::string("SIGINT"))
-    {
-      ret_sig = SIGINT;
-    }
-  else if (v == std::string("SIGTERM"))
-    {
-      ret_sig = SIGTERM;
-    }
+  if (v == std::string("SIGINT")) {
+    ret_sig = SIGINT;
+  } else if (v == std::string("SIGTERM")) {
+    ret_sig = SIGTERM;
+  }
 
   return ret_sig;
 }
 
-
-bool
-rc_rm_t::read_supported_rm_confs(const std::string &os_isa_string,
-                 const std::string &rm_info_conf_path,
-                 std::vector<std::string> &supported_rm_fnames)
-{
+bool rc_rm_t::read_supported_rm_confs(
+    const std::string &os_isa_string, const std::string &rm_info_conf_path,
+    std::vector<std::string> &supported_rm_fnames) {
   std::ifstream ri_conf;
   char line_max[PATH_MAX];
   bool found = false;
@@ -966,63 +685,45 @@ rc_rm_t::read_supported_rm_confs(const std::string &os_isa_string,
   std::string a_line;
 
   ri_conf.open(rm_info_conf_path.c_str());
-  if (ri_conf.is_open())
-    {
-       while (!ri_conf.eof())
-         {
-           ri_conf.getline(line_max, PATH_MAX);
-           if (ri_conf.bad() || ri_conf.fail())
-             {
-               self_trace_t::trace ( LEVELCHK(level1),
-                 MODULENAME,1,
-                 "getline enountered an error.");
+  if (ri_conf.is_open()) {
+    while (!ri_conf.eof()) {
+      ri_conf.getline(line_max, PATH_MAX);
+      if (ri_conf.bad() || ri_conf.fail()) {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "getline enountered an error.");
 
-               break;
-             }
+        break;
+      }
 
-           a_line = line_max;
+      a_line = line_max;
 
-           if (a_line[0] == '#' || a_line[0] == '\0')
-             continue;
+      if (a_line[0] == '#' || a_line[0] == '\0') continue;
 
-           if (!plat_found) 
-             {
-               if (a_line[0] == '[')
-                 {
-                   size_t ix = a_line.find_first_of(']', 1);
-                   if (ix != std::string::npos)
-                     {
-                       std::string found_os_isa = a_line.substr(1, ix-1);
-                       if (found_os_isa == os_isa_string)
-                         plat_found = true;
-                     }
-                   else
-                     {
-                       self_trace_t::trace ( LEVELCHK(level1),
-                         MODULENAME,1,
-                         "ill-formed line.");
-                     }
-                  }
-             }
-           else
-             {
-               if (a_line[0] == '[')
-                 break; // OK, done with parsing for my platform
-               supported_rm_fnames.push_back(a_line);
-               found = true;
-             }
-         }
-       ri_conf.close();
+      if (!plat_found) {
+        if (a_line[0] == '[') {
+          size_t ix = a_line.find_first_of(']', 1);
+          if (ix != std::string::npos) {
+            std::string found_os_isa = a_line.substr(1, ix - 1);
+            if (found_os_isa == os_isa_string) plat_found = true;
+          } else {
+            self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                                "ill-formed line.");
+          }
+        }
+      } else {
+        if (a_line[0] == '[') break;  // OK, done with parsing for my platform
+        supported_rm_fnames.push_back(a_line);
+        found = true;
+      }
     }
+    ri_conf.close();
+  }
 
   return found;
 }
 
-
-bool
-rc_rm_t::parse_and_fill_rm(const std::string &rm_conf_path,
-                           resource_manager_t &a_rm)
-{
+bool rc_rm_t::parse_and_fill_rm(const std::string &rm_conf_path,
+                                resource_manager_t &a_rm) {
   std::ifstream inputfile;
   std::map<std::string, std::vector<std::string> > key_value_pair;
   std::map<std::string, std::vector<std::string> >::iterator iter;
@@ -1032,128 +733,101 @@ rc_rm_t::parse_and_fill_rm(const std::string &rm_conf_path,
 
   inputfile.open(rm_conf_path.c_str());
 
-  if (inputfile.is_open())
-    {
-      while (!inputfile.eof())
-        {
-          inputfile.getline(line_max, PATH_MAX);
-          if (inputfile.bad() || inputfile.fail())
-            {
-              self_trace_t::trace ( LEVELCHK(level1),
-                MODULENAME,1,
-                "getline encountered an error.");
+  if (inputfile.is_open()) {
+    while (!inputfile.eof()) {
+      inputfile.getline(line_max, PATH_MAX);
+      if (inputfile.bad() || inputfile.fail()) {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "getline encountered an error.");
 
-              break;
-            }
+        break;
+      }
 
-          a_line = line_max;
-          if (a_line[0] == '#' || a_line[0] == '\n')
-            continue;
+      a_line = line_max;
+      if (a_line[0] == '#' || a_line[0] == '\n') continue;
 
-          size_t equal = a_line.find_first_of('=', 0);
-          if (equal != std::string::npos)
-            {
-              std::string key = a_line.substr(0, equal);
-              std::string value = a_line.substr(equal+1, std::string::npos);
-              iter = key_value_pair.find(key);
+      size_t equal = a_line.find_first_of('=', 0);
+      if (equal != std::string::npos) {
+        std::string key = a_line.substr(0, equal);
+        std::string value = a_line.substr(equal + 1, std::string::npos);
+        iter = key_value_pair.find(key);
 
-              if (iter == key_value_pair.end())
-                {
-                  std::vector<std::string> value_vect;
-                  value_vect.push_back(value);
-                  key_value_pair[key] = value_vect;
-                }
-              else
-                {
-                  iter->second.push_back(value);
-                }
-            }
-          else
-            {
-              self_trace_t::trace ( LEVELCHK(level1),
-                MODULENAME,1,
-                "ill-formed line.");
-
-              error_found = true;
-            }
+        if (iter == key_value_pair.end()) {
+          std::vector<std::string> value_vect;
+          value_vect.push_back(value);
+          key_value_pair[key] = value_vect;
+        } else {
+          iter->second.push_back(value);
         }
-      inputfile.close();
+      } else {
+        self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                            "ill-formed line.");
+
+        error_found = true;
+      }
     }
+    inputfile.close();
+  }
 
   iter = key_value_pair.find(std::string("RM"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_rm_type (iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_rm_type(iter->second[0]);
+  }
 
   iter = key_value_pair.find(std::string("RM_MPIR"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_mpir_type (iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_mpir_type(iter->second[0]);
+  }
 
   iter = key_value_pair.find(std::string("RM_launcher"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launchers(iter->second);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_launchers(iter->second);
+  }
 
   iter = key_value_pair.find(std::string("RM_launcher_id"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launcher_id(iter->second);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_launcher_id(iter->second);
+  }
 
   iter = key_value_pair.find(std::string("RM_launcher_so"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launcher_so(iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_launcher_so(iter->second[0]);
+  }
 
   iter = key_value_pair.find(std::string("RM_jobid"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_job_id(iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_job_id(iter->second[0]);
+  }
 
-  iter
-    = key_value_pair.find(std::string("RM_signal_for_kill"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_kill_singals(iter->second[0]);
-    }
+  iter = key_value_pair.find(std::string("RM_signal_for_kill"));
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_kill_singals(iter->second[0]);
+  }
 
-  iter
-    = key_value_pair.find(std::string("RM_fail_detection"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_fail_detection(iter->second[0]);
-    }
+  iter = key_value_pair.find(std::string("RM_fail_detection"));
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_fail_detection(iter->second[0]);
+  }
 
   iter = key_value_pair.find(std::string("RM_launch_helper"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launch_helper(iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_launch_helper(iter->second[0]);
+  }
 
   iter = key_value_pair.find(std::string("RM_launch_str"));
-  if (iter != key_value_pair.end())
-    {
-      a_rm.fill_launch_string(iter->second[0]);
-    }
+  if (iter != key_value_pair.end()) {
+    a_rm.fill_launch_string(iter->second[0]);
+  }
 
   return error_found;
 }
 
-
-const std::string
-rc_rm_t::expand_a_letter(const char p, bool *split_maybe_needed)
-{
+const std::string rc_rm_t::expand_a_letter(const char p,
+                                           bool *split_maybe_needed) {
   std::stringstream ssm;
   *split_maybe_needed = false;
 
-  switch (p)
-    {
+  switch (p) {
     case 'b':
       ssm << coloc_paramset.rm_daemon_stub;
       break;
@@ -1179,11 +853,11 @@ rc_rm_t::expand_a_letter(const char p, bool *split_maybe_needed)
       break;
 
     case 'o':
-       for (std::list<std::string>::iterator i = coloc_paramset.rm_daemon_args.begin();
-            i != coloc_paramset.rm_daemon_args.end(); i++)
-       {
-          ssm << *i << " ";
-       }
+      for (std::list<std::string>::iterator i =
+               coloc_paramset.rm_daemon_args.begin();
+           i != coloc_paramset.rm_daemon_args.end(); i++) {
+        ssm << *i << " ";
+      }
       *split_maybe_needed = true;
       break;
 
@@ -1193,21 +867,23 @@ rc_rm_t::expand_a_letter(const char p, bool *split_maybe_needed)
 
     case 'h':
       //
-      // for now, we only support localhost as an expansion choice for 
-      // %h. This is to support GUPC. But this can be extended later 
-      // for a more complex model.  
+      // for now, we only support localhost as an expansion choice for
+      // %h. This is to support GUPC. But this can be extended later
+      // for a more complex model.
       //
       ssm << "localhost";
       break;
 
     default:
       ssm << "na";
-      self_trace_t::trace ( LEVELCHK(level1),
-        MODULENAME,1,
-        "Unknown RM_launch_str parameter.");
+      self_trace_t::trace(LEVELCHK(level1), MODULENAME, 1,
+                          "Unknown RM_launch_str parameter.");
       break;
-    }
+  }
 
   return ssm.str();
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_rm_map.hxx
+++ b/launchmon/src/sdbg_rm_map.hxx
@@ -1,29 +1,30 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *-------------------------------------------------------------------------------- 
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Feb 20 2015 andrewg@cray.com: Added Cray support.
@@ -47,12 +48,12 @@
 
 #include "sdbg_std.hxx"
 
-#include <cstdio>
-#include <signal.h>
 #include <limits.h>
+#include <signal.h>
+#include <cstdio>
+#include <list>
 #include <string>
 #include <vector>
-#include <list>
 
 #include <lmon_api/lmon_api_std.h>
 
@@ -70,34 +71,17 @@ enum mpir_catalogue_e {
   x_none
 };
 
+enum id_method_e { symbol, pid, unknown_method };
 
-enum id_method_e {
-  symbol,
-  pid,
-  unknown_method
-};
+enum id_from_e { from_launcher, from_unknown_source };
 
-
-enum id_from_e {
-  from_launcher,
-  from_unknown_source
-};
-
-
-enum id_datatype_e {
-  cstring,
-  integer32,
-  integer64,
-  unknown_type
-};
-
+enum id_datatype_e { cstring, integer32, integer64, unknown_type };
 
 enum launch_method_e {
   mpir_coloc,
   launch_helper_method,
   launch_method_unknown
 };
-
 
 struct rm_id_t {
   rm_id_t();
@@ -106,7 +90,7 @@ struct rm_id_t {
 
   ~rm_id_t();
 
-  rm_id_t & operator=(const rm_id_t &rhs);
+  rm_id_t &operator=(const rm_id_t &rhs);
 
   id_from_e from;
   id_method_e method;
@@ -117,75 +101,63 @@ struct rm_id_t {
   } id;
 };
 
-
 struct launch_method_t {
-  launch_method_t() : launch_method(launch_method_unknown),
-                      launcher_command(std::string("na"))
-    { }
+  launch_method_t()
+      : launch_method(launch_method_unknown),
+        launcher_command(std::string("na")) {}
 
-  launch_method_t(const launch_method_t& o) 
-    { 
-      launch_method = o.launch_method;
-      launcher_command = o.launcher_command;
-    }
+  launch_method_t(const launch_method_t &o) {
+    launch_method = o.launch_method;
+    launcher_command = o.launcher_command;
+  }
 
-  ~launch_method_t()
-    { }
+  ~launch_method_t() {}
 
-  launch_method_t & operator=(const launch_method_t &rhs)
-    {
-      launch_method = rhs.launch_method;
-      launcher_command = rhs.launcher_command;
-    }
+  launch_method_t &operator=(const launch_method_t &rhs) {
+    launch_method = rhs.launch_method;
+    launcher_command = rhs.launcher_command;
+  }
 
   launch_method_e launch_method;
   std::string launcher_command;
 };
 
+struct coloc_str_param_t {
+  coloc_str_param_t()
+      : rm_daemon_path(std::string("na")),
+        rm_daemon_stub(std::string("na")),
+        nnodes(-1),
+        ndaemons(-1),
+        sharedsec(NULL),
+        randomid(NULL),
+        resourceid(-1),
+        hnfilename(NULL) {}
 
-struct coloc_str_param_t
-{
-  coloc_str_param_t() 
-    : rm_daemon_path(std::string("na")),
-      rm_daemon_stub(std::string("na")),
-      nnodes(-1),
-      ndaemons(-1),
-      sharedsec(NULL),
-      randomid(NULL),
-      resourceid(-1),
-      hnfilename(NULL)
-    {
+  coloc_str_param_t(const coloc_str_param_t &o) {
+    rm_daemon_path = o.rm_daemon_path;
+    rm_daemon_args = o.rm_daemon_args;
+    rm_daemon_stub = o.rm_daemon_stub;
+    nnodes = o.nnodes;
+    ndaemons = o.ndaemons;
+    sharedsec = o.sharedsec;
+    randomid = o.randomid;
+    resourceid = o.resourceid;
+    hnfilename = o.hnfilename;
+  }
 
-    } 
+  ~coloc_str_param_t() {}
 
-  coloc_str_param_t(const coloc_str_param_t &o) 
-    {
-      rm_daemon_path = o.rm_daemon_path; 
-      rm_daemon_args = o.rm_daemon_args;
-      rm_daemon_stub = o.rm_daemon_stub;
-      nnodes = o.nnodes;
-      ndaemons = o.ndaemons;
-      sharedsec = o.sharedsec;
-      randomid = o.randomid;
-      resourceid = o.resourceid;
-      hnfilename = o.hnfilename;
-    }
-
-  ~coloc_str_param_t()
-    { }
-
-  coloc_str_param_t & operator=(const coloc_str_param_t &rhs)
-    {
-      rm_daemon_path = rhs.rm_daemon_path;
-      rm_daemon_args = rhs.rm_daemon_args;
-      rm_daemon_stub = rhs.rm_daemon_stub;
-      nnodes = rhs.nnodes;
-      ndaemons = rhs.ndaemons;
-      sharedsec = rhs.sharedsec;
-      randomid = rhs.randomid;
-      resourceid = rhs.resourceid;
-      hnfilename = rhs.hnfilename;
-    }
+  coloc_str_param_t &operator=(const coloc_str_param_t &rhs) {
+    rm_daemon_path = rhs.rm_daemon_path;
+    rm_daemon_args = rhs.rm_daemon_args;
+    rm_daemon_stub = rhs.rm_daemon_stub;
+    nnodes = rhs.nnodes;
+    ndaemons = rhs.ndaemons;
+    sharedsec = rhs.sharedsec;
+    randomid = rhs.randomid;
+    resourceid = rhs.resourceid;
+    hnfilename = rhs.hnfilename;
+  }
 
   std::string rm_daemon_path;
   std::list<std::string> rm_daemon_args;
@@ -198,32 +170,28 @@ struct coloc_str_param_t
   char *hnfilename;
 };
 
-
-class resource_manager_t
-{
-public:
-
+class resource_manager_t {
+ public:
   resource_manager_t();
   resource_manager_t(const resource_manager_t &r);
   ~resource_manager_t();
-  resource_manager_t & operator=(const resource_manager_t &rhs);
+  resource_manager_t &operator=(const resource_manager_t &rhs);
 
   define_gset(rm_catalogue_e, rm)
   define_gset(mpir_catalogue_e, mpir)
-  define_gset(std::vector<std::string>&, launchers)
-  define_gset(std::vector<rm_id_t>&, launcher_ids)
-  define_gset(rm_id_t&, job_id)
-  define_gset(launch_method_t&, launch_helper)
-  define_gset(std::vector<int>&, kill_signals)
+  define_gset(std::vector<std::string> &, launchers)
+  define_gset(std::vector<rm_id_t> &, launcher_ids)
+  define_gset(rm_id_t &, job_id)
+  define_gset(launch_method_t &, launch_helper)
+  define_gset(std::vector<int> &, kill_signals)
   define_gset(bool, fail_detection_supported)
-  define_gset(std::string&, launch_string)
-  define_gset(std::string&, expanded_launch_string)
+  define_gset(std::string &, launch_string)
+  define_gset(std::string &, expanded_launch_string)
   define_gset(bool, has_launcher_so)
-  define_gset(std::string&, launcher_so_name)
-  define_gset(std::string&, attach_fifo_path)
-
-  const std::vector<rm_id_t>& get_const_launcher_ids() const; 
-  const std::vector<std::string>& get_const_launchers() const; 
+  define_gset(std::string &, launcher_so_name)
+  define_gset(std::string &, attach_fifo_path)
+  const std::vector<rm_id_t> &get_const_launcher_ids() const;
+  const std::vector<std::string> &get_const_launchers() const;
 
   void fill_rm_type(const std::string &v);
   void fill_mpir_type(const std::string &v);
@@ -239,8 +207,7 @@ public:
   void fill_expanded_launch_string(const std::string &v);
   void fill_attach_fifo_path(const std::string &v);
 
-private:
-
+ private:
   int resolve_signal(const std::string &v);
 
   rm_catalogue_e rm;
@@ -258,29 +225,25 @@ private:
   std::string attach_fifo_path;
 };
 
-
-class rc_rm_t
-{
-public:
+class rc_rm_t {
+ public:
   rc_rm_t();
   rc_rm_t(const rc_rm_t &o);
   ~rc_rm_t();
-  rc_rm_t & operator=(const rc_rm_t &rhs);
+  rc_rm_t &operator=(const rc_rm_t &rhs);
 
   bool init(const std::string &os_isa_string);
 
-  bool set_paramset (int n_nodes, int n_daemons, char *secret,
-                     char *ran_id, int resource_id,
-                     char *host_file_name);
+  bool set_paramset(int n_nodes, int n_daemons, char *secret, char *ran_id,
+                    int resource_id, char *host_file_name);
 
-  const std::list<std::string>
-        expand_launch_string(std::string &s);
+  const std::list<std::string> expand_launch_string(std::string &s);
 
-  const std::string & get_expanded_launch_string();
+  const std::string &get_expanded_launch_string();
 
   bool graceful_rmkill(int pid);
 
-  const std::vector<resource_manager_t> & get_supported_rms();
+  const std::vector<resource_manager_t> &get_supported_rms();
 
   bool need_check_launcher_so();
 
@@ -300,33 +263,34 @@ public:
 
   bool is_fail_detect_sup();
 
-  resource_manager_t & get_resource_manager();
+  resource_manager_t &get_resource_manager();
 
-  coloc_str_param_t & get_coloc_paramset();
+  coloc_str_param_t &get_coloc_paramset();
 
-  const coloc_str_param_t & get_const_coloc_paramset();
+  const coloc_str_param_t &get_const_coloc_paramset();
 
-  const char * get_hostnames_fn();
+  const char *get_hostnames_fn();
 
-  const std::string & get_launcher_so_name();
+  const std::string &get_launcher_so_name();
 
-  const std::string & get_attach_fifo_path();
+  const std::string &get_attach_fifo_path();
 
   void set_attach_fifo_path(const std::string &fifo_path);
 
   void set_resource_manager(const resource_manager_t &rmgr);
 
-private:
-
-  bool LEVELCHK(self_trace_verbosity level)
-       { return (self_trace_t::self_trace().rm_module_trace.verbosity_level >= level); }
+ private:
+  bool LEVELCHK(self_trace_verbosity level) {
+    return (self_trace_t::self_trace().rm_module_trace.verbosity_level >=
+            level);
+  }
 
   bool read_supported_rm_confs(const std::string &os_isa_string,
-                 const std::string &rm_info_conf_path,
-                 std::vector<std::string> &supported_rm_fnames);
+                               const std::string &rm_info_conf_path,
+                               std::vector<std::string> &supported_rm_fnames);
 
   bool parse_and_fill_rm(const std::string &rm_conf_path,
-                 resource_manager_t &a_rm);
+                         resource_manager_t &a_rm);
 
   const std::string expand_a_letter(const char p, bool *split_maybe_needed);
 
@@ -339,37 +303,35 @@ private:
   // For self tracing
   //
   std::string MODULENAME;
-
 };
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-class rc_rm_plat_matcher
-{
-public:
-  rc_rm_plat_matcher() { MODULENAME = self_trace_t::self_trace().rm_module_trace.module_name; }
+class rc_rm_plat_matcher {
+ public:
+  rc_rm_plat_matcher() {
+    MODULENAME = self_trace_t::self_trace().rm_module_trace.module_name;
+  }
   rc_rm_plat_matcher(const rc_rm_plat_matcher &o) { MODULENAME = o.MODULENAME; }
   ~rc_rm_plat_matcher() {}
 
-  bool init_rm_instance(rc_rm_t &rm_obj,
-                 const std::string &lnchrpath,
-                 const std::string &tool_daemon_path,
-                 const std::list<std::string> &tool_daemon_opts,
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab=NULL,
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab=NULL,
-                 const std::string be_stub_path="");
+  bool init_rm_instance(
+      rc_rm_t &rm_obj, const std::string &lnchrpath,
+      const std::string &tool_daemon_path,
+      const std::list<std::string> &tool_daemon_opts,
+      const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab = NULL,
+      const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab = NULL,
+      const std::string be_stub_path = "");
 
-private:
-  bool has_matching_signiture (const std::string &lnchrpath,
-                 const resource_manager_t &a_rm, 
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab=NULL,
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab=NULL);
+ private:
+  bool has_matching_signiture(
+      const std::string &lnchrpath, const resource_manager_t &a_rm,
+      const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab = NULL,
+      const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab = NULL);
 
   // For self tracing
   //
   std::string MODULENAME;
 };
-
 
 ///////////////////////////////////////////////////////////////////
 //                                                               //
@@ -379,50 +341,38 @@ private:
 ///////////////////////////////////////////////////////////////////
 
 template <BASE_IMAGE_TEMPLATELIST>
-bool
-rc_rm_plat_matcher<BASE_IMAGE_TEMPLPARAM>::init_rm_instance(rc_rm_t &rm_obj,
-              const std::string &launchr_path,
-              const std::string &tool_daemon_path,
-              const std::list<std::string> &tool_daemon_opts,
-              const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab,
-              const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab,
-              const std::string be_stub_path)
-{
+bool rc_rm_plat_matcher<BASE_IMAGE_TEMPLPARAM>::init_rm_instance(
+    rc_rm_t &rm_obj, const std::string &launchr_path,
+    const std::string &tool_daemon_path,
+    const std::list<std::string> &tool_daemon_opts,
+    const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab,
+    const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab,
+    const std::string be_stub_path) {
   bool found_matched_rm = false;
   std::vector<resource_manager_t>::const_iterator r_i;
 
   for (r_i = rm_obj.get_supported_rms().begin();
-           r_i != rm_obj.get_supported_rms().end(); r_i++)
-    {
-      if (has_matching_signiture(launchr_path,
-                                 (*r_i),
-                                 main_symtab, rmso_symtab))
-        {
-          rm_obj.set_resource_manager(*r_i);
-          found_matched_rm = true;
-          break;
-        }
+       r_i != rm_obj.get_supported_rms().end(); r_i++) {
+    if (has_matching_signiture(launchr_path, (*r_i), main_symtab,
+                               rmso_symtab)) {
+      rm_obj.set_resource_manager(*r_i);
+      found_matched_rm = true;
+      break;
     }
+  }
 
-  rm_obj.get_coloc_paramset().rm_daemon_path
-    = tool_daemon_path;
-  rm_obj.get_coloc_paramset().rm_daemon_args
-    = tool_daemon_opts;
-  rm_obj.get_coloc_paramset().rm_daemon_stub
-    = be_stub_path;
+  rm_obj.get_coloc_paramset().rm_daemon_path = tool_daemon_path;
+  rm_obj.get_coloc_paramset().rm_daemon_args = tool_daemon_opts;
+  rm_obj.get_coloc_paramset().rm_daemon_stub = be_stub_path;
 
   return found_matched_rm;
 }
 
-
 template <BASE_IMAGE_TEMPLATELIST>
-bool
-rc_rm_plat_matcher<BASE_IMAGE_TEMPLPARAM>::has_matching_signiture (
-                 const std::string &lnchrpath,
-                 const resource_manager_t &a_rm,
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab,
-                 const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab)
-{
+bool rc_rm_plat_matcher<BASE_IMAGE_TEMPLPARAM>::has_matching_signiture(
+    const std::string &lnchrpath, const resource_manager_t &a_rm,
+    const image_base_t<BASE_IMAGE_TEMPLPARAM> *main_symtab,
+    const image_base_t<BASE_IMAGE_TEMPLPARAM> *rmso_symtab) {
   char *bnbuf = strdup(lnchrpath.c_str());
   char *launcher_name = basename(bnbuf);
   bool match = false;
@@ -430,78 +380,64 @@ rc_rm_plat_matcher<BASE_IMAGE_TEMPLPARAM>::has_matching_signiture (
   std::vector<rm_id_t>::const_iterator id_i;
 
   for (r_i = a_rm.get_const_launchers().begin();
-           r_i != a_rm.get_const_launchers().end(); r_i++)
-    {
-      if (launcher_name == (*r_i) || (*r_i) == std::string("*"))
-        {
-          //
-          // Name matched!
-          //
-          const std::vector<rm_id_t> &id_vector = a_rm.get_const_launcher_ids();
-          for (id_i = id_vector.begin(); id_i != id_vector.end(); id_i++)
-            {
-              switch ((*id_i).from)
-                {
-                case from_launcher:
-                  {
-                    if ((*id_i).method == symbol)
-                      {
-                        if (main_symtab && (*id_i).id.symbol_name)
-                          {
-                            const std::string sn((*id_i).id.symbol_name);
-                            const symbol_base_t<VA> &symb
-                              = main_symtab->get_a_symbol(sn);
-                            if (!(!symb))
-                              {
-                                //
-                                // Symbol matched!
-                                //
-                                match = true;
-                                break;
-                              }
-                          }
-
-                        if (rmso_symtab && (*id_i).id.symbol_name)
-                          {
-                            const std::string sn((*id_i).id.symbol_name);
-                            const symbol_base_t<VA> &symb
-                              = rmso_symtab->get_a_symbol(sn);
-                            if (!(!symb))
-                              {
-                                //
-                                // Symbol matched!
-                                //
-                                match = true;
-                                break;
-                              }
-                          }
-                      }
-                    else
-                      {
-                        self_trace_t::trace (true,
-                          MODULENAME,1,
-                          "only symbol-based id method is supported (%s)!",
-                          (*r_i).c_str());
-                      }
-                  }
-                  break;
-
-                default:
-                  {
-                    self_trace_t::trace (true,
-                      MODULENAME,1,
-                      "only symbol-based id method is supported (%s)!",
-                      (*r_i).c_str());
-                  }
+       r_i != a_rm.get_const_launchers().end(); r_i++) {
+    if (launcher_name == (*r_i) || (*r_i) == std::string("*")) {
+      //
+      // Name matched!
+      //
+      const std::vector<rm_id_t> &id_vector = a_rm.get_const_launcher_ids();
+      for (id_i = id_vector.begin(); id_i != id_vector.end(); id_i++) {
+        switch ((*id_i).from) {
+          case from_launcher: {
+            if ((*id_i).method == symbol) {
+              if (main_symtab && (*id_i).id.symbol_name) {
+                const std::string sn((*id_i).id.symbol_name);
+                const symbol_base_t<VA> &symb = main_symtab->get_a_symbol(sn);
+                if (!(!symb)) {
+                  //
+                  // Symbol matched!
+                  //
+                  match = true;
                   break;
                 }
+              }
+
+              if (rmso_symtab && (*id_i).id.symbol_name) {
+                const std::string sn((*id_i).id.symbol_name);
+                const symbol_base_t<VA> &symb = rmso_symtab->get_a_symbol(sn);
+                if (!(!symb)) {
+                  //
+                  // Symbol matched!
+                  //
+                  match = true;
+                  break;
+                }
+              }
+            } else {
+              self_trace_t::trace(
+                  true, MODULENAME, 1,
+                  "only symbol-based id method is supported (%s)!",
+                  (*r_i).c_str());
             }
+          } break;
+
+          default: {
+            self_trace_t::trace(
+                true, MODULENAME, 1,
+                "only symbol-based id method is supported (%s)!",
+                (*r_i).c_str());
+          } break;
         }
+      }
     }
+  }
 
   free(bnbuf);
   return match;
 }
 
-#endif // SDBG_RM_MAP_HXX
+#endif  // SDBG_RM_MAP_HXX
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_self_trace.cxx
+++ b/launchmon/src/sdbg_self_trace.cxx
@@ -1,87 +1,82 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_self_trace.cxx,v 1.7.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        Jun 09 2010 DHA: Use LMON_timestamp to get consistent timestamp format
- *        Feb 09 2008 DHA: Added LLNS Copyright 
+ *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jul 03 2006 DHA: trace method
- *        Mar 30 2006 DHA: File created      
- */ 
+ *        Mar 30 2006 DHA: File created
+ */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <lmon_api/common.h>
-#include <iostream>
+#include <sys/time.h>
 #include <cstdarg>
 #include <ctime>
-#include <sys/time.h>
-#include <limits.h>
+#include <iostream>
 
 #include "lmon_api/lmon_say_msg.hxx"
 #include "sdbg_self_trace.hxx"
 
-self_trace_t &
-self_trace_t::self_trace(void)
-{
-    static self_trace_t singleton;
-    return singleton;
+self_trace_t &self_trace_t::self_trace(void) {
+  static self_trace_t singleton;
+  return singleton;
 }
 
 FILE *self_trace_t::tracefptr = stdout;
 
-
 //!  opts_args_t::trace
-/*!        
+/*!
     logs self-tracing event
 */
-bool 
-self_trace_t::trace ( bool levelchk,
-		      const std::string & mn, 
-		      bool error_or_info,
-		      const char *output, ... )
-{
-  if (!levelchk) 
-    return false;
+bool self_trace_t::trace(bool levelchk, const std::string &mn,
+                         bool error_or_info, const char *output, ...) {
+  if (!levelchk) return false;
 
   va_list ap;
   char log[PATH_MAX];
   const char *ei_str = error_or_info ? "ERROR" : "INFO";
   bool rc = false;
 
-  if (LMON_timestamp(mn.c_str(), ei_str, output, log, PATH_MAX) >= 0)
-    {
-      va_start(ap, output);
-      vfprintf(tracefptr, log, ap);
-      va_end(ap);
-      rc = true;
-    }
+  if (LMON_timestamp(mn.c_str(), ei_str, output, log, PATH_MAX) >= 0) {
+    va_start(ap, output);
+    vfprintf(tracefptr, log, ap);
+    va_end(ap);
+    rc = true;
+  }
 
-  return rc; 
+  return rc;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_self_trace.hxx
+++ b/launchmon/src/sdbg_self_trace.hxx
@@ -1,53 +1,47 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_self_trace.hxx,v 1.5.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *	
  *
  *  Update Log:
  *        Feb  09 2008 DHA: Added LLNS Copyright
  *        Jul 03 2006 DHA: added trace method and tracefptr
- *        Mar 30 2006 DHA: File created      
- */ 
+ *        Mar 30 2006 DHA: File created
+ */
 
 #ifndef SDBG_SELF_TRACE_HXX
 #define SDBG_SELF_TRACE_HXX 1
 
 #if HAVE_STRING
-# include <string>
+#include <string>
 #else
-# error string is required
+#error string is required
 #endif
 
-enum self_trace_verbosity {
-  quiet = 0,
-  level1,
-  level2,
-  level3,
-  level4
-};
+enum self_trace_verbosity { quiet = 0, level1, level2, level3, level4 };
 
 struct self_trace_entry_t {
   self_trace_verbosity verbosity_level;
@@ -56,13 +50,11 @@ struct self_trace_entry_t {
 
   self_trace_entry_t(void) { ; }
 
-  self_trace_entry_t(
-    self_trace_verbosity v,
-    std::string m_name,
-    std::string m_symbol
-  ) : verbosity_level(v)
-    , module_name(m_name)
-    , module_symbol(m_symbol) { ; }
+  self_trace_entry_t(self_trace_verbosity v, std::string m_name,
+                     std::string m_symbol)
+      : verbosity_level(v), module_name(m_name), module_symbol(m_symbol) {
+    ;
+  }
 };
 
 struct self_trace_t {
@@ -80,26 +72,23 @@ struct self_trace_t {
   self_trace_t(void) {
     launchmon_module_trace =
         self_trace_entry_t(quiet, "<Launchmon>", "launchmon");
-    tracer_module_trace =
-        self_trace_entry_t(quiet, "<ProcTracer>", "tracer");
-    symtab_module_trace =
-        self_trace_entry_t(quiet, "<Symtable>", "symtab");
-    machine_module_trace =
-        self_trace_entry_t(quiet, "<Machine>", "machine");
-    event_module_trace =
-        self_trace_entry_t(quiet, "<EventMgr>", "event");
-    driver_module_trace =
-        self_trace_entry_t(quiet, "<Driver>", "driver");
-    opt_module_trace =
-        self_trace_entry_t(quiet, "<OptionParser>", "option");
-    rm_module_trace =
-        self_trace_entry_t(quiet, "<ResourceMgr>", "resmgr");
+    tracer_module_trace = self_trace_entry_t(quiet, "<ProcTracer>", "tracer");
+    symtab_module_trace = self_trace_entry_t(quiet, "<Symtable>", "symtab");
+    machine_module_trace = self_trace_entry_t(quiet, "<Machine>", "machine");
+    event_module_trace = self_trace_entry_t(quiet, "<EventMgr>", "event");
+    driver_module_trace = self_trace_entry_t(quiet, "<Driver>", "driver");
+    opt_module_trace = self_trace_entry_t(quiet, "<OptionParser>", "option");
+    rm_module_trace = self_trace_entry_t(quiet, "<ResourceMgr>", "resmgr");
     sighandler_module_trace =
         self_trace_entry_t(quiet, "<SigHandler>", "sighandler");
   }
-  static self_trace_t &self_trace(void);
-  static bool trace(bool, const std::string&, bool, const char*, ... );
+  static self_trace_t& self_trace(void);
+  static bool trace(bool, const std::string&, bool, const char*, ...);
   static FILE* tracefptr;
 };
 
-#endif // SDBG_SELF_TRACE_HXX
+#endif  // SDBG_SELF_TRACE_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_signal_hlr.hxx
+++ b/launchmon/src/sdbg_signal_hlr.hxx
@@ -1,89 +1,97 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_signal_hlr.hxx,v 1.3.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
+ *
  *
  *  Update Log:
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Jul 05  2006 DHA: File created
- */ 
+ */
 
 #ifndef SDBG_SIGNAL_HLR_HXX
 #define SDBG_SIGNAL_HLR_HXX 1
 
 #include <vector>
-#include "sdbg_std.hxx"
-#include "sdbg_base_tracer.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_tracer.hxx"
 #include "sdbg_self_trace.hxx"
+#include "sdbg_std.hxx"
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-class signal_handler_t 
-{
+class signal_handler_t {
+ public:
+  signal_handler_t();
+  signal_handler_t(const signal_handler_t& s);
+  ~signal_handler_t();
 
-public:
-  
-  signal_handler_t ( );
-  signal_handler_t ( const signal_handler_t& s );
-  ~signal_handler_t ( );
+  static void set_tracer(tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>* t) {
+    tracer = t;
+  }
+  static tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>* get_tracer() { return tracer; }
 
-  static void set_tracer ( tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>* t ) 
-                                                          { tracer = t; }
-  static tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>* get_tracer() 
-                                                          { return tracer; } 
+  static void set_launcher_proc(process_base_t<SDBG_DEFAULT_TEMPLPARAM>* p) {
+    launcher_proc = p;
+  }
 
-  static void set_launcher_proc ( process_base_t<SDBG_DEFAULT_TEMPLPARAM>* p )
-                                                          { launcher_proc = p; }
- 
-  static process_base_t<SDBG_DEFAULT_TEMPLPARAM>* get_launcher_proc ( )
-                                                          { return launcher_proc; }
+  static process_base_t<SDBG_DEFAULT_TEMPLPARAM>* get_launcher_proc() {
+    return launcher_proc;
+  }
 
-  static void sighandler ( int sig );
-  static void install_hdlr_for_all_sigs ( );
+  static void sighandler(int sig);
+  static void install_hdlr_for_all_sigs();
 
-  static void set_evman ( event_manager_t<SDBG_DEFAULT_TEMPLPARAM>* em )
-                                                          { evman = em; }
-  static void set_lmon ( launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>* lm )
-                                                          { lmon = lm; }
+  static void set_evman(event_manager_t<SDBG_DEFAULT_TEMPLPARAM>* em) {
+    evman = em;
+  }
+  static void set_lmon(launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>* lm) {
+    lmon = lm;
+  }
 
-private:
-  static bool LEVELCHK(self_trace_verbosity level) 
-       { return (self_trace_t::self_trace().sighandler_module_trace.verbosity_level >= level); }
- 
-  static std::vector<int> monitoring_signals;  
-  static tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *tracer;
-  static process_base_t<SDBG_DEFAULT_TEMPLPARAM> *launcher_proc;
-  static event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *evman;
-  static launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *lmon;
+ private:
+  static bool LEVELCHK(self_trace_verbosity level) {
+    return (
+        self_trace_t::self_trace().sighandler_module_trace.verbosity_level >=
+        level);
+  }
+
+  static std::vector<int> monitoring_signals;
+  static tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>* tracer;
+  static process_base_t<SDBG_DEFAULT_TEMPLPARAM>* launcher_proc;
+  static event_manager_t<SDBG_DEFAULT_TEMPLPARAM>* evman;
+  static launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>* lmon;
 
   //
   // For self tracing
   //
   static std::string MODULENAME;
-
 };
 
-#endif // SDBG_SIGNAL_HLR_HXX 
+#endif  // SDBG_SIGNAL_HLR_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_signal_hlr_impl.hxx
+++ b/launchmon/src/sdbg_signal_hlr_impl.hxx
@@ -1,37 +1,37 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_signal_hlr_impl.hxx,v 1.4.2.2 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *			
  *
  *  Update Log:
  *        Sep 24 2008 DHA: Enforced the error handling semantics defined
  *                         in README.ERROR_HANDLING
  *        Feb 09 2008 DHA: Added LLNS Copyright
- *        Jul 05 2006 DHA: File created      
- */ 
+ *        Jul 05 2006 DHA: File created
+ */
 
 #ifndef SDBG_SIGNAL_HLR_IMPL_HXX
 #define SDBG_SIGNAL_HLR_IMPL_HXX 1
@@ -43,41 +43,38 @@
 #include <lmon_api/common.h>
 
 extern "C" {
-#include <sys/types.h>
-#include <signal.h>  
-#include <unistd.h>
 #include <libgen.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
 }
 
 #include <cassert>
-#include "sdbg_signal_hlr.hxx"
-#include "sdbg_base_tracer.hxx"
 #include "sdbg_base_mach.hxx"
 #include "sdbg_base_tracer.hxx"
+#include "sdbg_signal_hlr.hxx"
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> *
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::tracer        = NULL;
+tracer_base_t<SDBG_DEFAULT_TEMPLPARAM>*
+    signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::tracer = NULL;
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-std::vector<int> 
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::monitoring_signals;
+std::vector<int> signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::monitoring_signals;
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-process_base_t<SDBG_DEFAULT_TEMPLPARAM> *
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::launcher_proc = NULL;
+process_base_t<SDBG_DEFAULT_TEMPLPARAM>*
+    signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::launcher_proc = NULL;
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-event_manager_t<SDBG_DEFAULT_TEMPLPARAM> *
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::evman         = NULL;
+event_manager_t<SDBG_DEFAULT_TEMPLPARAM>*
+    signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::evman = NULL;
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM> *
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::lmon          = NULL;
+launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>*
+    signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::lmon = NULL;
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-std::string 
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::MODULENAME;
+std::string signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::MODULENAME;
 
 ////////////////////////////////////////////////////////////////////
 //
@@ -85,86 +82,65 @@ signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::MODULENAME;
 //
 //
 
-
 //! PUBLIC: signal_handler_t
 /*!
     Default constructor.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::signal_handler_t ( )
-{
-
+signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::signal_handler_t() {
   //
-  // Some signals would make it difficult to 
+  // Some signals would make it difficult to
   // continue with the cleanup routine, but
-  // it is better to try it and fail 
-  // than not to try at all, which will always fail. 
+  // it is better to try it and fail
+  // than not to try at all, which will always fail.
   //
   monitoring_signals.push_back(SIGFPE);
   monitoring_signals.push_back(SIGINT);
   monitoring_signals.push_back(SIGBUS);
   monitoring_signals.push_back(SIGTERM);
-  monitoring_signals.push_back(SIGSEGV);  
-  monitoring_signals.push_back(SIGILL);  
+  monitoring_signals.push_back(SIGSEGV);
+  monitoring_signals.push_back(SIGILL);
 
   MODULENAME = self_trace_t::self_trace().sighandler_module_trace.module_name;
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::signal_handler_t ( 
-		 const signal_handler_t& s )
-{
-  
-}
-
+signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::signal_handler_t(
+    const signal_handler_t& s) {}
 
 //! PUBLIC: signal_handler_t
 /*!
     Default destructor.
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::~signal_handler_t ( )
-{
-  
-}
-
+signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::~signal_handler_t() {}
 
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::install_hdlr_for_all_sigs ( )
-{
+void signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::install_hdlr_for_all_sigs() {
   using namespace std;
-  
-  if ( monitoring_signals.empty() )
-    return;
+
+  if (monitoring_signals.empty()) return;
 
   vector<int>::const_iterator pos;
-  for (pos = monitoring_signals.begin(); 
-         pos != monitoring_signals.end(); pos++)      
-    signal (*pos, sighandler);   
+  for (pos = monitoring_signals.begin(); pos != monitoring_signals.end(); pos++)
+    signal(*pos, sighandler);
 }
 
-
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
-void 
-signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::sighandler ( int sig )
-{
+void signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::sighandler(int sig) {
   using namespace std;
 
-  if ( monitoring_signals.empty() )
-    return; 
+  if (monitoring_signals.empty()) return;
 
-  if ( tracer == NULL || launcher_proc == NULL )
-    return;
-     
+  if (tracer == NULL || launcher_proc == NULL) return;
+
   process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p = *launcher_proc;
 
   // DHA 6/03/2009 so far the failure handling due to an anomalous signal into
   // the Engine has been the same, regardless of RMs. Genericize the following
-  // code until it breaks for a certain RM... 
+  // code until it breaks for a certain RM...
   //
-  // failure handling sequence is specific to 
+  // failure handling sequence is specific to
   // RM implementations. Regardless, the engine must enforce
   // the following defined error handling.
   //
@@ -184,12 +160,10 @@ signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::sighandler ( int sig )
   // detach from the target RM_job (A.1.1).
   //
   // This attempts to stop all of the threads
-  // and mark "detach" If a kill/detach request has been already registered, 
+  // and mark "detach" If a kill/detach request has been already registered,
   // don't bother
-  self_trace_t::trace ( LEVELCHK(quiet), 
-    MODULENAME,
-    0,
-    "A signal (%d) received. Starting cleanup...", sig);
+  self_trace_t::trace(LEVELCHK(quiet), MODULENAME, 0,
+                      "A signal (%d) received. Starting cleanup...", sig);
   lmon->request_detach(p, ENGINE_dying_wsignal);
 
   //
@@ -200,26 +174,22 @@ signal_handler_t<SDBG_DEFAULT_TEMPLPARAM>::sighandler ( int sig )
   // before proceed. A.1.1 and A.1.2.
   //
   const int nMaxEvs = 15;
-  int i=0;
-  while ( evman->poll_processes ( p, *lmon ) != false )
-    {
-      self_trace_t::trace ( LEVELCHK(level1), 
-        MODULENAME,
-	0,
-	"Attempting to consume all launchmon events before aborting...");
-      i++;
-      if (i >= nMaxEvs)
-        break;
-    }
-
-  {
-     self_trace_t::trace ( LEVELCHK(quiet), 
- 	                   MODULENAME,
-			   0,
-			   "Aborting...");
+  int i = 0;
+  while (evman->poll_processes(p, *lmon) != false) {
+    self_trace_t::trace(
+        LEVELCHK(level1), MODULENAME, 0,
+        "Attempting to consume all launchmon events before aborting...");
+    i++;
+    if (i >= nMaxEvs) break;
   }
+
+  { self_trace_t::trace(LEVELCHK(quiet), MODULENAME, 0, "Aborting..."); }
 
   abort();
 }
 
-#endif //SDBG_SIGNAL_HLR_IMPL_HXX
+#endif  // SDBG_SIGNAL_HLR_IMPL_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/launchmon/src/sdbg_std.hxx
+++ b/launchmon/src/sdbg_std.hxx
@@ -1,39 +1,39 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/launchmon/src/sdbg_std.hxx,v 1.4.2.1 2008/02/20 17:37:57 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
- *	
  *
  *  Update Log:
  *        Jun 01 2009 DHA: Upped GracePeriodBNSignals by x10
  *                         to deal with unreliable signals
- *        Feb 09 2008 DHA: Added LLNS Copyright 
+ *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Mar 30 2006 DHA: Added exception handling support
- *        Mar 16 2006 DHA: Created file. 
+ *        Mar 16 2006 DHA: Created file.
  *
- */ 
+ */
 
 #ifndef SDBG_STD_HXX
 #define SDBG_STD_HXX 1
@@ -43,30 +43,31 @@
 #endif
 #include <lmon_api/common.h>
 
-#define CONCATENATE(A,B) A##B
+#define CONCATENATE(A, B) A##B
 
-#define DEFINE_GET_METHOD(TYPENAME,MEMBER)       \
-  TYPENAME CONCATENATE(get_,MEMBER) ()  { return (MEMBER); }
+#define DEFINE_GET_METHOD(TYPENAME, MEMBER) \
+  TYPENAME CONCATENATE(get_, MEMBER)() { return (MEMBER); }
 
-#define DEFINE_SET_METHOD(TYPENAME,MEMBER)       \
-  void CONCATENATE(set_,MEMBER) (TYPENAME param) { MEMBER = param; }
+#define DEFINE_SET_METHOD(TYPENAME, MEMBER) \
+  void CONCATENATE(set_, MEMBER)(TYPENAME param) { MEMBER = param; }
 
-#define define_gset(TYPENAME,MEMBER)             \
-  DEFINE_GET_METHOD(TYPENAME,MEMBER)             \
-  DEFINE_SET_METHOD(TYPENAME,MEMBER) 
+#define define_gset(TYPENAME, MEMBER) \
+  DEFINE_GET_METHOD(TYPENAME, MEMBER) \
+  DEFINE_SET_METHOD(TYPENAME, MEMBER)
 
-#define SDBG_DEFAULT_TEMPLATE_WIDTH typename VA, \
-                                    typename WT, \
-                                    typename IT, \
-                                    typename GRS,\
-                                    typename FRS,\
-                                    typename NT, \
-                                    typename EXECHANDLER
+#define SDBG_DEFAULT_TEMPLATE_WIDTH                                  \
+  typename VA, typename WT, typename IT, typename GRS, typename FRS, \
+      typename NT, typename EXECHANDLER
 
-#define SDBG_DEFAULT_TEMPLPARAM VA,WT,IT,GRS,FRS,NT,EXECHANDLER
+#define SDBG_DEFAULT_TEMPLPARAM VA, WT, IT, GRS, FRS, NT, EXECHANDLER
 
 const unsigned int GracePeriodForZombieThread = 10000;
-const unsigned int GracePeriodBNSignals       = 100000; // 100 millisecs
-const unsigned int GracePeriodFEDisconnection = 2000000; // 2 secs
-const double DefaultWarmPeriods               = 10.0;
-#endif // SDBG_STD_HXX
+const unsigned int GracePeriodBNSignals = 100000;         // 100 millisecs
+const unsigned int GracePeriodFEDisconnection = 2000000;  // 2 secs
+const double DefaultWarmPeriods = 10.0;
+
+#endif  // SDBG_STD_HXX
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/LE_model_checker.c
+++ b/test/src/LE_model_checker.c
@@ -1,43 +1,44 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
  * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
- * LLNL-CODE-409469. All rights reserved.
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
  *
- * This program is free software; you can redistribute it and/or modify it under the
- * terms of the GNU General Public License (as published by the Free Software
- * Foundation) version 2.1 dated February 1999.
-                                                                                                                                                                                     
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 05 2008 DHA: Support for generic BlueGene systems
- *        Jun 12 2008 DHA: GNU build system support 
+ *        Jun 12 2008 DHA: GNU build system support
  *        Feb 09 2008 DHA: Added LLNS Copyright
- *        Dec 07 2007 DHA: Included more header files to shut up the 
+ *        Dec 07 2007 DHA: Included more header files to shut up the
  *                         compiler.
- *        Dec 05 2007 DHA: Added update log. 
- *                         Enhance the dummy mpirun to add 
- *                         a model checker capability for 
- *                         the LaunchMon Engine. 
- *                         Copied this from dummy_mpirun directory. 
+ *        Dec 05 2007 DHA: Added update log.
+ *                         Enhance the dummy mpirun to add
+ *                         a model checker capability for
+ *                         the LaunchMon Engine.
+ *                         Copied this from dummy_mpirun directory.
  *                         Renamed the source file: LE_model_checker.c.
- *                         TODO: populate a wide range of error cases.  
+ *                         TODO: populate a wide range of error cases.
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -47,375 +48,330 @@
 #include <lmon_api/common.h>
 #include <pthread.h>
 
-#define MPIR_DEBUG_SPAWNED  1
+#define MPIR_DEBUG_SPAWNED 1
 #define MPIR_DEBUG_ABORTING 2
-#define EXECPATH_SIZE       256
-#define SERVER_ARG_SIZE     1024
+#define EXECPATH_SIZE 256
+#define SERVER_ARG_SIZE 1024
 
 #ifdef __cplusplus
 #define EXTERN_C extern "C"
 #else
-#define EXTERN_C 
+#define EXTERN_C
 #endif
 
 typedef struct {
-  char * host_name;           /* Something we can pass to inet_addr */
-  char * executable_name;     /* The name of the image */
-  int  pid;                   /* The pid of the process */
+  char* host_name;       /* Something we can pass to inet_addr */
+  char* executable_name; /* The name of the image */
+  int pid;               /* The pid of the process */
 } MPIR_PROCDESC;
 
 BEGIN_C_DECLS
 
 /* Standard variables */
-MPIR_PROCDESC * MPIR_proctable    = NULL;
-volatile int MPIR_debug_state     = 0;
-volatile int MPIR_debug_gate      = 0;
-int MPIR_proctable_size           = 0;
-volatile int  MPIR_being_debugged = 0;
-  
+MPIR_PROCDESC* MPIR_proctable = NULL;
+volatile int MPIR_debug_state = 0;
+volatile int MPIR_debug_gate = 0;
+int MPIR_proctable_size = 0;
+volatile int MPIR_being_debugged = 0;
+
 /* BG/MPIRUN specific variables */
 char MPIR_executable_path[EXECPATH_SIZE] = {0};
 char MPIR_server_arguments[SERVER_ARG_SIZE] = {0};
 
 /* SLURM/SRUN specific variable */
-char * totalview_jobid            = NULL;
+char* totalview_jobid = NULL;
 
 END_C_DECLS
 
-enum errormode_e { 
-  err0, 
-  err1, 
-  err2, 
-  err3, 
-  err4 }; 
+enum errormode_e { err0, err1, err2, err3, err4 };
 
-enum whichthread_e { 
-  mainthread, 
-  slavethread };
+enum whichthread_e { mainthread, slavethread };
 
 typedef struct _option_t {
   int pcount;
-  enum errormode_e emode; 
+  enum errormode_e emode;
   enum whichthread_e thr;
 } option_t;
-
 
 /*
  * The variable to store model checker options
  */
 option_t myopt;
 
+void print_debug_state() {
+  fprintf(stdout, "*************************************************\n");
+  if (!MPIR_debug_state) {
+    fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_debug_state     : %d, %s\n",
+            MPIR_debug_state, "State not set");
+  } else {
+    fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_debug_state     : %d, %s\n",
+            MPIR_debug_state,
+            (MPIR_debug_state == MPIR_DEBUG_SPAWNED) ? "Spawned" : "Aborting");
+  }
 
-void 
-print_debug_state ()
-{
-
-  fprintf ( stdout, "*************************************************\n" );
-  if ( !MPIR_debug_state )
-    {
-      fprintf ( stdout, 
-		"[LaunchMON MODEL CHECKER] MPIR_debug_state     : %d, %s\n", 
-		MPIR_debug_state, "State not set" ); 
-    }
-  else
-    {
-      fprintf ( stdout, 
-		"[LaunchMON MODEL CHECKER] MPIR_debug_state     : %d, %s\n", 
-		MPIR_debug_state, (MPIR_debug_state == MPIR_DEBUG_SPAWNED) 
-			          ? "Spawned" : "Aborting"); 
-    }
-
-  fprintf ( stdout, 
-	    "[LaunchMON MODEL CHECKER] MPIR_debug_gate      : %d\n", 
-	    MPIR_debug_gate ); 
-  fprintf ( stdout, 
-	    "[LaunchMON MODEL CHECKER] MPIR_proctable_size  : %d\n", 
-	    MPIR_proctable_size ); 
-  fprintf ( stdout, 
-	    "[LaunchMON MODEL CHECKER] MPIR_being_debugged  : %d\n", 
-	    MPIR_being_debugged ); 
-  fprintf ( stdout, 
-	    "[LaunchMON MODEL CHECKER] MPIR_executable_path : %s\n", 
-	    MPIR_executable_path ); 
-  fprintf ( stdout, 
-	    "[LaunchMON MODEL CHECKER] MPIR_server_arguments: "); 
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_debug_gate      : %d\n",
+          MPIR_debug_gate);
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_proctable_size  : %d\n",
+          MPIR_proctable_size);
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_being_debugged  : %d\n",
+          MPIR_being_debugged);
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_executable_path : %s\n",
+          MPIR_executable_path);
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_server_arguments: ");
   char* trav = MPIR_server_arguments;
-  while ((*trav != '\0') && (*(trav+1) != '\0'))
-    {
-      fprintf ( stdout, "%s ", trav); 
-      trav += strlen(trav)+1;	
-    }
-  fprintf ( stdout, "\n");
+  while ((*trav != '\0') && (*(trav + 1) != '\0')) {
+    fprintf(stdout, "%s ", trav);
+    trav += strlen(trav) + 1;
+  }
+  fprintf(stdout, "\n");
 }
 
-
-EXTERN_C int MPIR_Breakpoint ()
-{
-
+EXTERN_C int MPIR_Breakpoint() {
   /*  This is the dummy function that gets called
    *  when A) the job's state is about to be attached or
-   *  B) is about to be terminated.     
+   *  B) is about to be terminated.
    */
 
-  fprintf ( stdout, "[LaunchMON MODEL CHECKER] MPIR_Breakpoint invoked \n" );
-  print_debug_state ();
+  fprintf(stdout, "[LaunchMON MODEL CHECKER] MPIR_Breakpoint invoked \n");
+  print_debug_state();
 
   return 0;
 }
 
-
-void *
-setup_debugger ( void* arg )
-{
+void* setup_debugger(void* arg) {
   int i;
-  char *tmphn;
-  MPIR_proctable_size = myopt.pcount; 
+  char* tmphn;
+  MPIR_proctable_size = myopt.pcount;
 
-  if ( MPIR_being_debugged ) 
-    {
-      MPIR_debug_state = MPIR_DEBUG_SPAWNED;
-      MPIR_proctable = (MPIR_PROCDESC*) 
-	malloc (MPIR_proctable_size * sizeof(MPIR_PROCDESC));     
-      tmphn = (char*) malloc (21);
+  if (MPIR_being_debugged) {
+    MPIR_debug_state = MPIR_DEBUG_SPAWNED;
+    MPIR_proctable =
+        (MPIR_PROCDESC*)malloc(MPIR_proctable_size * sizeof(MPIR_PROCDESC));
+    tmphn = (char*)malloc(21);
 
-      for (i = 0;  i < MPIR_proctable_size; i++ )
-	{
-	  if ( i/10 == 0 )	    
-	    sprintf ( tmphn, "virtualmachine00000%d", i);  	      	    
-	  else if ( i/100 == 0 )
-	    sprintf ( tmphn, "virtualmachine0000%d", i);  
-	  else if ( i/1000 == 0 )
-	    sprintf ( tmphn, "virtualmachine000%d", i);  	  
-	  else if ( i/10000 == 0 )
-	    sprintf ( tmphn, "virtualmachine00%d", i);    
-	  else if ( i/100000 == 0 )
-	    sprintf ( tmphn, "virtualmachine0%d", i);    
-	  else
-	    sprintf ( tmphn, "virtualmachine%d", i);
+    for (i = 0; i < MPIR_proctable_size; i++) {
+      if (i / 10 == 0)
+        sprintf(tmphn, "virtualmachine00000%d", i);
+      else if (i / 100 == 0)
+        sprintf(tmphn, "virtualmachine0000%d", i);
+      else if (i / 1000 == 0)
+        sprintf(tmphn, "virtualmachine000%d", i);
+      else if (i / 10000 == 0)
+        sprintf(tmphn, "virtualmachine00%d", i);
+      else if (i / 100000 == 0)
+        sprintf(tmphn, "virtualmachine0%d", i);
+      else
+        sprintf(tmphn, "virtualmachine%d", i);
 
-	  MPIR_proctable[i].host_name = strdup (tmphn);
-	  MPIR_proctable[i].executable_name = strdup("appX");
-	  MPIR_proctable[i].pid = i;
-	}
-      totalview_jobid = strdup("387266");
-      MPIR_Breakpoint();
+      MPIR_proctable[i].host_name = strdup(tmphn);
+      MPIR_proctable[i].executable_name = strdup("appX");
+      MPIR_proctable[i].pid = i;
     }
+    totalview_jobid = strdup("387266");
+    MPIR_Breakpoint();
+  }
 
   return NULL;
 }
-
 
 #include <sys/types.h>
 
-void * 
-abort_debugger ( void* arg )
-{
-  if ( MPIR_being_debugged ) 
-    {
-      MPIR_debug_state = MPIR_DEBUG_ABORTING;	
-      MPIR_Breakpoint();
-    }
+void* abort_debugger(void* arg) {
+  if (MPIR_being_debugged) {
+    MPIR_debug_state = MPIR_DEBUG_ABORTING;
+    MPIR_Breakpoint();
+  }
 
   return NULL;
 }
 
-
-void * 
-do_something ( void* arg )
-{
+void* do_something(void* arg) {
   int cnt = 0;
   long tid = ((long)arg);
 
-  if (tid == 24) 
-    {
-      setup_debugger(arg);
-    }
+  if (tid == 24) {
+    setup_debugger(arg);
+  }
 
   while (1) {
-   
     sleep(1);
- 
+
     cnt++;
-    //fprintf ( stdout, ".",tid );
-    //fflush ( stdout );
-	
-    if ( cnt == 3 ) 
-      {
-	break;
-      }
-  }       
-   
-  fprintf ( stdout, "tid[%ld]done \n", tid);
+    // fprintf ( stdout, ".",tid );
+    // fflush ( stdout );
+
+    if (cnt == 3) {
+      break;
+    }
+  }
+
+  fprintf(stdout, "tid[%ld]done \n", tid);
   pthread_exit(NULL);
 }
 
-
-void 
-print_usage ()
-{
-  fprintf ( stdout, "usage: mpirun-modelchker [OPTIONS]\n");
-  fprintf ( stdout, "OPTIONS\n");
-  fprintf ( stdout, "%s \n\t\t\tspecify process count to emulate\n", "-p<process count>:" );
-  fprintf ( stdout, "%s \n\t\t\terror injection type [0~4]\n", "-e<error type>: " );
-  fprintf ( stdout, "%s \n\t\t\t0 for main thread, 1 for pthread\n", "-t<which thread to call MPIR_Breakpoint>:" );
-  fprintf ( stdout, "%s \n\t\t\tprint this message\n", "-h:");
+void print_usage() {
+  fprintf(stdout, "usage: mpirun-modelchker [OPTIONS]\n");
+  fprintf(stdout, "OPTIONS\n");
+  fprintf(stdout, "%s \n\t\t\tspecify process count to emulate\n",
+          "-p<process count>:");
+  fprintf(stdout, "%s \n\t\t\terror injection type [0~4]\n",
+          "-e<error type>: ");
+  fprintf(stdout, "%s \n\t\t\t0 for main thread, 1 for pthread\n",
+          "-t<which thread to call MPIR_Breakpoint>:");
+  fprintf(stdout, "%s \n\t\t\tprint this message\n", "-h:");
 
   exit(0);
-  
 }
 
-
-void 
-echo_argv (int argc, char** argv)
-{
+void echo_argv(int argc, char** argv) {
   int i;
 
-  fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Below is the launch string invoked by LaunchMON\n");
+  fprintf(stdout,
+          "[LaunchMON MODEL CHECKER]: Below is the launch string invoked by "
+          "LaunchMON\n");
 
-  for ( i = 0; i < argc; i++ )    
-    fprintf ( stdout, "[LaunchMON MODEL CHECKER]: %s\n", argv[i]);   
+  for (i = 0; i < argc; i++)
+    fprintf(stdout, "[LaunchMON MODEL CHECKER]: %s\n", argv[i]);
 
   exit(0);
 }
 
-
-int modelchecker_run( int argc, char* argv[])
-{
+int modelchecker_run(int argc, char* argv[]) {
   int i = 0;
   int errorlevel;
 
   myopt.pcount = 16;
   myopt.emode = err0;
   myopt.thr = slavethread;
-  
-  while ( i < argc )
-    {      
-      if ( argv[i][0] == '-' )
-	{
-	  switch ( argv[i][1] )
-	    {
-	    case 'p':	     
-	      if ( ( myopt.pcount = atoi ( argv[i]+2 ) ) < 0 )
-		{
-		  myopt.pcount = 16;
-		  fprintf ( stderr, 
-			    "[LaunchMON MODEL CHECKER]: cannot convert %s to an pcount\n", 
-			    &(argv[i][2]));
-		}		
-	      break;
-	      
-	    case 'e':	     
-	      errorlevel = atoi ( argv[i]+2 );
-	      if ( errorlevel < 0 || errorlevel > 4 )
-		{
-		  fprintf ( stderr, 
-			    "[LaunchMON MODEL CHECKER]: unknown error level: %s\n", 
-			    &(argv[i][2]));
-		}
-	      else
-		{
-		  switch ( argv[i][2] )
-		    {
-		    case '0':
-		      myopt.emode = err0;
-		      break;
-		    case '1':
-		      myopt.emode = err1;
-		      break;
-		    case '2':
-		      myopt.emode = err2;
-		      break;
-		    case '3':
-		      myopt.emode = err3;
-		      break;
-		    case '4':
-		      myopt.emode = err4;
-		      break;
-		    default:
-		      myopt.emode = err0;
-		      break;		      
-		    }		   
-		}
-	      break;
 
-	    case 't':	      
-	      if ( argv[i][2] == '0' )
-		myopt.thr = mainthread;	       
-	      else if ( argv[i][2] == '1')
-		myopt.thr = slavethread;
-	      else
-		{
-		  fprintf ( stderr, 
-			    "[LaunchMON MODEL CHECKER]: unknown thread option: %s\n", 
-			    &(argv[i][2]));
-		  myopt.thr = mainthread;
-		}		
-	      break;
+  while (i < argc) {
+    if (argv[i][0] == '-') {
+      switch (argv[i][1]) {
+        case 'p':
+          if ((myopt.pcount = atoi(argv[i] + 2)) < 0) {
+            myopt.pcount = 16;
+            fprintf(
+                stderr,
+                "[LaunchMON MODEL CHECKER]: cannot convert %s to an pcount\n",
+                &(argv[i][2]));
+          }
+          break;
 
-	    case 'h':
-	      print_usage ();
-	      break;
+        case 'e':
+          errorlevel = atoi(argv[i] + 2);
+          if (errorlevel < 0 || errorlevel > 4) {
+            fprintf(stderr,
+                    "[LaunchMON MODEL CHECKER]: unknown error level: %s\n",
+                    &(argv[i][2]));
+          } else {
+            switch (argv[i][2]) {
+              case '0':
+                myopt.emode = err0;
+                break;
+              case '1':
+                myopt.emode = err1;
+                break;
+              case '2':
+                myopt.emode = err2;
+                break;
+              case '3':
+                myopt.emode = err3;
+                break;
+              case '4':
+                myopt.emode = err4;
+                break;
+              default:
+                myopt.emode = err0;
+                break;
+            }
+          }
+          break;
 
-	    case 'c':
-	      echo_argv (argc, argv);
-	      break;
+        case 't':
+          if (argv[i][2] == '0')
+            myopt.thr = mainthread;
+          else if (argv[i][2] == '1')
+            myopt.thr = slavethread;
+          else {
+            fprintf(stderr,
+                    "[LaunchMON MODEL CHECKER]: unknown thread option: %s\n",
+                    &(argv[i][2]));
+            myopt.thr = mainthread;
+          }
+          break;
 
-	    default:
-	      fprintf ( stderr, "[LaunchMON MODEL CHECKER]: unknown option: %c, ignore\n", argv[i][1] ); 
-	      break;
-	    }
-	}
-	  i++;            
+        case 'h':
+          print_usage();
+          break;
+
+        case 'c':
+          echo_argv(argc, argv);
+          break;
+
+        default:
+          fprintf(stderr,
+                  "[LaunchMON MODEL CHECKER]: unknown option: %c, ignore\n",
+                  argv[i][1]);
+          break;
+      }
     }
+    i++;
+  }
 
-  if ( myopt.thr == slavethread )
-    {
-      pthread_t thr[256];
-      long i;
-	  
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Starting mpirun model checker...\n");
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Process Count: %d\n", 
-		myopt.pcount);
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Pthreads calling MPIR_Breakpoint %d\n", 
-		myopt.thr);
-	  
-      for (i=0; i < 256; i++) 	  
-	pthread_create(&thr[i], NULL, do_something, (void *) i);
+  if (myopt.thr == slavethread) {
+    pthread_t thr[256];
+    long i;
 
-      //pthread_create(&thr[1023], NULL, setup_debugger, (void *) argv[0]);
-	
-      for (i=0; i < 256; i++)
-	pthread_join(thr[i], NULL);
-	
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Finishing up...\n");
-      pthread_create(&thr[0], NULL, abort_debugger, (void *) argv[0]);
-      pthread_join(thr[0], NULL);
-    }
-  else
-    {
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Starting mpirun model checker...\n");
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Process Count: %d\n", 
-		myopt.pcount);
-      fprintf ( stdout, "[LaunchMON MODEL CHECKER]: Main process thread calling MPIR_Breakpoint %d\n", 
-		myopt.pcount);
+    fprintf(stdout,
+            "[LaunchMON MODEL CHECKER]: Starting mpirun model checker...\n");
+    fprintf(stdout, "[LaunchMON MODEL CHECKER]: Process Count: %d\n",
+            myopt.pcount);
+    fprintf(stdout,
+            "[LaunchMON MODEL CHECKER]: Pthreads calling MPIR_Breakpoint %d\n",
+            myopt.thr);
 
-	  
-      setup_debugger ((void*) argv[0]);
-      abort_debugger ((void*) argv[0]);
-    }
- 
-  fprintf ( stdout, "\n****************************************************************\n");
-  fprintf ( stdout,
-    "[LMON LE: OK] MPI job launcher model checker reached the end\n");
-  fprintf ( stdout,
-    "[LMON LE: OK] Please check if launchmon fetched all RPDTAB entries of %d tasks\n", myopt.pcount);
-  fprintf ( stdout, "****************************************************************\n\n");
+    for (i = 0; i < 256; i++)
+      pthread_create(&thr[i], NULL, do_something, (void*)i);
+
+    // pthread_create(&thr[1023], NULL, setup_debugger, (void *) argv[0]);
+
+    for (i = 0; i < 256; i++) pthread_join(thr[i], NULL);
+
+    fprintf(stdout, "[LaunchMON MODEL CHECKER]: Finishing up...\n");
+    pthread_create(&thr[0], NULL, abort_debugger, (void*)argv[0]);
+    pthread_join(thr[0], NULL);
+  } else {
+    fprintf(stdout,
+            "[LaunchMON MODEL CHECKER]: Starting mpirun model checker...\n");
+    fprintf(stdout, "[LaunchMON MODEL CHECKER]: Process Count: %d\n",
+            myopt.pcount);
+    fprintf(stdout,
+            "[LaunchMON MODEL CHECKER]: Main process thread calling "
+            "MPIR_Breakpoint %d\n",
+            myopt.pcount);
+
+    setup_debugger((void*)argv[0]);
+    abort_debugger((void*)argv[0]);
+  }
+
+  fprintf(
+      stdout,
+      "\n****************************************************************\n");
+  fprintf(stdout,
+          "[LMON LE: OK] MPI job launcher model checker reached the end\n");
+  fprintf(stdout,
+          "[LMON LE: OK] Please check if launchmon fetched all RPDTAB entries "
+          "of %d tasks\n",
+          myopt.pcount);
+  fprintf(
+      stdout,
+      "****************************************************************\n\n");
 
   return 0;
 }
 
-int
-main ( int argc, char* argv[])
-{
-  return modelchecker_run(argc, argv);
-}
+int main(int argc, char* argv[]) { return modelchecker_run(argc, argv); }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/Makefile.am
+++ b/test/src/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##
 ##--------------------------------------------------------------------------------
@@ -101,13 +101,13 @@ fe_launch_smoketest_SOURCES = fe_launch_smoketest.cxx util.c
 fe_launch_smoketest_CFLAGS = $(AM_CFLAGS)
 fe_launch_smoketest_CXXFLAGS = $(AM_CXXFLAGS)
 fe_launch_smoketest_LDFLAGS = -L$(API_LIB_DIR)
-fe_launch_smoketest_LDADD = -lmonfeapi 
+fe_launch_smoketest_LDADD = -lmonfeapi
 
 fe_launch_usrpayload_test_SOURCES = fe_launch_usrpayload_test.cxx util.c
 fe_launch_usrpayload_test_CFLAGS = $(AM_CFLAGS)
 fe_launch_usrpayload_test_CXXFLAGS = $(AM_CXXFLAGS)
 fe_launch_usrpayload_test_LDFLAGS = -L$(API_LIB_DIR)
-fe_launch_usrpayload_test_LDADD = -lmonfeapi 
+fe_launch_usrpayload_test_LDADD = -lmonfeapi
 
 fe_attach_smoketest_SOURCES = fe_attach_smoketest.cxx util.c
 fe_attach_smoketest_CFLAGS = $(AM_CFLAGS)
@@ -119,7 +119,7 @@ be_kicker_SOURCES = be_kicker.cxx util.c
 be_kicker_CFLAGS = $(AM_CFLAGS)
 be_kicker_CXXFLAGS = $(AM_CXXFLAGS)
 be_kicker_LDFLAGS = -L$(API_LIB_DIR)
-be_kicker_LDADD = -lmonbeapi 
+be_kicker_LDADD = -lmonbeapi
 
 be_kicker_usrpayload_test_SOURCES = be_kicker_usrpayload_test.cxx
 be_kicker_usrpayload_test_CFLAGS = $(AM_CFLAGS)
@@ -131,7 +131,7 @@ fe_launch_middleware_SOURCES = fe_launch_middleware.cxx util.c
 fe_launch_middleware_CFLAGS = $(AM_CFLAGS)
 fe_launch_middleware_CXXFLAGS = $(AM_CXXFLAGS)
 fe_launch_middleware_LDFLAGS = -L$(API_LIB_DIR)
-fe_launch_middleware_LDADD = -lmonfeapi 
+fe_launch_middleware_LDADD = -lmonfeapi
 
 be_standalone_kicker_SOURCES = be_standalone_kicker.cxx
 be_standalone_kicker_CFLAGS = $(AM_CFLAGS)
@@ -143,13 +143,13 @@ be_mem_fetcher_SOURCES = be_mem_fetcher.cxx util.c
 be_mem_fetcher_CFLAGS = $(AM_CFLAGS)
 be_mem_fetcher_CXXFLAGS = $(AM_CXXFLAGS)
 be_mem_fetcher_LDFLAGS = -L$(API_LIB_DIR)
-be_mem_fetcher_LDADD = -lmonbeapi 
+be_mem_fetcher_LDADD = -lmonbeapi
 
 fe_jobsnap_SOURCES = fe_jobsnap.cxx util.c
 fe_jobsnap_CFLAGS = $(AM_CFLAGS)
 fe_jobsnap_CXXFLAGS = $(AM_CXXFLAGS)
 fe_jobsnap_LDFLAGS = -L$(API_LIB_DIR)
-fe_jobsnap_LDADD = -lmonfeapi 
+fe_jobsnap_LDADD = -lmonfeapi
 
 be_jobsnap_SOURCES = be_jobsnap.cxx util.c
 be_jobsnap_CFLAGS = $(AM_CFLAGS)
@@ -217,11 +217,11 @@ $(check_SCRIPTS): %: %.in
 	chmod +x $@
 
 run_3mins$(EXEEXT): run_3mins.c Makefile
-	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<	
+	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<
 
 hang_on_SIGUSR1$(EXEEXT): hang_on_SIGUSR1.c Makefile
-	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<	
+	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<
 
 simple_MPI$(EXEEXT): simple_MPI.c Makefile
-	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<	
+	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) -I$(BASE_SRC_DIR) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -o $@ $<
 

--- a/test/src/be_jobsnap.cxx
+++ b/test/src/be_jobsnap.cxx
@@ -1,29 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Dec 16 2009 DHA: Added limits.h
@@ -31,7 +32,7 @@
  *        Jun 12 2008 DHA: Added GNU build system support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
  *        Dec 04 2007 DHA: Change %x to %lx for sscanf
- *                         to quiet the compilation. 
+ *                         to quiet the compilation.
  *        Aug 08 2007 DHA: Created file.
  */
 
@@ -43,23 +44,23 @@
 
 #define __GNU_SOURCE
 
-#include <unistd.h>
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <iomanip>
-#include <signal.h>
 #include <limits.h>
+#include <signal.h>
+#include <unistd.h>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
-# include "debugger_interface.h"
-  using namespace DebuggerInterface;
-#else 
-#include <sys/types.h>
-#include <sys/wait.h>
+#include "debugger_interface.h"
+using namespace DebuggerInterface;
+#else
+#include <errno.h>
 #include <sys/ptrace.h>
 #include <sys/resource.h>
-#include <errno.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #endif
 
 #include <lmon_api/lmon_be.h>
@@ -68,25 +69,25 @@ using namespace std;
 
 #if MEASURE_TRACING_COST
 extern "C" {
-extern int begin_timer ();
-extern int time_stamp ( const char* description );
+extern int begin_timer();
+extern int time_stamp(const char *description);
 }
 #endif
 
-const int MAX_TID          = 0x0fffffff;
+const int MAX_TID = 0x0fffffff;
 const int JIFFY_CONVERSION = 10000;
 const int LENGTH_REQ_4_HEX = 18;
-const int PAGESIZE         = 4096;
+const int PAGESIZE = 4096;
 
 struct ProcStat {
-  int mpiRank; 
-  int pid;                  /* process id; use %d */
-  char comm[PATH_MAX];      /* exec name; use %s */
-  char state;               /* RSDZTW; use %c */
+  int mpiRank;
+  int pid;             /* process id; use %d */
+  char comm[PATH_MAX]; /* exec name; use %s */
+  char state;          /* RSDZTW; use %c */
   int nThread;
   unsigned long startStack;
-  unsigned long stkSp;    /* %lu stack pointer */
-  unsigned long stkIp;    /* %lu instruction pointer*/
+  unsigned long stkSp; /* %lu stack pointer */
+  unsigned long stkIp; /* %lu instruction pointer*/
 
   typedef union {
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
@@ -96,38 +97,41 @@ struct ProcStat {
     } BgpStat;
 #else
     struct {
-      int ppid;                 /* parent's pid; use %d */
-      int pgid;                 /* process group id; %d */
-      int session;              /* session id; %d */
-      int tty_nr;               /* the tty that the process uses; %d */
-      int tpgid;                /* see manpage: %d */
-      unsigned long flags;      /* the flags of the process; %lu */
-      unsigned long minflt;     /* # of minor faults: %lu */
-      unsigned long cminflt;    /* # of minor faults that the process waited for children have made: %lu */
-      unsigned long majflt;     /* # of major faults; %lu */
-      unsigned long cmajflt;    /* %lu */
-      unsigned long utime;      /* # of jiffies (1/100th sec) in user mode: %lu */
-      unsigned long stime;      /* # of jiffies (1/100th sec) in kernel mode: %lu */
-      unsigned long cutime;     /* # of jiffies in user mode, which the process waited for children have made: %ld */
-      unsigned long cstime;     /* # of jiffies in system mode, which the process waited for children have made: %ld */
-      unsigned long priority;   /* %ld */
+      int ppid;              /* parent's pid; use %d */
+      int pgid;              /* process group id; %d */
+      int session;           /* session id; %d */
+      int tty_nr;            /* the tty that the process uses; %d */
+      int tpgid;             /* see manpage: %d */
+      unsigned long flags;   /* the flags of the process; %lu */
+      unsigned long minflt;  /* # of minor faults: %lu */
+      unsigned long cminflt; /* # of minor faults that the process waited for
+                                children have made: %lu */
+      unsigned long majflt;  /* # of major faults; %lu */
+      unsigned long cmajflt; /* %lu */
+      unsigned long utime;   /* # of jiffies (1/100th sec) in user mode: %lu */
+      unsigned long stime;  /* # of jiffies (1/100th sec) in kernel mode: %lu */
+      unsigned long cutime; /* # of jiffies in user mode, which the process
+                               waited for children have made: %ld */
+      unsigned long cstime; /* # of jiffies in system mode, which the process
+                               waited for children have made: %ld */
+      unsigned long priority; /* %ld */
       unsigned long nice;
-      unsigned long itrealvalue;     /* %lu */
-      unsigned long long starttime;  /* %lu */
-      unsigned long vsize;      /* %lu */
-      long rss;                 /* %ld */
-      unsigned long rlim;       /* %lu */
-      unsigned long startcode;  /* %lu */
-      unsigned long endcode;    /* %lu */
-      unsigned long signal;     /* %lu */
-      unsigned long blocked;    /* %lu */
-      unsigned long sigignore;  /* %lu */
-      unsigned long sigcatch;   /* %lu */
-      unsigned long wchan;      /* %lu */
-      unsigned long nswap;      /* %lu */
-      unsigned long cnswap;     /* %lu */
-      int exit_signal;          /* %d */
-      int processor;            /* %d */
+      unsigned long itrealvalue;    /* %lu */
+      unsigned long long starttime; /* %lu */
+      unsigned long vsize;          /* %lu */
+      long rss;                     /* %ld */
+      unsigned long rlim;           /* %lu */
+      unsigned long startcode;      /* %lu */
+      unsigned long endcode;        /* %lu */
+      unsigned long signal;         /* %lu */
+      unsigned long blocked;        /* %lu */
+      unsigned long sigignore;      /* %lu */
+      unsigned long sigcatch;       /* %lu */
+      unsigned long wchan;          /* %lu */
+      unsigned long nswap;          /* %lu */
+      unsigned long cnswap;         /* %lu */
+      int exit_signal;              /* %d */
+      int processor;                /* %d */
       unsigned long rt_prior;
       unsigned long policy;
     } LinuxStat;
@@ -144,7 +148,7 @@ struct MemStat {
     struct {
       unsigned long brk;
       unsigned long heapStart;
-      unsigned long sharedMem; 
+      unsigned long sharedMem;
       unsigned long persistentMem;
       unsigned long mmapMem;
     } BgpMemStat;
@@ -154,7 +158,7 @@ struct MemStat {
       unsigned long vm_lock_memory;
       unsigned long rss_high_watermark;
       unsigned long vm_data;
-      unsigned long vm_stack; 
+      unsigned long vm_stack;
       unsigned long vm_lib;
       unsigned long vm_exe;
       unsigned long brk;
@@ -170,70 +174,62 @@ struct MemStat {
 /*
  * Utility routines to talk to CIOD
  */
-static bool
-sendMessage(BG_Debugger_Msg &msg)
-{
+static bool sendMessage(BG_Debugger_Msg &msg) {
   bool rc = BG_Debugger_Msg::writeOnFd(BG_DEBUGGER_WRITE_PIPE, msg);
 
   // There was an error writing to the pipe.
   if (rc == false) {
-     cerr << "[JOBSNAP BE FAILED] Failed to write to CIOD" 
-          << BG_Debugger_Msg::getMessageName(msg.header.messageType)
-          << " to control daemon" << endl;
+    cerr << "[JOBSNAP BE FAILED] Failed to write to CIOD"
+         << BG_Debugger_Msg::getMessageName(msg.header.messageType)
+         << " to control daemon" << endl;
   }
 
   return rc;
 }
 
-static bool
-receiveMessage(BG_Debugger_Msg &msg)
-{
+static bool receiveMessage(BG_Debugger_Msg &msg) {
   bool rc = BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, msg);
 
   // There was an error reading from the pipe.
   if (rc == false) {
-     cerr << "[JOBSNAP BE FAILED] Failed to read message from CIOD"
-	  << endl;
+    cerr << "[JOBSNAP BE FAILED] Failed to read message from CIOD" << endl;
   }
 
   return rc;
 }
 
-static bool
-receiveMessage(BG_Debugger_Msg &msg, BG_MsgType_t type, uint32_t length)
-{
-   bool rc = BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, msg);
+static bool receiveMessage(BG_Debugger_Msg &msg, BG_MsgType_t type,
+                           uint32_t length) {
+  bool rc = BG_Debugger_Msg::readFromFd(BG_DEBUGGER_READ_PIPE, msg);
 
-   // There was an error reading from the pipe.
-   if (rc == false) {
-     cerr << "[JOBSNAP BE FAILED] Failed to read message from CIOD"
-	  << endl;
-     return false;
-   }
+  // There was an error reading from the pipe.
+  if (rc == false) {
+    cerr << "[JOBSNAP BE FAILED] Failed to read message from CIOD" << endl;
+    return false;
+  }
 
-   if (msg.header.messageType != type) {
-      cerr << "[JOBSNAP BE FAILED] Response %s message is not the expected message"
-	   << endl;
-      return false;
-   }
+  if (msg.header.messageType != type) {
+    cerr
+        << "[JOBSNAP BE FAILED] Response %s message is not the expected message"
+        << endl;
+    return false;
+  }
 
-   if (msg.header.returnCode != 0) {
-      cerr << "[JOBSNAP BE FAILED] Bad return code" << endl;
-      return false;
-   }
+  if (msg.header.returnCode != 0) {
+    cerr << "[JOBSNAP BE FAILED] Bad return code" << endl;
+    return false;
+  }
 
-   if (msg.header.dataLength != length) {
-      cerr << "[JOBSNAP BE FAILED] Bad data length" << endl;
-      return false;
-   }
+  if (msg.header.dataLength != length) {
+    cerr << "[JOBSNAP BE FAILED] Bad data length" << endl;
+    return false;
+  }
 
-   return rc;
+  return rc;
 }
 #endif
 
-int
-main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   using namespace std;
 
   MPIR_PROCDESC_EXT *proctab;
@@ -243,7 +239,7 @@ main(int argc, char *argv[])
   MemStat *gatheredTms = NULL;
 
   int i, k, t;
-  int maxSize=0, *aggrSizes=NULL;
+  int maxSize = 0, *aggrSizes = NULL;
   int rank;
   int be_size;
   int proctab_size;
@@ -255,63 +251,54 @@ main(int argc, char *argv[])
   // LMON Backend API initialization
   //
   lrc = LMON_be_init(LMON_VERSION, &argc, &argv);
-  if ( lrc != LMON_OK ) {
-      cerr << "[JOBSNAP BE: FAILED] LMON_be_init" << endl;
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE: FAILED] LMON_be_init" << endl;
 
-      return EXIT_FAILURE;
+    return EXIT_FAILURE;
   }
 
-  if (argc > 1)
-    signum = atoi(argv[1]);
+  if (argc > 1) signum = atoi(argv[1]);
 
   //
-  // LMON Backend rank that will be used in generating 
+  // LMON Backend rank that will be used in generating
   // error messages if any
   //
-  LMON_be_getMyRank (&rank);
-  LMON_be_getSize (&be_size);
+  LMON_be_getMyRank(&rank);
+  LMON_be_getSize(&be_size);
 
   //
   // LMON BE-FE handshaking
   //
   lrc = LMON_be_handshake(NULL);
-  if ( lrc != LMON_OK ) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_handshake"
-	   << endl;
-      LMON_be_finalize();
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_handshake" << endl;
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
+    return EXIT_FAILURE;
   }
 
   //
   // Handshake is over; All backend daemons are synchronized with
   // a be_ready.
   //
-  if ( (lrc = LMON_be_ready(NULL)) != LMON_OK ) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_ready"
-	   << endl;
-      LMON_be_finalize();
+  if ((lrc = LMON_be_ready(NULL)) != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_ready" << endl;
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
+    return EXIT_FAILURE;
   }
 
   //
   // Testing the size of the local proctab
   // note that proctab_size could differ across different BEs
   //
-  lrc = LMON_be_getMyProctabSize (&proctab_size);
-  if ( lrc != LMON_OK) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_getMyProctabSize"
-	   << endl;
-      LMON_be_finalize();
+  lrc = LMON_be_getMyProctabSize(&proctab_size);
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_getMyProctabSize"
+         << endl;
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
+    return EXIT_FAILURE;
   }
 
   //
@@ -319,587 +306,532 @@ main(int argc, char *argv[])
   //
   aggrSizes = new int[be_size];
 
-  if ( LMON_be_gather(&proctab_size, sizeof(int), aggrSizes) < 0 ) {
-    cerr << "[JOBSNAP BE("
-	 << rank
-	 << "): FAILED] LMON_be_gather"
-	 << endl;
+  if (LMON_be_gather(&proctab_size, sizeof(int), aggrSizes) < 0) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_gather" << endl;
 
     LMON_be_finalize();
 
     return EXIT_FAILURE;
   }
 
-  if ( LMON_be_amIMaster () == LMON_YES ) {
-    for(k=0; k < be_size; ++k) {
-      if (aggrSizes[k] > maxSize)
-        maxSize= aggrSizes[k];
+  if (LMON_be_amIMaster() == LMON_YES) {
+    for (k = 0; k < be_size; ++k) {
+      if (aggrSizes[k] > maxSize) maxSize = aggrSizes[k];
     }
   }
 
   delete aggrSizes;
 
-  if ( LMON_be_broadcast(&maxSize,sizeof(int)) < 0) {
-    cerr << "[JOBSNAP BE("
-	 << rank
-	 << "): FAILED] LMON_be_broadcast"
-	 << endl;
+  if (LMON_be_broadcast(&maxSize, sizeof(int)) < 0) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_broadcast" << endl;
 
     LMON_be_finalize();
 
     return EXIT_FAILURE;
   }
 
-  proctab = (MPIR_PROCDESC_EXT *) 
-           malloc (maxSize*sizeof(MPIR_PROCDESC_EXT));
-  if ( proctab == NULL )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: malloc returned null\n",
-        rank );
-      LMON_be_finalize();
+  proctab = (MPIR_PROCDESC_EXT *)malloc(maxSize * sizeof(MPIR_PROCDESC_EXT));
+  if (proctab == NULL) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: malloc returned null\n", rank);
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
-  tps = (ProcStat *) 
-        malloc (maxSize*sizeof(ProcStat));
-  if ( tps == NULL )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: malloc returned null\n",
-        rank );
-      LMON_be_finalize();
+  tps = (ProcStat *)malloc(maxSize * sizeof(ProcStat));
+  if (tps == NULL) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: malloc returned null\n", rank);
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
-  tms = (MemStat *) 
-        malloc (maxSize*sizeof(MemStat));
-  if ( tms  == NULL )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: malloc returned null\n",
-        rank );
-      LMON_be_finalize();
+  tms = (MemStat *)malloc(maxSize * sizeof(MemStat));
+  if (tms == NULL) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: malloc returned null\n", rank);
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
   //
   // Fetching per-node proctable
   //
   lrc = LMON_be_getMyProctab(proctab, &proctab_size, proctab_size);
-  if ( lrc != LMON_OK ) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_getMyProctab"
-	   << endl;
-      LMON_be_finalize();
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_getMyProctab" << endl;
+    LMON_be_finalize();
 
-      return EXIT_FAILURE;
+    return EXIT_FAILURE;
   }
 
-
-  for(i=0; i < proctab_size; i++) {
+  for (i = 0; i < proctab_size; i++) {
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
-      //
-      // BGP specific process snapshot interface
-      //
-      BG_Process_Data_t procData;
-      BG_Thread_Data_t mainThrData;
-      BG_Debugger_Msg response;
+    //
+    // BGP specific process snapshot interface
+    //
+    BG_Process_Data_t procData;
+    BG_Thread_Data_t mainThrData;
+    BG_Debugger_Msg response;
 
-      tps[i].mpiRank = proctab[i].mpirank;
-      tps[i].pid = proctab[i].pd.pid;
-      strncpy (tps[i].comm, proctab[i].pd.executable_name, PATH_MAX);
+    tps[i].mpiRank = proctab[i].mpirank;
+    tps[i].pid = proctab[i].pd.pid;
+    strncpy(tps[i].comm, proctab[i].pd.executable_name, PATH_MAX);
 
-      //
-      // please attach
-      //
-      BG_Debugger_Msg attach(ATTACH, proctab[i].pd.pid, 0, 0, 0);
-      attach.header.dataLength = sizeof(attach.dataArea.ATTACH);
+    //
+    // please attach
+    //
+    BG_Debugger_Msg attach(ATTACH, proctab[i].pd.pid, 0, 0, 0);
+    attach.header.dataLength = sizeof(attach.dataArea.ATTACH);
 
-      if (!sendMessage(attach)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, ATTACH_ACK, sizeof(response.dataArea.ATTACH_ACK))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      //
-      // please stop
-      //
-      BG_Debugger_Msg stop(KILL, proctab[i].pd.pid, 0, 0, 0);
-      stop.dataArea.KILL.signal = SIGSTOP;
-      stop.header.dataLength = sizeof(stop.dataArea.KILL);
-
-      if (!sendMessage(stop)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, KILL_ACK, sizeof(response.dataArea.KILL_ACK))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      //
-      // please wait for signal encountered event
-      //
-      if (!receiveMessage(response, SIGNAL_ENCOUNTERED, sizeof(response.dataArea.SIGNAL_ENCOUNTERED))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      //
-      // please GET_THREAD_INFO
-      //
-      BG_Debugger_Msg threadInfo(GET_THREAD_INFO, proctab[i].pd.pid,0,0,0);
-      if (!sendMessage(threadInfo)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, GET_THREAD_INFO_ACK, sizeof(response.dataArea.GET_THREAD_INFO_ACK))) {
-        LMON_be_finalize();
-        return EXIT_FAILURE;
-      }
-
-      tps[i].nThread = response.dataArea.GET_THREAD_INFO_ACK.numThreads;
-
-      //
-      // the main thread id will be the smallest of available thread ids, which
-      // is larger than 4 (1-4 are system threads
-      //
-      int mainTid = MAX_TID;
-      for (t=0; t < tps[i].nThread ; ++t) {
-	int targetTid = response.dataArea.GET_THREAD_INFO_ACK.threadIDS[t];
-        if ( (targetTid > 4) && (targetTid < mainTid) )
-	  mainTid =  targetTid;
-      }
-
-      if ( mainTid == MAX_TID ) {
-        cerr << "[JOBSNAP BE("
-	     << rank
-	     << "): FAILED] main thread id info is not available."
-	     << endl;
-
-        LMON_be_finalize();
-        return EXIT_FAILURE;
-      }
-
-      //
-      // please GET_PROCESS_DATA
-      //
-      BG_Debugger_Msg processData(GET_PROCESS_DATA, proctab[i].pd.pid, mainTid, 0, 0);
-      processData.header.dataLength = sizeof(processData.dataArea.GET_PROCESS_DATA);
-
-      if (!sendMessage(processData)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, GET_PROCESS_DATA_ACK, sizeof(response.dataArea.GET_PROCESS_DATA_ACK))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      memcpy( &procData, 
-	      &(response.dataArea.GET_PROCESS_DATA_ACK.processData), 
-              sizeof(procData));
-
-      tps[i].xStat.BgpStat.jobtime 
-        = (double) procData.jobTime.tv_sec + (double) procData.jobTime.tv_usec/1000000.0;
-      tms[i].xMem.BgpMemStat.brk 
-        = procData.heapBreakAddr;
-      tms[i].xMem.BgpMemStat.heapStart 
-        = procData.heapStartAddr;
-      tms[i].xMem.BgpMemStat.sharedMem 
-        = procData.sharedMemoryStartAddr - procData.sharedMemoryEndAddr;
-      tms[i].xMem.BgpMemStat.persistentMem 
-        = procData.persistMemoryStartAddr - procData.persistMemoryEndAddr;
-      tms[i].xMem.BgpMemStat.mmapMem 
-        = procData.mmapStartAddr - procData.mmapEndAddr;
-
-      //
-      // please GET_THREAD_DATA for the main thread
-      //
-      BG_Debugger_Msg threadData(GET_THREAD_DATA, proctab[i].pd.pid, mainTid, 0, 0);
-      threadData.header.dataLength = sizeof(processData.dataArea.GET_THREAD_DATA);
-
-      if (!sendMessage(threadData)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, GET_THREAD_DATA_ACK, sizeof(response.dataArea.GET_THREAD_DATA_ACK))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      memcpy( &mainThrData, 
-              &(response.dataArea.GET_THREAD_DATA_ACK.threadData), 
-              sizeof(mainThrData));
-
-      if ( mainThrData.threadID != mainTid) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      //
-      // get the process state 
-      //
-      switch (mainThrData.state) {
-	case Running:
-          tps[i].state = 'R';
-	  break;
-        case Sleeping:
-          tps[i].state = 'S';
-	  break;
-        case Waiting:
-          tps[i].state = 'W';
-	  break;
-	case Zombie:
-          tps[i].state = 'Z';
-	  break;
-	case Idle:
-          tps[i].state = 'I';
-	  break;
-      }
-
-      tps[i].startStack = mainThrData.stackStartAddr;    // 
-      tps[i].stkSp = mainThrData.gprs.gpr[1];            // R01 is the stack pointer register
-      tps[i].stkIp = mainThrData.gprs.iar;               // IAR is instruction pointer
-
-      //
-      // please continue
-      //
-      BG_Debugger_Msg conti(CONTINUE, proctab[i].pd.pid, 0, 0, 0);
-      conti.header.dataLength = sizeof(processData.dataArea.CONTINUE);
-
-      if (!sendMessage(conti)) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-      if (!receiveMessage(response, CONTINUE_ACK, sizeof(response.dataArea.CONTINUE_ACK))) {
-        LMON_be_finalize();
-
-        return EXIT_FAILURE;
-      }
-
-#else 
-     //
-     // Linux specific process snapshot interface 
-     //
-      ostringstream ost1, ost2;
-      ifstream ifst;
-      char line[4096];
-      size_t len;
-
-      ost1 << "/proc/" << proctab[i].pd.pid << "/stat";
-
-      // how do you want to check exceptions?
-      ifst.open(ost1.str().c_str(), ios::in);
-
-      tps[i].mpiRank = proctab[i].mpirank;
-
-      ifst >> tps[i].pid
-	   >> tps[i].comm
-	   >> tps[i].state
-	   >> tps[i].xStat.LinuxStat.ppid // ppid
-	   >> tps[i].xStat.LinuxStat.pgid
-	   >> tps[i].xStat.LinuxStat.session
-	   >> tps[i].xStat.LinuxStat.tty_nr
-	   >> tps[i].xStat.LinuxStat.tpgid
-	   >> tps[i].xStat.LinuxStat.flags
-	   >> tps[i].xStat.LinuxStat.minflt
-	   >> tps[i].xStat.LinuxStat.cminflt
-	   >> tps[i].xStat.LinuxStat.majflt
-	   >> tps[i].xStat.LinuxStat.cmajflt
-	   >> tps[i].xStat.LinuxStat.utime
-	   >> tps[i].xStat.LinuxStat.stime
-	   >> tps[i].xStat.LinuxStat.cutime
-	   >> tps[i].xStat.LinuxStat.cstime
-	   >> tps[i].xStat.LinuxStat.priority
-	   >> tps[i].xStat.LinuxStat.nice
-	   >> tps[i].nThread
-	   >> tps[i].xStat.LinuxStat.itrealvalue
-	   >> tps[i].xStat.LinuxStat.starttime
-	   >> tps[i].xStat.LinuxStat.vsize
-	   >> tps[i].xStat.LinuxStat.rss
-	   >> tps[i].xStat.LinuxStat.rlim
-	   >> tps[i].xStat.LinuxStat.startcode
-	   >> tps[i].xStat.LinuxStat.endcode
-	   >> tps[i].startStack
-	   >> tps[i].stkSp
-	   >> tps[i].stkIp
-	   >> tps[i].xStat.LinuxStat.signal
-	   >> tps[i].xStat.LinuxStat.blocked
-	   >> tps[i].xStat.LinuxStat.sigignore
-	   >> tps[i].xStat.LinuxStat.sigcatch
-	   >> tps[i].xStat.LinuxStat.wchan
-	   >> tps[i].xStat.LinuxStat.nswap
-	   >> tps[i].xStat.LinuxStat.cnswap
-	   >> tps[i].xStat.LinuxStat.exit_signal
-	   >> tps[i].xStat.LinuxStat.processor
-	   >> tps[i].xStat.LinuxStat.rt_prior
-	   >> tps[i].xStat.LinuxStat.policy;
-
-      ifst.close();
-
-      ost2 << "/proc/" << proctab[i].pd.pid << "/status";
-
-      // how do you want to check exceptions?
-      ifst.open(ost2.str().c_str(), ios::in);
-
-      while (!ifst.eof()) {
-        ifst.getline(line, 4096);
-	char* tok;
-	char* linebuf = strdup (line);
-	tok = strtok ( linebuf, ": \t");
-
-        if (!tok)
-          continue;
-
-	if ( strcmp ( tok, "VmPeak") == 0 ) {
-	  tok = strtok ( NULL, ": \t");
-	  tms[i].xMem.LinuxMemStat.vm_high_watermark = atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "VmLck") == 0 ) {
-	   tok = strtok ( NULL, ": \t");
-	   tms[i].xMem.LinuxMemStat.vm_lock_memory = atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "VmHWM") == 0 ) {
-	  tok = strtok ( NULL, ": \t");
-	  tms[i].xMem.LinuxMemStat.rss_high_watermark = atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "VmData") == 0 ) {
-	  tok = strtok ( NULL, ": \t");
-	  tms[i].xMem.LinuxMemStat.vm_data = atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "VmStk") == 0 ) {
-	  tok = strtok ( NULL, ": \t");
-	  tms[i].xMem.LinuxMemStat.vm_stack = atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "StaBrk") == 0 ) {
-	  tok = strtok ( NULL, ": \t");
-          sscanf (tok, "%lx", &(tms[i].xMem.LinuxMemStat.brkstart));
-	  tms[i].xMem.LinuxMemStat.brkstart *= 1024;
-	}
-	else if ( strcmp ( tok, "Brk") == 0 ) {
-	   tok = strtok ( NULL, ": \t");
-	   sscanf (tok, "%lx", &(tms[i].xMem.LinuxMemStat.brk));
-           tms[i].xMem.LinuxMemStat.brk *= 1024;
-	}
-	else if ( strcmp ( tok, "VmLib") == 0 ) {
-	   tok = strtok ( NULL, ": \t");
-	   tms[i].xMem.LinuxMemStat.vm_lib= atoi(tok)*1024;
-	}
-	else if ( strcmp ( tok, "VmExe") == 0 ) {
-	   tok = strtok ( NULL, ": \t");
-	   tms[i].xMem.LinuxMemStat.vm_exe= atoi(tok)*1024;
-	}
-	free (linebuf);
-      }
-
-      ifst.close();
-#endif //SUB_ARCH_BGP vs LINUX with /proc
-  } // local proctab loop
-
-  //
-  // fill the potentially remaining elements with the dummy rank 
-  //
-  while ( i < maxSize )
-    tps[i++].mpiRank = -1;
-
-  if ( LMON_be_amIMaster () == LMON_YES ) {
-    gatheredTps = (ProcStat *) malloc(be_size*maxSize*sizeof(ProcStat));
-    gatheredTms = (MemStat *) malloc(be_size*maxSize*sizeof(MemStat));
-  }
-
-  lrc =  LMON_be_gather((void *) tps, 
-                        sizeof(ProcStat)*maxSize, 
-                        (void *) gatheredTps);
-
-  if ( lrc != LMON_OK ) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_gather"
-	   << endl;
-
+    if (!sendMessage(attach)) {
       LMON_be_finalize();
 
       return EXIT_FAILURE;
-  }
+    }
 
-  lrc = LMON_be_gather((void *) tms,
-		       sizeof(MemStat)*maxSize, 
-		       (void *) gatheredTms);
-
-  if ( lrc != LMON_OK ) {
-      cerr << "[JOBSNAP BE("
-	   << rank
-	   << "): FAILED] LMON_be_gather"
-	   << endl;
-
+    if (!receiveMessage(response, ATTACH_ACK,
+                        sizeof(response.dataArea.ATTACH_ACK))) {
       LMON_be_finalize();
 
       return EXIT_FAILURE;
-  }
+    }
 
-  if  ( LMON_be_amIMaster() == LMON_YES ) {
-     //
-     // the BE master is responsible for reporting the gathered data 
-     //
-     ofstream ofs;
-     char fn[PATH_MAX];
-     time_t now;
-     time(&now);
-     strftime ( fn, PATH_MAX, "./jobsnap.out.%Y.%m.%d.%H.%M.%S", localtime(&now));
+    //
+    // please stop
+    //
+    BG_Debugger_Msg stop(KILL, proctab[i].pd.pid, 0, 0, 0);
+    stop.dataArea.KILL.signal = SIGSTOP;
+    stop.header.dataLength = sizeof(stop.dataArea.KILL);
 
-     ofs.open(fn, ios::out);
+    if (!sendMessage(stop)) {
+      LMON_be_finalize();
 
-#if MEASURE_TRACING_COST
-     begin_timer ();
-#endif
+      return EXIT_FAILURE;
+    }
 
-     ofs << setw(6) << "Rank" << setw(24) << "Execname" << setw(6) << "State" << setw(20) << "InstPtr" << setw(8) << "nThread" 
-         << setw(20) << "StartStk" << setw(20) << "StackPtr" << setw(15) << "Brk Size(Byte)" << setw(15) << "Utime (secs)" << setw(15) << "Stime (secs)" << endl; 
+    if (!receiveMessage(response, KILL_ACK,
+                        sizeof(response.dataArea.KILL_ACK))) {
+      LMON_be_finalize();
 
-     for ( i=0; i < be_size*maxSize; ++i ) {
-       if ( gatheredTps[i].mpiRank != -1 )  {
-         char bname[24];
-	 char *execname = strdup(gatheredTps[i].comm);
-         snprintf(bname, 24, basename(execname));
-         ofs << setw(6)  << dec << gatheredTps[i].mpiRank 
-             << setw(24) << bname
-	     << setw(6)  << gatheredTps[i].state
-	     << "  Ox" << setfill('0') << setw(16) << hex << gatheredTps[i].stkIp << setfill(' ')
-	     << setw(8)  << gatheredTps[i].nThread
-	     << "  Ox" << setfill('0') << setw(16) << hex << gatheredTps[i].startStack
-	     << "  Ox" << setfill('0') << setw(16) << hex << gatheredTps[i].stkSp << setfill(' ')
-#if SUB_ARCH_BGL || SUB_ARCH_BGP
-	     << setw(15) << dec << (gatheredTms[i].xMem.BgpMemStat.brk - gatheredTms[i].xMem.BgpMemStat.heapStart)
-	     << setw(15) << (double) gatheredTps[i].xStat.BgpStat.jobtime
-	     << setw(15) << 0.0
-	     << endl;
+      return EXIT_FAILURE;
+    }
+
+    //
+    // please wait for signal encountered event
+    //
+    if (!receiveMessage(response, SIGNAL_ENCOUNTERED,
+                        sizeof(response.dataArea.SIGNAL_ENCOUNTERED))) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    //
+    // please GET_THREAD_INFO
+    //
+    BG_Debugger_Msg threadInfo(GET_THREAD_INFO, proctab[i].pd.pid, 0, 0, 0);
+    if (!sendMessage(threadInfo)) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    if (!receiveMessage(response, GET_THREAD_INFO_ACK,
+                        sizeof(response.dataArea.GET_THREAD_INFO_ACK))) {
+      LMON_be_finalize();
+      return EXIT_FAILURE;
+    }
+
+    tps[i].nThread = response.dataArea.GET_THREAD_INFO_ACK.numThreads;
+
+    //
+    // the main thread id will be the smallest of available thread ids, which
+    // is larger than 4 (1-4 are system threads
+    //
+    int mainTid = MAX_TID;
+    for (t = 0; t < tps[i].nThread; ++t) {
+      int targetTid = response.dataArea.GET_THREAD_INFO_ACK.threadIDS[t];
+      if ((targetTid > 4) && (targetTid < mainTid)) mainTid = targetTid;
+    }
+
+    if (mainTid == MAX_TID) {
+      cerr << "[JOBSNAP BE(" << rank
+           << "): FAILED] main thread id info is not available." << endl;
+
+      LMON_be_finalize();
+      return EXIT_FAILURE;
+    }
+
+    //
+    // please GET_PROCESS_DATA
+    //
+    BG_Debugger_Msg processData(GET_PROCESS_DATA, proctab[i].pd.pid, mainTid, 0,
+                                0);
+    processData.header.dataLength =
+        sizeof(processData.dataArea.GET_PROCESS_DATA);
+
+    if (!sendMessage(processData)) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    if (!receiveMessage(response, GET_PROCESS_DATA_ACK,
+                        sizeof(response.dataArea.GET_PROCESS_DATA_ACK))) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    memcpy(&procData, &(response.dataArea.GET_PROCESS_DATA_ACK.processData),
+           sizeof(procData));
+
+    tps[i].xStat.BgpStat.jobtime = (double)procData.jobTime.tv_sec +
+                                   (double)procData.jobTime.tv_usec / 1000000.0;
+    tms[i].xMem.BgpMemStat.brk = procData.heapBreakAddr;
+    tms[i].xMem.BgpMemStat.heapStart = procData.heapStartAddr;
+    tms[i].xMem.BgpMemStat.sharedMem =
+        procData.sharedMemoryStartAddr - procData.sharedMemoryEndAddr;
+    tms[i].xMem.BgpMemStat.persistentMem =
+        procData.persistMemoryStartAddr - procData.persistMemoryEndAddr;
+    tms[i].xMem.BgpMemStat.mmapMem =
+        procData.mmapStartAddr - procData.mmapEndAddr;
+
+    //
+    // please GET_THREAD_DATA for the main thread
+    //
+    BG_Debugger_Msg threadData(GET_THREAD_DATA, proctab[i].pd.pid, mainTid, 0,
+                               0);
+    threadData.header.dataLength = sizeof(processData.dataArea.GET_THREAD_DATA);
+
+    if (!sendMessage(threadData)) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    if (!receiveMessage(response, GET_THREAD_DATA_ACK,
+                        sizeof(response.dataArea.GET_THREAD_DATA_ACK))) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    memcpy(&mainThrData, &(response.dataArea.GET_THREAD_DATA_ACK.threadData),
+           sizeof(mainThrData));
+
+    if (mainThrData.threadID != mainTid) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    //
+    // get the process state
+    //
+    switch (mainThrData.state) {
+      case Running:
+        tps[i].state = 'R';
+        break;
+      case Sleeping:
+        tps[i].state = 'S';
+        break;
+      case Waiting:
+        tps[i].state = 'W';
+        break;
+      case Zombie:
+        tps[i].state = 'Z';
+        break;
+      case Idle:
+        tps[i].state = 'I';
+        break;
+    }
+
+    tps[i].startStack = mainThrData.stackStartAddr;  //
+    tps[i].stkSp =
+        mainThrData.gprs.gpr[1];          // R01 is the stack pointer register
+    tps[i].stkIp = mainThrData.gprs.iar;  // IAR is instruction pointer
+
+    //
+    // please continue
+    //
+    BG_Debugger_Msg conti(CONTINUE, proctab[i].pd.pid, 0, 0, 0);
+    conti.header.dataLength = sizeof(processData.dataArea.CONTINUE);
+
+    if (!sendMessage(conti)) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
+    if (!receiveMessage(response, CONTINUE_ACK,
+                        sizeof(response.dataArea.CONTINUE_ACK))) {
+      LMON_be_finalize();
+
+      return EXIT_FAILURE;
+    }
+
 #else
-	     << setw(15) << "Not avail yet" //dec << (gatheredTms[i].xMem.LinuxMemStat.brk - gatheredTms[i].xMem.LinuxMemStat.brkstart)
-	     << setw(15) << (double)(gatheredTps[i].xStat.LinuxStat.utime)/100.0 
-	     << setw(15) << (double)(gatheredTps[i].xStat.LinuxStat.stime)/100.0 
-	     << endl;
-#endif
-           free(execname);
-         }
-       }
+    //
+    // Linux specific process snapshot interface
+    //
+    ostringstream ost1, ost2;
+    ifstream ifst;
+    char line[4096];
+    size_t len;
 
-     ofs.close();
+    ost1 << "/proc/" << proctab[i].pd.pid << "/stat";
+
+    // how do you want to check exceptions?
+    ifst.open(ost1.str().c_str(), ios::in);
+
+    tps[i].mpiRank = proctab[i].mpirank;
+
+    ifst >> tps[i].pid >> tps[i].comm >> tps[i].state >>
+        tps[i].xStat.LinuxStat.ppid  // ppid
+        >> tps[i].xStat.LinuxStat.pgid >> tps[i].xStat.LinuxStat.session >>
+        tps[i].xStat.LinuxStat.tty_nr >> tps[i].xStat.LinuxStat.tpgid >>
+        tps[i].xStat.LinuxStat.flags >> tps[i].xStat.LinuxStat.minflt >>
+        tps[i].xStat.LinuxStat.cminflt >> tps[i].xStat.LinuxStat.majflt >>
+        tps[i].xStat.LinuxStat.cmajflt >> tps[i].xStat.LinuxStat.utime >>
+        tps[i].xStat.LinuxStat.stime >> tps[i].xStat.LinuxStat.cutime >>
+        tps[i].xStat.LinuxStat.cstime >> tps[i].xStat.LinuxStat.priority >>
+        tps[i].xStat.LinuxStat.nice >> tps[i].nThread >>
+        tps[i].xStat.LinuxStat.itrealvalue >>
+        tps[i].xStat.LinuxStat.starttime >> tps[i].xStat.LinuxStat.vsize >>
+        tps[i].xStat.LinuxStat.rss >> tps[i].xStat.LinuxStat.rlim >>
+        tps[i].xStat.LinuxStat.startcode >> tps[i].xStat.LinuxStat.endcode >>
+        tps[i].startStack >> tps[i].stkSp >> tps[i].stkIp >>
+        tps[i].xStat.LinuxStat.signal >> tps[i].xStat.LinuxStat.blocked >>
+        tps[i].xStat.LinuxStat.sigignore >> tps[i].xStat.LinuxStat.sigcatch >>
+        tps[i].xStat.LinuxStat.wchan >> tps[i].xStat.LinuxStat.nswap >>
+        tps[i].xStat.LinuxStat.cnswap >> tps[i].xStat.LinuxStat.exit_signal >>
+        tps[i].xStat.LinuxStat.processor >> tps[i].xStat.LinuxStat.rt_prior >>
+        tps[i].xStat.LinuxStat.policy;
+
+    ifst.close();
+
+    ost2 << "/proc/" << proctab[i].pd.pid << "/status";
+
+    // how do you want to check exceptions?
+    ifst.open(ost2.str().c_str(), ios::in);
+
+    while (!ifst.eof()) {
+      ifst.getline(line, 4096);
+      char *tok;
+      char *linebuf = strdup(line);
+      tok = strtok(linebuf, ": \t");
+
+      if (!tok) continue;
+
+      if (strcmp(tok, "VmPeak") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_high_watermark = atoi(tok) * 1024;
+      } else if (strcmp(tok, "VmLck") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_lock_memory = atoi(tok) * 1024;
+      } else if (strcmp(tok, "VmHWM") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.rss_high_watermark = atoi(tok) * 1024;
+      } else if (strcmp(tok, "VmData") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_data = atoi(tok) * 1024;
+      } else if (strcmp(tok, "VmStk") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_stack = atoi(tok) * 1024;
+      } else if (strcmp(tok, "StaBrk") == 0) {
+        tok = strtok(NULL, ": \t");
+        sscanf(tok, "%lx", &(tms[i].xMem.LinuxMemStat.brkstart));
+        tms[i].xMem.LinuxMemStat.brkstart *= 1024;
+      } else if (strcmp(tok, "Brk") == 0) {
+        tok = strtok(NULL, ": \t");
+        sscanf(tok, "%lx", &(tms[i].xMem.LinuxMemStat.brk));
+        tms[i].xMem.LinuxMemStat.brk *= 1024;
+      } else if (strcmp(tok, "VmLib") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_lib = atoi(tok) * 1024;
+      } else if (strcmp(tok, "VmExe") == 0) {
+        tok = strtok(NULL, ": \t");
+        tms[i].xMem.LinuxMemStat.vm_exe = atoi(tok) * 1024;
+      }
+      free(linebuf);
+    }
+
+    ifst.close();
+#endif  // SUB_ARCH_BGP vs LINUX with /proc
+  }     // local proctab loop
+
+  //
+  // fill the potentially remaining elements with the dummy rank
+  //
+  while (i < maxSize) tps[i++].mpiRank = -1;
+
+  if (LMON_be_amIMaster() == LMON_YES) {
+    gatheredTps = (ProcStat *)malloc(be_size * maxSize * sizeof(ProcStat));
+    gatheredTms = (MemStat *)malloc(be_size * maxSize * sizeof(MemStat));
+  }
+
+  lrc = LMON_be_gather((void *)tps, sizeof(ProcStat) * maxSize,
+                       (void *)gatheredTps);
+
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_gather" << endl;
+
+    LMON_be_finalize();
+
+    return EXIT_FAILURE;
+  }
+
+  lrc = LMON_be_gather((void *)tms, sizeof(MemStat) * maxSize,
+                       (void *)gatheredTms);
+
+  if (lrc != LMON_OK) {
+    cerr << "[JOBSNAP BE(" << rank << "): FAILED] LMON_be_gather" << endl;
+
+    LMON_be_finalize();
+
+    return EXIT_FAILURE;
+  }
+
+  if (LMON_be_amIMaster() == LMON_YES) {
+    //
+    // the BE master is responsible for reporting the gathered data
+    //
+    ofstream ofs;
+    char fn[PATH_MAX];
+    time_t now;
+    time(&now);
+    strftime(fn, PATH_MAX, "./jobsnap.out.%Y.%m.%d.%H.%M.%S", localtime(&now));
+
+    ofs.open(fn, ios::out);
 
 #if MEASURE_TRACING_COST
-     time_stamp ( "LMON_be writing jobsnap output to a file" );
+    begin_timer();
+#endif
+
+    ofs << setw(6) << "Rank" << setw(24) << "Execname" << setw(6) << "State"
+        << setw(20) << "InstPtr" << setw(8) << "nThread" << setw(20)
+        << "StartStk" << setw(20) << "StackPtr" << setw(15) << "Brk Size(Byte)"
+        << setw(15) << "Utime (secs)" << setw(15) << "Stime (secs)" << endl;
+
+    for (i = 0; i < be_size * maxSize; ++i) {
+      if (gatheredTps[i].mpiRank != -1) {
+        char bname[24];
+        char *execname = strdup(gatheredTps[i].comm);
+        snprintf(bname, 24, basename(execname));
+        ofs << setw(6) << dec << gatheredTps[i].mpiRank << setw(24) << bname
+            << setw(6) << gatheredTps[i].state << "  Ox" << setfill('0')
+            << setw(16) << hex << gatheredTps[i].stkIp << setfill(' ')
+            << setw(8) << gatheredTps[i].nThread << "  Ox" << setfill('0')
+            << setw(16) << hex << gatheredTps[i].startStack << "  Ox"
+            << setfill('0') << setw(16) << hex << gatheredTps[i].stkSp
+            << setfill(' ')
+#if SUB_ARCH_BGL || SUB_ARCH_BGP
+            << setw(15) << dec << (gatheredTms[i].xMem.BgpMemStat.brk -
+                                   gatheredTms[i].xMem.BgpMemStat.heapStart)
+            << setw(15) << (double)gatheredTps[i].xStat.BgpStat.jobtime
+            << setw(15) << 0.0 << endl;
+#else
+            << setw(15)
+            << "Not avail yet"  // dec << (gatheredTms[i].xMem.LinuxMemStat.brk
+                                // - gatheredTms[i].xMem.LinuxMemStat.brkstart)
+            << setw(15)
+            << (double)(gatheredTps[i].xStat.LinuxStat.utime) / 100.0
+            << setw(15)
+            << (double)(gatheredTps[i].xStat.LinuxStat.stime) / 100.0 << endl;
+#endif
+        free(execname);
+      }
+    }
+
+    ofs.close();
+
+#if MEASURE_TRACING_COST
+    time_stamp("LMON_be writing jobsnap output to a file");
 #endif
   }
 
 #if MEASURE_TRACING_COST
   //
-  // Although be_sendUsrData only affects the master, 
-  // every task should call because it works as a barrier.  
+  // Although be_sendUsrData only affects the master,
+  // every task should call because it works as a barrier.
   //
-  LMON_be_sendUsrData ( NULL );
+  LMON_be_sendUsrData(NULL);
 #endif
 
-  if ( signum != SIGCONT ) {
-      //
-      // this is only to support the regression test case
-      //
+  if (signum != SIGCONT) {
+//
+// this is only to support the regression test case
+//
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
-       for (i=0; i < proctab_size; i++) {
-	  //
-          // please stop so that I can continue with a signal
-          //
-          BG_Debugger_Msg dbgmsg(KILL,proctab[i].pd.pid,0,0,0);
-          dbgmsg.dataArea.KILL.signal = SIGSTOP;
-          dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
-          BG_Debugger_Msg ackmsg;
-          BG_Debugger_Msg ackmsg2;
+    for (i = 0; i < proctab_size; i++) {
+      //
+      // please stop so that I can continue with a signal
+      //
+      BG_Debugger_Msg dbgmsg(KILL, proctab[i].pd.pid, 0, 0, 0);
+      dbgmsg.dataArea.KILL.signal = SIGSTOP;
+      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.KILL);
+      BG_Debugger_Msg ackmsg;
+      BG_Debugger_Msg ackmsg2;
 
-	  if(! sendMessage(dbgmsg)) {
-            LMON_be_finalize();
+      if (!sendMessage(dbgmsg)) {
+        LMON_be_finalize();
 
-            return EXIT_FAILURE;
-          }
-
-	  if (!receiveMessage(ackmsg, KILL_ACK, sizeof(ackmsg.dataArea.KILL_ACK))) {
-            LMON_be_finalize();
-
-            return EXIT_FAILURE;
-          }
- 
-	  if (!receiveMessage(ackmsg2, SIGNAL_ENCOUNTERED, sizeof(ackmsg2.dataArea.SIGNAL_ENCOUNTERED))) {
-            LMON_be_finalize();
-
-            return EXIT_FAILURE;
-	  }
+        return EXIT_FAILURE;
       }
 
-      for (i=0; i < proctab_size; i++) {
-	  //
-          // please continue with a signal
-          //
-          BG_Debugger_Msg dbgmsg(CONTINUE,proctab[i].pd.pid,0,0,0);
-          BG_Debugger_Msg ackmsg;
-          dbgmsg.dataArea.CONTINUE.signal = signum;
-          dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.CONTINUE);
+      if (!receiveMessage(ackmsg, KILL_ACK, sizeof(ackmsg.dataArea.KILL_ACK))) {
+        LMON_be_finalize();
 
-	  if(! sendMessage(dbgmsg)) {
-            LMON_be_finalize();
-            return EXIT_FAILURE;
-          }
-
-	  if (!receiveMessage(ackmsg, CONTINUE_ACK, sizeof(ackmsg.dataArea.CONTINUE_ACK))) {
-            LMON_be_finalize();
-            return EXIT_FAILURE;
-          }
+        return EXIT_FAILURE;
       }
+
+      if (!receiveMessage(ackmsg2, SIGNAL_ENCOUNTERED,
+                          sizeof(ackmsg2.dataArea.SIGNAL_ENCOUNTERED))) {
+        LMON_be_finalize();
+
+        return EXIT_FAILURE;
+      }
+    }
+
+    for (i = 0; i < proctab_size; i++) {
+      //
+      // please continue with a signal
+      //
+      BG_Debugger_Msg dbgmsg(CONTINUE, proctab[i].pd.pid, 0, 0, 0);
+      BG_Debugger_Msg ackmsg;
+      dbgmsg.dataArea.CONTINUE.signal = signum;
+      dbgmsg.header.dataLength = sizeof(dbgmsg.dataArea.CONTINUE);
+
+      if (!sendMessage(dbgmsg)) {
+        LMON_be_finalize();
+        return EXIT_FAILURE;
+      }
+
+      if (!receiveMessage(ackmsg, CONTINUE_ACK,
+                          sizeof(ackmsg.dataArea.CONTINUE_ACK))) {
+        LMON_be_finalize();
+        return EXIT_FAILURE;
+      }
+    }
 #else
 
-      for(i=0; i < proctab_size; i++) {
-	  kill(proctab[i].pd.pid, signum);
-      }
+    for (i = 0; i < proctab_size; i++) {
+      kill(proctab[i].pd.pid, signum);
+    }
 #endif
   }
 
-  if (proctab) 
-    free (proctab);
+  if (proctab) free(proctab);
 
-  if (tps)
-    free (tps);
+  if (tps) free(tps);
 
-  if (tms)
-    free (tms);
+  if (tms) free(tms);
 
-  if ( LMON_be_amIMaster () == LMON_YES ) {
-    if (gatheredTps)
-      free (gatheredTps);
-    if (gatheredTms)
-      free (gatheredTms);
+  if (LMON_be_amIMaster() == LMON_YES) {
+    if (gatheredTps) free(gatheredTps);
+    if (gatheredTms) free(gatheredTms);
   }
 
   LMON_be_finalize();
@@ -907,3 +839,6 @@ main(int argc, char *argv[])
   return EXIT_SUCCESS;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/be_kicker.cxx
+++ b/test/src/be_kicker.cxx
@@ -1,39 +1,40 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
  *        Jun 12 2008 DHA: Added GNU build support.
  *        Mar 20 2008 DHA: Added BlueGene support.
  *        Feb 09 2008 DHA: Dynamic RPDTAB buff size support with the
- *                         addition of LMON_be_getMyProctabSize. 
+ *                         addition of LMON_be_getMyProctabSize.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Jul 30 2007 DHA: Adjust this case for minor API changes. 
- *        Dec 20 2006 DHA: Created file.          
+ *        Jul 30 2007 DHA: Adjust this case for minor API changes.
+ *        Dec 20 2006 DHA: Created file.
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -42,19 +43,19 @@
 
 #include <lmon_api/common.h>
 
-#include <unistd.h>
-#include <iostream>
+#include <lmon_api/lmon_be.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <lmon_api/lmon_be.h>
-#include "lmon_daemon_internal.hxx"
+#include <unistd.h>
+#include <iostream>
 #include "lmon_be_sync_mpi.hxx"
+#include "lmon_daemon_internal.hxx"
 
 enum be_subtest_e {
   subtest_no = 0,
   subtest_kill_detach_shutdown,
-  subtest_mw_coloc, 
+  subtest_mw_coloc,
   subtest_fail_mode,
   subtest_reserved
 };
@@ -68,223 +69,178 @@ const unsigned int fail_mode_test_time = 180;
  * Usage: be_kicker signumber waittime
  *
  * argv[1]: specify if a non-continue-signal should be delivered to the job
- * argv[2]: specify the number of seconds this daemon must wait before exit 
+ * argv[2]: specify the number of seconds this daemon must wait before exit
  *
  */
 
-int 
-main( int argc, char* argv[] )
-{
+int main(int argc, char* argv[]) {
   MPIR_PROCDESC_EXT* proctab;
   int proctab_size;
   int signum;
-  be_subtest_e subtest = subtest_no; 
-  int i, rank,size;
+  be_subtest_e subtest = subtest_no;
+  int i, rank, size;
   lmon_rc_e lrc;
 
   signum = SIGCONT;
 
-  if ( (lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) 
-              != LMON_OK )
-    {      
-      fprintf(stdout, 
-        "[LMON BE] FAILED: LMON_be_init\n");
+  if ((lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE] FAILED: LMON_be_init\n");
+    return EXIT_FAILURE;
+  }
+
+  if (argc > 1) {
+    signum = atoi(argv[1]);
+    printf("[LMON BE] signum: %d, argv[1]: %s argc(%d)\n", signum, argv[1],
+           argc);
+  }
+
+  if (argc > 2) {
+    subtest = (be_subtest_e)atoi(argv[2]);
+    printf("[LMON BE] subtest: %d, argv[2]: %s\n", subtest, argv[2]);
+    if (subtest >= subtest_reserved) {
+      printf("[LMON BE] Unknown subtest. Existing...\n");
+      LMON_be_finalize();
       return EXIT_FAILURE;
     }
-
-  if (argc > 1) 
-    {
-      signum = atoi(argv[1]);
-      printf ("[LMON BE] signum: %d, argv[1]: %s argc(%d)\n", signum, argv[1], argc);
-    }
-
-  if ( argc > 2 )
-    {
-      subtest = (be_subtest_e) atoi(argv[2]);
-      printf ("[LMON BE] subtest: %d, argv[2]: %s\n", subtest, argv[2]);
-      if (subtest >= subtest_reserved) {
-         printf ("[LMON BE] Unknown subtest. Existing...\n");
-         LMON_be_finalize();
-         return EXIT_FAILURE;
-      }
-    } 
+  }
 
   LMON_be_getMyRank(&rank);
   LMON_be_getSize(&size);
 
-  if ( (lrc = LMON_be_handshake(NULL)) 
-              != LMON_OK )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_handshake\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_handshake(NULL)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_handshake\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  if ( (lrc = LMON_be_ready(NULL)) 
-              != LMON_OK )
-    {     
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_ready\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    } 
+  if ((lrc = LMON_be_ready(NULL)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_ready\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   //
   // This routine should only be used by test cases like this
   //
-  if ( (lrc = LMON_be_tester_init ( ) ) 
-              != LMON_OK )
-    {      
-      fprintf(stdout, 
-        "[LMON BE] FAILED: LMON_be_tester_init\n");
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_tester_init()) != LMON_OK) {
+    fprintf(stdout, "[LMON BE] FAILED: LMON_be_tester_init\n");
+    return EXIT_FAILURE;
+  }
 
-  if ( (lrc = LMON_be_getMyProctabSize(&proctab_size)) != LMON_OK ) 
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;	
-    }
-  
-  proctab = (MPIR_PROCDESC_EXT *) 
-           malloc (proctab_size*sizeof(MPIR_PROCDESC_EXT));
-  if ( proctab == NULL ) 
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: malloc returned null\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
- 
-  if ( (lrc = LMON_be_getMyProctab (proctab, 
-                &proctab_size, proctab_size)) != LMON_OK )
-    {    
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_getMyProctab\n", 
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_getMyProctabSize(&proctab_size)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  for(i=0; i < proctab_size; i++)
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", 
-        rank,
-        proctab[i].pd.pid, 
-        proctab[i].mpirank);
-    }
+  proctab =
+      (MPIR_PROCDESC_EXT*)malloc(proctab_size * sizeof(MPIR_PROCDESC_EXT));
+  if (proctab == NULL) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: malloc returned null\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_getMyProctab(proctab, &proctab_size, proctab_size)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_getMyProctab\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  for (i = 0; i < proctab_size; i++) {
+    fprintf(stdout, "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", rank,
+            proctab[i].pd.pid, proctab[i].mpirank);
+  }
 
   //
   // This routine should only be used by test cases like this
   //
-  per_be_data_t *myBeData = NULL;
-  if ( (lrc = LMON_daemon_internal_tester_getBeData (&myBeData)) 
-              != LMON_OK )
-    {
-      fprintf(stdout, 
+  per_be_data_t* myBeData = NULL;
+  if ((lrc = LMON_daemon_internal_tester_getBeData(&myBeData)) != LMON_OK) {
+    fprintf(
+        stdout,
         "[LMON BE(%d)] FAILED: LMON_be_internal_getBeDat returned an error\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+        rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   //
   // Unless LMON_DONT_STOP_APP condition is met
   // LMON_be_procctl_init will leave the job stopped
   //
-  int fastpath_state = 2; //inherit the state
+  int fastpath_state = 2;  // inherit the state
 
-  if ( signum != SIGCONT)
-    {
-      fastpath_state = 0;
-    }
+  if (signum != SIGCONT) {
+    fastpath_state = 0;
+  }
 
-  LMON_be_procctl_tester_init ( myBeData->rmtype_instance,
-                         proctab, 0, proctab_size, 
-                         fastpath_state );
+  LMON_be_procctl_tester_init(myBeData->rmtype_instance, proctab, 0,
+                              proctab_size, fastpath_state);
 
-  LMON_be_procctl_run ( myBeData->rmtype_instance,
-                        signum,
-                        proctab, proctab_size);
+  LMON_be_procctl_run(myBeData->rmtype_instance, signum, proctab, proctab_size);
 
   sleep(1);
 
-  switch (subtest)
-    {
+  switch (subtest) {
     case subtest_kill_detach_shutdown:
-      sleep (kill_detach_shutdown_time);
+      sleep(kill_detach_shutdown_time);
       break;
 
     case subtest_fail_mode:
-      sleep (fail_mode_test_time);
+      sleep(fail_mode_test_time);
       break;
 
-    case subtest_mw_coloc:
-      {
-        //
-        // MW daemon co-location support
-        //
-        if (LMON_be_assist_mw_coloc() != LMON_OK)
-          {
-            fprintf(stdout,
-              "[LMON BE(%d)] FAILED: LMON_be_assist_mw_coloc failed \n", rank);
-            LMON_be_finalize();
-            return EXIT_FAILURE;
-          }
-
-         break;
+    case subtest_mw_coloc: {
+      //
+      // MW daemon co-location support
+      //
+      if (LMON_be_assist_mw_coloc() != LMON_OK) {
+        fprintf(stdout,
+                "[LMON BE(%d)] FAILED: LMON_be_assist_mw_coloc failed \n",
+                rank);
+        LMON_be_finalize();
+        return EXIT_FAILURE;
       }
+
+      break;
+    }
     default:
-        break;
-    }
+      break;
+  }
 
-  for (i=0; i < proctab_size; i++)
-    {
-      if (proctab[i].pd.executable_name)
-        free(proctab[i].pd.executable_name);
-      if (proctab[i].pd.host_name)
-        free(proctab[i].pd.host_name);
-    }
-  free (proctab);
+  for (i = 0; i < proctab_size; i++) {
+    if (proctab[i].pd.executable_name) free(proctab[i].pd.executable_name);
+    if (proctab[i].pd.host_name) free(proctab[i].pd.host_name);
+  }
+  free(proctab);
 
-  // sending this to mark the end of the BE session 
-  // This should be used to determine PASS/FAIL criteria 
-  if ( (( lrc = LMON_be_sendUsrData ( NULL )) == LMON_EBDARG)
-       || ( lrc == LMON_EINVAL ) 
-       || ( lrc == LMON_ENOMEM )
-       || ( lrc == LMON_ENEGCB )) 
-     {
-       fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n",
-               rank, lrc );
-       LMON_be_finalize();
-       return EXIT_FAILURE;
-     }
+  // sending this to mark the end of the BE session
+  // This should be used to determine PASS/FAIL criteria
+  if (((lrc = LMON_be_sendUsrData(NULL)) == LMON_EBDARG) ||
+      (lrc == LMON_EINVAL) || (lrc == LMON_ENOMEM) || (lrc == LMON_ENEGCB)) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n", rank,
+            lrc);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   //
   // recving an ack back
-  if ( (( lrc = LMON_be_recvUsrData ( NULL )) == LMON_EBDARG)
-       || ( lrc == LMON_EINVAL )
-       || ( lrc == LMON_ENOMEM )
-       || ( lrc == LMON_ENEGCB ))
-     {
-       fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_recvUsrData\n",
-               rank, lrc );
-       LMON_be_finalize();
-       return EXIT_FAILURE;
-     }
-
-
+  if (((lrc = LMON_be_recvUsrData(NULL)) == LMON_EBDARG) ||
+      (lrc == LMON_EINVAL) || (lrc == LMON_ENOMEM) || (lrc == LMON_ENEGCB)) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_recvUsrData\n", rank,
+            lrc);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   LMON_be_finalize();
 
   return EXIT_SUCCESS;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/be_kicker_usrpayload_test.cxx
+++ b/test/src/be_kicker_usrpayload_test.cxx
@@ -1,36 +1,37 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
  *        Jun 12 2008 DHA: Added GNU build system support
  *        Feb 09 2008 DHA: Added LLNS Copyright.
  *        Aug 06 2007 DHA: Created file.
- *          
+ *
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -38,136 +39,106 @@
 #endif
 
 #include <lmon_api/common.h>
-#include <unistd.h>
-#include <iostream>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
+#include <iostream>
 
 #include <map>
 
 #include <lmon_api/lmon_be.h>
-#include "lmon_daemon_internal.hxx"
 #include "lmon_be_sync_mpi.hxx"
-
+#include "lmon_daemon_internal.hxx"
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
-# include "debugger_interface.h"
-  using namespace DebuggerInterface;
+#include "debugger_interface.h"
+using namespace DebuggerInterface;
 #endif
 
-std::map<std::string, int> usrdata;  // this will have "hostname," "port" pair  
-std::map<std::string, int> recvdata; // this will have "hostname," "port" pair echoed back from BE
+std::map<std::string, int> usrdata;  // this will have "hostname," "port" pair
+std::map<std::string, int>
+    recvdata;  // this will have "hostname," "port" pair echoed back from BE
 
-
-static int 
-fill_usrdata ( )
-{
+static int fill_usrdata() {
   using namespace std;
 
   int i;
-  
+
   //
-  // 128 is an arbitrary number; i.e. emulating 
+  // 128 is an arbitrary number; i.e. emulating
   // 128 ip/port pair vector
   //
-  for ( i=0; i < 128; ++i )
-    {
-      char hnconcat[128];
+  for (i = 0; i < 128; ++i) {
+    char hnconcat[128];
 
-      if ( i < 0 )
-        break;
+    if (i < 0) break;
 
-      if ( i < 10 )
-        {
-          sprintf ( hnconcat, 
-            "BEIP00%d.llnl.gov", i); // faking a hostname 
-        }
-      else if ( i < 100 )
-        {
-          sprintf ( hnconcat, 
-            "BEIP0%d.llnl.gov", i); // faking a hostname
-        }
-      else if ( i < 1000 )
-        {
-          sprintf ( hnconcat, 
-            "BEIP%d.llnl.gov", i);  // faking a hostname
-        }
-
-      usrdata[string(hnconcat)] = i+1024; // faking a port 
+    if (i < 10) {
+      sprintf(hnconcat, "BEIP00%d.llnl.gov", i);  // faking a hostname
+    } else if (i < 100) {
+      sprintf(hnconcat, "BEIP0%d.llnl.gov", i);  // faking a hostname
+    } else if (i < 1000) {
+      sprintf(hnconcat, "BEIP%d.llnl.gov", i);  // faking a hostname
     }
+
+    usrdata[string(hnconcat)] = i + 1024;  // faking a port
+  }
 
   return 0;
 }
 
-
-static int 
-packbefe_cb ( void* udata, 
-              void* msgbuf, 
-              int msgbufmax, 
-              int* msgbuflen )
-{
+static int packbefe_cb(void* udata, void* msgbuf, int msgbufmax,
+                       int* msgbuflen) {
   using namespace std;
-  
-  map<string, int>* u = ( map<string, int>* ) udata; 
-  map<string, int>& myudata =  *u;
-  map<string, int>::const_iterator iter; 
-  char* trav  = (char*) msgbuf;
+
+  map<string, int>* u = (map<string, int>*)udata;
+  map<string, int>& myudata = *u;
+  map<string, int>::const_iterator iter;
+  char* trav = (char*)msgbuf;
   int usedbuf = 0;
   int trun = 0;
 
-  if ( ( msgbuf == NULL ) || ( msgbufmax < 0) )
-    return -1; 
+  if ((msgbuf == NULL) || (msgbufmax < 0)) return -1;
 
-  for ( iter = myudata.begin(); iter != myudata.end(); iter++)
-    {
-      int accum_len = usedbuf + iter->first.size() + + sizeof(int);
-      if ( accum_len > msgbufmax )
-        {
-          trun = 1; 
-          break;
-        } 
-
-      memcpy ( (void*) trav, iter->first.c_str(), iter->first.size()+1); 
-      trav += iter->first.size()+1; 
-      memcpy ( (void*) trav, (void*) &(iter->second), sizeof (int) );
-      trav += sizeof (int); 
-      usedbuf += iter->first.size()+1+sizeof (int);
+  for (iter = myudata.begin(); iter != myudata.end(); iter++) {
+    int accum_len = usedbuf + iter->first.size() + +sizeof(int);
+    if (accum_len > msgbufmax) {
+      trun = 1;
+      break;
     }
 
-   (*msgbuflen) = usedbuf;
+    memcpy((void*)trav, iter->first.c_str(), iter->first.size() + 1);
+    trav += iter->first.size() + 1;
+    memcpy((void*)trav, (void*)&(iter->second), sizeof(int));
+    trav += sizeof(int);
+    usedbuf += iter->first.size() + 1 + sizeof(int);
+  }
 
-   return ((trun == 0) ? 0 : -1);
+  (*msgbuflen) = usedbuf;
+
+  return ((trun == 0) ? 0 : -1);
 }
 
-
-static int
-unpackfebe_cb  ( void* udatabuf, 
-		 int udatabuflen, 
-		 void* udata )
-{
+static int unpackfebe_cb(void* udatabuf, int udatabuflen, void* udata) {
   using namespace std;
 
-  map<string, int>* u = ( map<string, int>* ) udata; 
+  map<string, int>* u = (map<string, int>*)udata;
   map<string, int>& myudata = *u;
-  char* trav = (char*) udatabuf;
+  char* trav = (char*)udatabuf;
   int usedbuf = 0;
 
-  while ( usedbuf < udatabuflen )
-    {
-      myudata[string(trav)] = (int) *(trav+strlen(trav)+1);
-      usedbuf += strlen(trav)+1+sizeof(int);
-      trav += strlen(trav)+1+sizeof(int);
-    }
-  
-  return 0;    
+  while (usedbuf < udatabuflen) {
+    myudata[string(trav)] = (int)*(trav + strlen(trav) + 1);
+    usedbuf += strlen(trav) + 1 + sizeof(int);
+    trav += strlen(trav) + 1 + sizeof(int);
+  }
+
+  return 0;
 }
 
-
-int 
-main( int argc, char* argv[] )
-{
-  MPIR_PROCDESC_EXT *proctab;
+int main(int argc, char* argv[]) {
+  MPIR_PROCDESC_EXT* proctab;
   int proctab_size;
   int signum;
   int i, rank, size;
@@ -175,185 +146,131 @@ main( int argc, char* argv[] )
 
   signum = SIGCONT;
 
-  if ( (lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) 
-              != LMON_OK )
-    {      
-      fprintf(stdout, 
-        "[LMON BE: FAILED] LMON_be_init\n");
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE: FAILED] LMON_be_init\n");
+    return EXIT_FAILURE;
+  }
 
-  if (argc > 1) 
-     signum = atoi(argv[1]);
+  if (argc > 1) signum = atoi(argv[1]);
 
-  fill_usrdata ();
+  fill_usrdata();
 
-  LMON_be_getMyRank (&rank);
-  LMON_be_getSize (&size);
+  LMON_be_getMyRank(&rank);
+  LMON_be_getSize(&size);
 
-  if ( ( lrc = LMON_be_regPackForBeToFe (packbefe_cb ))  
-              != LMON_OK )
-    {
-      fprintf (stdout,
-	"[LMON BE(%d)] LMON_be_regPackForBeToFe FAILED\n", 
-        rank);
-      return EXIT_FAILURE;
-    } 
+  if ((lrc = LMON_be_regPackForBeToFe(packbefe_cb)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] LMON_be_regPackForBeToFe FAILED\n", rank);
+    return EXIT_FAILURE;
+  }
 
-  if ( ( lrc = LMON_be_regUnpackForFeToBe (  
-                unpackfebe_cb ))  
-              != LMON_OK )
-    {
-       fprintf (stdout,
-        "[LMON BE(%d)] LMON_be_regUnpackForFeToBe FAILED\n",
-        rank);
-       return EXIT_FAILURE;
-    } 
+  if ((lrc = LMON_be_regUnpackForFeToBe(unpackfebe_cb)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] LMON_be_regUnpackForFeToBe FAILED\n", rank);
+    return EXIT_FAILURE;
+  }
 
-  if ( (lrc = LMON_be_handshake((void*) &recvdata) ) 
-              != LMON_OK )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d): FAILED] LMON_be_handshake\n",
-        rank );
+  if ((lrc = LMON_be_handshake((void*)&recvdata)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d): FAILED] LMON_be_handshake\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_ready((void*)&usrdata)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d): FAILED] LMON_be_ready\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_tester_init()) != LMON_OK) {
+    fprintf(stdout, "[LMON BE] FAILED: LMON_be_tester_init\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_getMyProctabSize(&proctab_size)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  proctab =
+      (MPIR_PROCDESC_EXT*)malloc(proctab_size * sizeof(MPIR_PROCDESC_EXT));
+  if (proctab == NULL) {
+    fprintf(stdout, "[LMON BE(%d): FAILED] malloc return null\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_getMyProctab(proctab, &proctab_size, proctab_size)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d): FAILED] LMON_be_getMyProctab\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if (LMON_be_amIMaster() == LMON_YES) {
+    if ((lrc = LMON_be_recvUsrData((void*)&recvdata)) != LMON_OK) {
+      fprintf(stdout, "[LMON BE(%d): FAILED] LMON_be_recvUsrData\n", rank);
+
       LMON_be_finalize();
+
       return EXIT_FAILURE;
     }
 
-  if ( (lrc = LMON_be_ready((void*) &usrdata)) 
-              != LMON_OK )
-    {     
-      fprintf(stdout, 
-        "[LMON BE(%d): FAILED] LMON_be_ready\n",
-        rank);
+    if ((lrc = LMON_be_sendUsrData((void*)&usrdata)) != LMON_OK) {
+      fprintf(stdout, "[LMON BE(%d): FAILED] LMON_be_sendUsrData\n", rank);
+
       LMON_be_finalize();
-      return EXIT_FAILURE;
-    } 
 
-
-  if ( (lrc = LMON_be_tester_init ( ) )
-              != LMON_OK )
-    {
-      fprintf(stdout,
-        "[LMON BE] FAILED: LMON_be_tester_init\n");
       return EXIT_FAILURE;
     }
+  }
 
-    if ( (lrc = LMON_be_getMyProctabSize(&proctab_size)) 
-                != LMON_OK )
-    {
-      fprintf(stdout,
-        "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n",
-        rank);
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+  for (i = 0; i < proctab_size; i++) {
+    fprintf(stdout, "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", rank,
+            proctab[i].pd.pid, proctab[i].mpirank);
+  }
 
-  proctab = (MPIR_PROCDESC_EXT *) 
-            malloc (proctab_size*sizeof(MPIR_PROCDESC_EXT));
-  if ( proctab == NULL )
-    {
-      fprintf (stdout, 
-               "[LMON BE(%d): FAILED] malloc return null\n",
-               rank);
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
-
-  if ( (lrc = LMON_be_getMyProctab(proctab, &proctab_size, proctab_size)) 
-              != LMON_OK )
-    {    
-      fprintf(stdout, 
-        "[LMON BE(%d): FAILED] LMON_be_getMyProctab\n", 
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
-
-  if ( LMON_be_amIMaster() == LMON_YES )
-    {
-      if ( ( lrc = LMON_be_recvUsrData ( (void*) &recvdata )) 
-                   != LMON_OK ) 
-        {
-          fprintf(stdout, 
-            "[LMON BE(%d): FAILED] LMON_be_recvUsrData\n",
-            rank );
-
-          LMON_be_finalize();
-
-          return EXIT_FAILURE;
-        }
-
-      if ( ( lrc = LMON_be_sendUsrData ( (void*) &usrdata )) 
-                   != LMON_OK ) 
-        {
-          fprintf(stdout, 
-            "[LMON BE(%d): FAILED] LMON_be_sendUsrData\n",
-            rank );
-
-          LMON_be_finalize();
-
-          return EXIT_FAILURE;
-        }
-    }
- 
-  for(i=0; i < proctab_size; i++)
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", 
-        rank,
-        proctab[i].pd.pid, 
-        proctab[i].mpirank);
-    }
-
-  per_be_data_t *myBeData = NULL;
-  if ( (lrc = LMON_daemon_internal_tester_getBeData (&myBeData))
-              != LMON_OK )
-    {
-      fprintf(stdout,
+  per_be_data_t* myBeData = NULL;
+  if ((lrc = LMON_daemon_internal_tester_getBeData(&myBeData)) != LMON_OK) {
+    fprintf(
+        stdout,
         "[LMON BE(%d)] FAILED: LMON_be_internal_getBeDat returned an error\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    } 
+        rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  int fastpath_state = 2; //inherit the state
+  int fastpath_state = 2;  // inherit the state
 
-  if ( signum != SIGCONT)
-    {
-      fastpath_state = 0;
-    }
+  if (signum != SIGCONT) {
+    fastpath_state = 0;
+  }
 
-  LMON_be_procctl_tester_init ( myBeData->rmtype_instance,
-                         proctab, 0, proctab_size, 
-                         fastpath_state );
+  LMON_be_procctl_tester_init(myBeData->rmtype_instance, proctab, 0,
+                              proctab_size, fastpath_state);
 
-  LMON_be_procctl_run ( myBeData->rmtype_instance,
-                        signum,
-                        proctab, proctab_size);
+  LMON_be_procctl_run(myBeData->rmtype_instance, signum, proctab, proctab_size);
 
-  for (i=0; i < proctab_size; i++)
-    {
-      if (proctab[i].pd.executable_name)
-        free(proctab[i].pd.executable_name);
-      if (proctab[i].pd.host_name)
-        free(proctab[i].pd.host_name);
-    }
-  free (proctab);
+  for (i = 0; i < proctab_size; i++) {
+    if (proctab[i].pd.executable_name) free(proctab[i].pd.executable_name);
+    if (proctab[i].pd.host_name) free(proctab[i].pd.host_name);
+  }
+  free(proctab);
 
   /* sending this to mark the end of the BE session */
   /* This should be used to determine PASS/FAIL criteria */
-  if ( (( lrc = LMON_be_sendUsrData ( NULL )) == LMON_EBDARG)
-       || ( lrc == LMON_EINVAL )
-       || ( lrc == LMON_ENOMEM ))
-     {
-       fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n",
-               rank, lrc );
-       LMON_be_finalize();
-       return EXIT_FAILURE;
-     }
+  if (((lrc = LMON_be_sendUsrData(NULL)) == LMON_EBDARG) ||
+      (lrc == LMON_EINVAL) || (lrc == LMON_ENOMEM)) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n", rank,
+            lrc);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   LMON_be_finalize();
 
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/be_mem_fetcher.cxx
+++ b/test/src/be_mem_fetcher.cxx
@@ -1,39 +1,40 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
  *        Jun 12 2008 DHA: Added GNU build support.
  *        Mar 20 2008 DHA: Added BlueGene support.
  *        Feb 09 2008 DHA: Dynamic RPDTAB buff size support with the
- *                         addition of LMON_be_getMyProctabSize. 
+ *                         addition of LMON_be_getMyProctabSize.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Jul 30 2007 DHA: Adjust this case for minor API changes. 
- *        Dec 20 2006 DHA: Created file.          
+ *        Jul 30 2007 DHA: Adjust this case for minor API changes.
+ *        Dec 20 2006 DHA: Created file.
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -42,15 +43,14 @@
 
 #include <lmon_api/common.h>
 
-#include <unistd.h>
-#include <iostream>
+#include <lmon_api/lmon_be.h>
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <lmon_api/lmon_be.h>
-#include "lmon_daemon_internal.hxx"
+#include <unistd.h>
+#include <iostream>
 #include "lmon_be_sync_mpi.hxx"
-
+#include "lmon_daemon_internal.hxx"
 
 /*
  * Multipurpose kicker daemon
@@ -58,177 +58,138 @@
  * Usage: be_kicker signumber waittime
  *
  * argv[1]: specify if a non-continue-signal should be delivered to the job
- * argv[2]: specify the number of seconds this daemon must wait before exit 
+ * argv[2]: specify the number of seconds this daemon must wait before exit
  *
  */
 
-int 
-main( int argc, char* argv[] )
-{
+int main(int argc, char* argv[]) {
   MPIR_PROCDESC_EXT* proctab;
   int proctab_size;
   int signum;
-  int kill_detach_shutdown_test; 
-  int i, rank,size;
+  int kill_detach_shutdown_test;
+  int i, rank, size;
   lmon_rc_e lrc;
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
   signum = 0;
 #else
   signum = SIGCONT;
-#endif 
+#endif
 
   kill_detach_shutdown_test = 0;
 
-  if ( (lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) 
-              != LMON_OK )
-    {      
-      fprintf(stdout, 
-        "[LMON BE] FAILED: LMON_be_init\n");
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_init(LMON_VERSION, &argc, &argv)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE] FAILED: LMON_be_init\n");
+    return EXIT_FAILURE;
+  }
 
-  if (argc > 1) 
-    {
-      signum = atoi(argv[1]);
-      printf ("[LMON BE] signum: %d, argv[1]: %s\n", signum, argv[1]);
-    }
+  if (argc > 1) {
+    signum = atoi(argv[1]);
+    printf("[LMON BE] signum: %d, argv[1]: %s\n", signum, argv[1]);
+  }
 
-  if ( argc > 2 )
-    {
-      kill_detach_shutdown_test = atoi(argv[2]);
-    } 
+  if (argc > 2) {
+    kill_detach_shutdown_test = atoi(argv[2]);
+  }
 
   LMON_be_getMyRank(&rank);
   LMON_be_getSize(&size);
 
-  if ( (lrc = LMON_be_handshake(NULL)) 
-              != LMON_OK )
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_handshake\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_handshake(NULL)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_handshake\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  if ( (lrc = LMON_be_ready(NULL)) 
-              != LMON_OK )
-    {     
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_ready\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    } 
+  if ((lrc = LMON_be_ready(NULL)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_ready\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   //
   // This routine should only be used by test cases like this
   //
-  if ( (lrc = LMON_be_tester_init ( ) ) 
-              != LMON_OK )
-    {      
-      fprintf(stdout, 
-        "[LMON BE] FAILED: LMON_be_tester_init\n");
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_tester_init()) != LMON_OK) {
+    fprintf(stdout, "[LMON BE] FAILED: LMON_be_tester_init\n");
+    return EXIT_FAILURE;
+  }
 
-  if ( (lrc = LMON_be_getMyProctabSize(&proctab_size)) != LMON_OK ) 
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;	
-    }
-  
-  proctab = (MPIR_PROCDESC_EXT *) 
-           malloc (proctab_size*sizeof(MPIR_PROCDESC_EXT));
-  if ( proctab == NULL ) 
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: malloc returned null\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
- 
-  if ( (lrc = LMON_be_getMyProctab (proctab, &proctab_size, proctab_size)) 
-              != LMON_OK )
-    {    
-      fprintf(stdout, 
-        "[LMON BE(%d)] FAILED: LMON_be_getMyProctab\n", 
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+  if ((lrc = LMON_be_getMyProctabSize(&proctab_size)) != LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_getMyProctabSize\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  for(i=0; i < proctab_size; i++)
-    {
-      fprintf(stdout, 
-        "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", 
-        rank,
-        proctab[i].pd.pid, 
-        proctab[i].mpirank);
-    }
+  proctab =
+      (MPIR_PROCDESC_EXT*)malloc(proctab_size * sizeof(MPIR_PROCDESC_EXT));
+  if (proctab == NULL) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: malloc returned null\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  if ((lrc = LMON_be_getMyProctab(proctab, &proctab_size, proctab_size)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED: LMON_be_getMyProctab\n", rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
+
+  for (i = 0; i < proctab_size; i++) {
+    fprintf(stdout, "[LMON BE(%d)] Target process: %8d, MPI RANK: %5d\n", rank,
+            proctab[i].pd.pid, proctab[i].mpirank);
+  }
 
   //
   // This routine should only be used by test cases like this
   //
-  per_be_data_t *myBeData = NULL;
-  if ( (lrc = LMON_daemon_internal_tester_getBeData (&myBeData)) != LMON_OK )
-    {
-      fprintf(stdout, 
+  per_be_data_t* myBeData = NULL;
+  if ((lrc = LMON_daemon_internal_tester_getBeData(&myBeData)) != LMON_OK) {
+    fprintf(
+        stdout,
         "[LMON BE(%d)] FAILED: LMON_be_internal_getBeDat returned an error\n",
-        rank );
-      LMON_be_finalize();
-      return EXIT_FAILURE;
-    }
+        rank);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
-  LMON_be_procctl_tester_init ( myBeData->rmtype_instance,
-                         proctab, 0, proctab_size, 1);
+  LMON_be_procctl_tester_init(myBeData->rmtype_instance, proctab, 0,
+                              proctab_size, 1);
 
   unsigned int fetchunit;
   unsigned int usecperunit;
-  
-  LMON_be_procctl_perf ( myBeData->rmtype_instance,
-                         proctab, proctab_size, 
-                         0x00000000015b4668, 409600,
-                         &fetchunit, &usecperunit);
 
-  LMON_be_procctl_run ( myBeData->rmtype_instance,
-                        signum,
-                        proctab, proctab_size);
+  LMON_be_procctl_perf(myBeData->rmtype_instance, proctab, proctab_size,
+                       0x00000000015b4668, 409600, &fetchunit, &usecperunit);
+
+  LMON_be_procctl_run(myBeData->rmtype_instance, signum, proctab, proctab_size);
 
   sleep(1);
 
-  if ( kill_detach_shutdown_test != 0)
-    sleep (kill_detach_shutdown_test);
+  if (kill_detach_shutdown_test != 0) sleep(kill_detach_shutdown_test);
 
-  for (i=0; i < proctab_size; i++)
-    {
-      if (proctab[i].pd.executable_name)
-        free(proctab[i].pd.executable_name);
-      if (proctab[i].pd.host_name)
-        free(proctab[i].pd.host_name);
-    }
-  free (proctab);
+  for (i = 0; i < proctab_size; i++) {
+    if (proctab[i].pd.executable_name) free(proctab[i].pd.executable_name);
+    if (proctab[i].pd.host_name) free(proctab[i].pd.host_name);
+  }
+  free(proctab);
 
-  // sending this to mark the end of the BE session 
-  // This should be used to determine PASS/FAIL criteria 
-  if ( (( lrc = LMON_be_sendUsrData ( NULL )) == LMON_EBDARG)
-       || ( lrc == LMON_EINVAL ) 
-       || ( lrc == LMON_ENOMEM )
-       || ( lrc == LMON_ENEGCB )) 
-     {
-       fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n",
-               rank, lrc );
-       LMON_be_finalize();
-       return EXIT_FAILURE;
-     }
+  // sending this to mark the end of the BE session
+  // This should be used to determine PASS/FAIL criteria
+  if (((lrc = LMON_be_sendUsrData(NULL)) == LMON_EBDARG) ||
+      (lrc == LMON_EINVAL) || (lrc == LMON_ENOMEM) || (lrc == LMON_ENEGCB)) {
+    fprintf(stdout, "[LMON BE(%d)] FAILED(%d): LMON_be_sendUsrData\n", rank,
+            lrc);
+    LMON_be_finalize();
+    return EXIT_FAILURE;
+  }
 
   LMON_be_finalize();
 
   return EXIT_SUCCESS;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/be_standalone_kicker.cxx
+++ b/test/src/be_standalone_kicker.cxx
@@ -1,34 +1,35 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jun 12 2008 DHA: Added GNU build system support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Jul 30 2006 DHA: Created file.          
+ *        Jul 30 2006 DHA: Created file.
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -36,60 +37,55 @@
 #endif
 
 #include <lmon_api/common.h>
-#include <unistd.h>
-#include <iostream>
-#include <cstdarg>
 #include <signal.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 #include <climits>
+#include <cstdarg>
 #include <ctime>
-#include <sys/time.h>
+#include <iostream>
 
-void 
-LMON_say_msg ( const char* m, const char* output, ... )
-{
+void LMON_say_msg(const char* m, const char* output, ...) {
   va_list ap;
   char log[PATH_MAX];
   struct timeval tv;
-  gettimeofday (&tv, NULL);
-  sprintf(log, "<%f> %s (%s): %s\n", tv.tv_sec+(tv.tv_usec/100000.0), m, "INFO", output);                                                                                                                                                                                    
+  gettimeofday(&tv, NULL);
+  sprintf(log, "<%f> %s (%s): %s\n", tv.tv_sec + (tv.tv_usec / 100000.0), m,
+          "INFO", output);
   va_start(ap, output);
   vfprintf(stdout, log, ap);
   va_end(ap);
 }
 
-int 
-main( int argc, char* argv[] )
-{
+int main(int argc, char* argv[]) {
   using namespace std;
   char hostName[PATH_MAX];
   char envName[PATH_MAX];
   char* envRet;
   char* token;
   int rc;
- 
-  rc = gethostname (hostName, PATH_MAX);
-  if ( rc < 0 )
-    return -1;
 
-  sprintf (envName, "LAUNCHMON_%s", hostName); 
-  envRet = getenv(envName); 
+  rc = gethostname(hostName, PATH_MAX);
+  if (rc < 0) return -1;
 
-  if ( envRet == NULL )
-    return -1;
+  sprintf(envName, "LAUNCHMON_%s", hostName);
+  envRet = getenv(envName);
 
-  token = strtok (envRet, ":");
-  if (token == NULL )
-    return -1;
+  if (envRet == NULL) return -1;
 
-  do 
-    {
-      kill ( atoi(token), SIGCONT); 
-    }
-  while ( (token = strtok (NULL, ":")) != NULL );
-  LMON_say_msg ("[BE KICKER]", "finished sending SIGCONT"); 
+  token = strtok(envRet, ":");
+  if (token == NULL) return -1;
+
+  do {
+    kill(atoi(token), SIGCONT);
+  } while ((token = strtok(NULL, ":")) != NULL);
+  LMON_say_msg("[BE KICKER]", "finished sending SIGCONT");
 
   return 0;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/fe_attach_smoketest.cxx
+++ b/test/src/fe_attach_smoketest.cxx
@@ -1,41 +1,42 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jun  02 2009 DHA: Added LMON_STATUS_CB_TEST support.
  *        May  19 2009 DHA: Added LMON_ERROR_CB_TEST support.
- *        Mar  13 2009 DHA: Dynamic check for proctabsize 
- *        Jun  12 2008 DHA: Added GNU build system support.  
+ *        Mar  13 2009 DHA: Dynamic check for proctabsize
+ *        Jun  12 2008 DHA: Added GNU build system support.
  *        Mar  20 2008 DHA: Added BlueGene support.
  *        Mar  06 2008 DHA: Added calls-after-fail case.
- *        Mar  05 2008 DHA: Added Invalid pid test case to exercise 
+ *        Mar  05 2008 DHA: Added Invalid pid test case to exercise
  *                          connection timeout capability.
  *        Feb  09 2008 DHA: Added LLNS Copyright.
- *        Aug  06 2006 DHA: Adjust this case for minor API changes  
+ *        Aug  06 2006 DHA: Adjust this case for minor API changes
  *        Dec  27 2006 DHA: Created file.
  */
 
@@ -43,28 +44,27 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <lmon_api/common.h>
 #include <unistd.h>
 #include <cstdarg>
-#include <limits.h>
 
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_fe.h>
+#include <lmon_api/lmon_proctab.h>
 
 #define ERROR_LOG_MAXSIZE 4096
 #define STRING_MAXSIZE 128
 
-#if MEASURE_TRACING_COST 
+#if MEASURE_TRACING_COST
 extern "C" {
-  int begin_timer ();
-  int time_stamp ( const char* description );
+int begin_timer();
+int time_stamp(const char *description);
 }
 #endif
 
-int statusFunc ( int *status )
-{
+int statusFunc(int *status) {
   int stcp = *status;
-  fprintf (stdout, "**** status callback routine is invoked:0x%x ****\n", stcp);
+  fprintf(stdout, "**** status callback routine is invoked:0x%x ****\n", stcp);
   if (WIFREGISTERED(stcp))
     fprintf(stdout, "* session registered\n");
   else
@@ -93,363 +93,289 @@ int statusFunc ( int *status )
   return 0;
 }
 
-int errFunc (const char *format, va_list ap)
-{
+int errFunc(const char *format, va_list ap) {
   int rc;
   char buf[ERROR_LOG_MAXSIZE];
 
   fprintf(stdout, "errFunc is called\n");
-  rc = vsnprintf(buf, ERROR_LOG_MAXSIZE, format, ap); 
+  rc = vsnprintf(buf, ERROR_LOG_MAXSIZE, format, ap);
   fprintf(stdout, "errFunc: %s\n", buf);
 
   return rc;
 }
 
-int 
-main (int argc, char* argv[])
-{
-  unsigned int i             = 0;
-  int spid                   = 0;
-  int jobidsize              = 0;
-  unsigned int psize         = 0;
-  unsigned int proctabsize   = 0;
-  int aSession               = 0;
-  char jobid[PATH_MAX]       = {0};
-  char **daemon_opts         = NULL;
+int main(int argc, char *argv[]) {
+  unsigned int i = 0;
+  int spid = 0;
+  int jobidsize = 0;
+  unsigned int psize = 0;
+  unsigned int proctabsize = 0;
+  int aSession = 0;
+  char jobid[PATH_MAX] = {0};
+  char **daemon_opts = NULL;
   MPIR_PROCDESC_EXT *proctab = NULL;
   lmon_rc_e rc;
 
-  if ( argc < 3 )
-    {
-      fprintf( stdout, 
-	"Usage: fe_launch_smoketest launcherpid daemonpath [daemonargs]\n");
-      fprintf( stdout, "[LMON FE] FAILED\n");
+  if (argc < 3) {
+    fprintf(stdout,
+            "Usage: fe_launch_smoketest launcherpid daemonpath [daemonargs]\n");
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (access(argv[2], X_OK) < 0) {
+    fprintf(stdout, "%s cannot be executed\n", argv[2]);
+
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (argc > 3) {
+    daemon_opts = argv + 3;
+  }
+
+  if ((rc = LMON_fe_init(LMON_VERSION)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (getenv("LMON_ERROR_CB_TEST")) {
+    if (LMON_fe_regErrorCB(errFunc) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
+  }
 
-  if ( access(argv[2], X_OK) < 0 )
-    {
-      fprintf ( stdout, 
-        "%s cannot be executed\n", argv[2] );
+  if ((rc = LMON_fe_createSession(&aSession)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-      fprintf ( stdout, "[LMON FE] FAILED\n" );
+  if (getenv("LMON_STATUS_CB_TEST")) {
+    if (LMON_fe_regStatusCB(aSession, statusFunc) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
-
-  if ( argc > 3 )
-    {
-      daemon_opts = argv+3;
-    }
-
-  if ( ( rc = LMON_fe_init (LMON_VERSION)) 
-              != LMON_OK )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
-  
-  if ( getenv ("LMON_ERROR_CB_TEST"))
-    {
-       if ( LMON_fe_regErrorCB(errFunc) != LMON_OK )
-         {
-            fprintf ( stdout, "[LMON FE] FAILED\n");
-            return EXIT_FAILURE;
-         } 
-    } 
-
-
-  if ( ( rc = LMON_fe_createSession (&aSession)) 
-              != LMON_OK)
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
-
-  if (getenv ("LMON_STATUS_CB_TEST"))
-    {
-       if ( LMON_fe_regStatusCB(aSession, statusFunc) != LMON_OK )
-         {
-            fprintf ( stdout, "[LMON FE] FAILED\n");
-            return EXIT_FAILURE;
-         }
-    }
+  }
 
   spid = atoi(argv[1]);
-  if ( spid < 0 )
-    {
-      fprintf( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
+  if (spid < 0) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
+  begin_timer();
 #endif
 
-  if (getenv ("FEN_RM_DISTRIBUTED"))
-    {
-      /*
-       * If the third argument is not null, the launchMON engine
-       * gets invoked via ssh or rsh.
-       */
-      char hn[1024];
-      gethostname ( hn, 1024);
-      if ( ( rc = LMON_fe_attachAndSpawnDaemons(
-                aSession,
-                hn,
-                spid,
-                argv[2],
-                daemon_opts,
-                NULL,
-                NULL))
-                  != LMON_OK )
-        {
-          if ( getenv ("LMON_INVALIDPID_TEST") != NULL )
-            {
-              if ( rc == LMON_ETOUT )
-                {
-                  fprintf ( stdout,
-                  "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
-                                                                                                                                                
-                  if ( getenv ("LMON_CALLS_AFTER_FAIL_TEST") != NULL )
-                    {
-                      if ( (rc = LMON_fe_detach (aSession)) != LMON_OK )
-                        {
-                          fprintf (stdout,
-                            "[LMON FE] PASS: LMON_fe_detach return with an error code [%d] \n", rc);
-                                                                                                                                                
-                          return EXIT_SUCCESS;
-                        }
-                      else
-                        {
-                          return EXIT_FAILURE;
-                        }
-                    } // if LMON_CALLS_AFTER_FAIL_TEST
-                                                                                                                                                
-                   return EXIT_SUCCESS;
-                } // LMON_ETOUT returned
-            } // if LMON_INVALIDPID_TEST 
-
-            fprintf ( stdout,
-              "[LMON FE] FAILED\n" );
-            return EXIT_FAILURE;
-        } // attachAndSpawn for remote
-    } 
-  else
-    {
-      if ( ( rc = LMON_fe_attachAndSpawnDaemons( 
-                aSession, 
-	        NULL,
-		spid,
-		argv[2],
-		daemon_opts,
-		NULL,
-	        NULL ))
-	      != LMON_OK )
-        {
-          if ( getenv ("LMON_INVALIDPID_TEST") != NULL )
-            {
-              if ( rc == LMON_ETOUT )
-                {
-                  fprintf ( stdout,
+  if (getenv("FEN_RM_DISTRIBUTED")) {
+    /*
+     * If the third argument is not null, the launchMON engine
+     * gets invoked via ssh or rsh.
+     */
+    char hn[1024];
+    gethostname(hn, 1024);
+    if ((rc = LMON_fe_attachAndSpawnDaemons(aSession, hn, spid, argv[2],
+                                            daemon_opts, NULL, NULL)) !=
+        LMON_OK) {
+      if (getenv("LMON_INVALIDPID_TEST") != NULL) {
+        if (rc == LMON_ETOUT) {
+          fprintf(stdout,
                   "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
 
-                  if ( getenv ("LMON_CALLS_AFTER_FAIL_TEST") != NULL )
-                    {
-                      if ( (rc = LMON_fe_detach (aSession)) != LMON_OK )
-                        {
-                          fprintf (stdout,
-                            "[LMON FE] PASS: LMON_fe_detach return with an error code [%d] \n", rc);
-                                                                                                                                                
-                          return EXIT_SUCCESS;
-                        }
-                      else
-                        {
-                          return EXIT_FAILURE;
-                        }
-                    } // if LMON_CALLS_AFTER_FAIL_TEST
-                  
-                   return EXIT_SUCCESS;
-                } // LMON_ETOUT returned
-            } // if LMON_INVALIDPID_TEST                                                                                                            
-            fprintf ( stdout, "[LMON FE] FAILED\n" );
-            return EXIT_FAILURE;
-        } // attachAndSpawn for local
-    } 
+          if (getenv("LMON_CALLS_AFTER_FAIL_TEST") != NULL) {
+            if ((rc = LMON_fe_detach(aSession)) != LMON_OK) {
+              fprintf(stdout,
+                      "[LMON FE] PASS: LMON_fe_detach return with an error "
+                      "code [%d] \n",
+                      rc);
+
+              return EXIT_SUCCESS;
+            } else {
+              return EXIT_FAILURE;
+            }
+          }  // if LMON_CALLS_AFTER_FAIL_TEST
+
+          return EXIT_SUCCESS;
+        }  // LMON_ETOUT returned
+      }    // if LMON_INVALIDPID_TEST
+
+      fprintf(stdout, "[LMON FE] FAILED\n");
+      return EXIT_FAILURE;
+    }  // attachAndSpawn for remote
+  } else {
+    if ((rc = LMON_fe_attachAndSpawnDaemons(aSession, NULL, spid, argv[2],
+                                            daemon_opts, NULL, NULL)) !=
+        LMON_OK) {
+      if (getenv("LMON_INVALIDPID_TEST") != NULL) {
+        if (rc == LMON_ETOUT) {
+          fprintf(stdout,
+                  "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
+
+          if (getenv("LMON_CALLS_AFTER_FAIL_TEST") != NULL) {
+            if ((rc = LMON_fe_detach(aSession)) != LMON_OK) {
+              fprintf(stdout,
+                      "[LMON FE] PASS: LMON_fe_detach return with an error "
+                      "code [%d] \n",
+                      rc);
+
+              return EXIT_SUCCESS;
+            } else {
+              return EXIT_FAILURE;
+            }
+          }  // if LMON_CALLS_AFTER_FAIL_TEST
+
+          return EXIT_SUCCESS;
+        }  // LMON_ETOUT returned
+      }    // if LMON_INVALIDPID_TEST
+      fprintf(stdout, "[LMON FE] FAILED\n");
+      return EXIT_FAILURE;
+    }  // attachAndSpawn for local
+  }
 #if MEASURE_TRACING_COST
-  time_stamp ( "LMON_fe_attachAndSpawnDaemons perf" );
+  time_stamp("LMON_fe_attachAndSpawnDaemons perf");
 #endif
 
-  if ( ( rc = LMON_fe_getProctableSize ( 
-                aSession, 
-                &proctabsize ))
-              !=  LMON_OK )
-    {
-       fprintf ( stdout, 
-         "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
-       return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_getProctableSize(aSession, &proctabsize)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
+    return EXIT_FAILURE;
+  }
 
-  if (proctabsize <= 0) 
-    {
-      fprintf ( stdout, 
-        "[LMON FE] FAILED, proctabsize is not equal to the given: %ud\n", 
-        proctabsize);
+  if (proctabsize <= 0) {
+    fprintf(stdout,
+            "[LMON FE] FAILED, proctabsize is not equal to the given: %ud\n",
+            proctabsize);
+    return EXIT_FAILURE;
+  }
+
+  proctab =
+      (MPIR_PROCDESC_EXT *)malloc(proctabsize * sizeof(MPIR_PROCDESC_EXT));
+
+  if (!proctab) {
+    fprintf(stdout, "[LMON FE] malloc returned null\n");
+    return EXIT_FAILURE;
+  }
+
+  fprintf(
+      stdout,
+      "[LMON FE] Please check the correctness of the following proctable\n");
+
+#if MEASURE_TRACING_COST
+  begin_timer();
+#endif
+
+  if ((rc = LMON_fe_getProctable(aSession, proctab, &psize, proctabsize)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+#if MEASURE_TRACING_COST
+  time_stamp("LMON_fe_getProctable perf");
+#endif
+
+  for (i = 0; i < psize; i++) {
+    fprintf(stdout, "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
+    fprintf(stdout, "[LMON FE] executable_name: %s\n",
+            proctab[i].pd.executable_name);
+    fprintf(stdout, "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid,
+            proctab[i].mpirank);
+    fprintf(stdout, "[LMON FE] \n");
+  }
+
+  rc = LMON_fe_getResourceHandle(aSession, jobid, &jobidsize, PATH_MAX);
+  if ((rc != LMON_OK) && (rc != LMON_EDUNAV)) {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
-
-  proctab = (MPIR_PROCDESC_EXT*) malloc (
-                proctabsize*sizeof (MPIR_PROCDESC_EXT) );
-  
-  if ( !proctab )
-    {
-       fprintf ( stdout, "[LMON FE] malloc returned null\n");
-       return EXIT_FAILURE;
+  } else {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout,
+              "\n[LMON FE] Please check the correctness of the following "
+              "resource handle\n");
+      fprintf(stdout,
+              "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n",
+              jobid);
+      fprintf(stdout, "[LMON FE]");
     }
-
-  fprintf ( stdout,
-    "[LMON FE] Please check the correctness of the following proctable\n");
-
-#if MEASURE_TRACING_COST
-  begin_timer ();
-#endif 
-
-  if ( ( rc = LMON_fe_getProctable (
-                aSession, 
-                proctab,
-                &psize,
-                proctabsize )) 
-              !=  LMON_OK)
-    {
-       fprintf ( stdout, "[LMON FE] FAILED\n" );
-       return EXIT_FAILURE;
-    }
-
-#if MEASURE_TRACING_COST
-  time_stamp ( "LMON_fe_getProctable perf" );
-#endif
-
-  for (i=0; i < psize; i++)
-    {
-      fprintf ( stdout,
-        "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
-      fprintf ( stdout,
-        "[LMON FE] executable_name: %s\n", proctab[i].pd.executable_name);
-      fprintf ( stdout,
-        "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid, proctab[i].mpirank);
-      fprintf ( stdout, "[LMON FE] \n");
-    }
-
-  rc = LMON_fe_getResourceHandle ( aSession, jobid,
-                                   &jobidsize, PATH_MAX);
-  if ((rc != LMON_OK) && (rc != LMON_EDUNAV))
-    {
-      if ( rc != LMON_EDUNAV )
-        {
-            fprintf ( stdout, "[LMON FE] FAILED\n");
-           return EXIT_FAILURE;
-        }
-    }
-  else
-    {
-      if (rc != LMON_EDUNAV)
-        {
-          fprintf ( stdout,
-            "\n[LMON FE] Please check the correctness of the following resource handle\n");
-          fprintf ( stdout,
-            "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n", jobid);
-          fprintf ( stdout,
-            "[LMON FE]");
-       }
-    }
+  }
 
   lmon_rm_info_t rminfo;
-  rc = LMON_fe_getRMInfo ( aSession, &rminfo);
-  if (rc != LMON_OK)
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
+  rc = LMON_fe_getRMInfo(aSession, &rminfo);
+  if (rc != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  } else {
+    fprintf(stdout, "\n[LMON FE] RM type is %d\n",
+            rminfo.rm_supported_types[rminfo.index_to_cur_instance]);
+    fprintf(stdout, "\n[LMON FE] RM launcher's pid is %d\n",
+            rminfo.rm_launcher_pid);
+  }
+
+  if ((getenv("LMON_FE_SHUTDOWNBE_TEST")) != NULL) {
+    if ((rc = LMON_fe_shutdownDaemons(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE]LMON_fe_shutdownBe FAILED\n");
       return EXIT_FAILURE;
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: you must not see the launcher "
+              "process(es) that control(s) kicker daemons\n");
+      return EXIT_SUCCESS;
     }
-  else
-   {
-      fprintf ( stdout,
-         "\n[LMON FE] RM type is %d\n",
-           rminfo.rm_supported_types[rminfo.index_to_cur_instance]);
-      fprintf ( stdout,
-         "\n[LMON FE] RM launcher's pid is %d\n", rminfo.rm_launcher_pid);
-   }
-  
-  if ( (getenv ("LMON_FE_SHUTDOWNBE_TEST")) != NULL )
-    {
-      if ( ( rc = LMON_fe_shutdownDaemons ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE]LMON_fe_shutdownBe FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: you must not see the launcher process(es) that control(s) kicker daemons\n");
-           return EXIT_SUCCESS;
-        }
-    }
+  }
 
-  if ( (getenv ("LMON_FE_KILL_TEST")) != NULL )
-    {
-      if ( ( rc = LMON_fe_kill ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE] LMON_fe_kill FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: you must not see the launcher process(es) nor the launchmon process.\n");
-           return EXIT_SUCCESS;
-        }
-    }
-
-  if ( (getenv ("LMON_FE_DETACH_TEST")) != NULL )
-    {
-      if ( ( rc = LMON_fe_detach ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE] LMON_fe_kill FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_detach\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: launcher process(es) must not be traced.\n");
-           return EXIT_SUCCESS;
-        }
-    }
-
-  rc = LMON_fe_recvUsrDataBe ( aSession, NULL );
-                                                                                                                                               
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
+  if ((getenv("LMON_FE_KILL_TEST")) != NULL) {
+    if ((rc = LMON_fe_kill(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] LMON_fe_kill FAILED\n");
       return EXIT_FAILURE;
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: you must not see the launcher "
+              "process(es) nor the launchmon process.\n");
+      return EXIT_SUCCESS;
     }
+  }
 
-  rc = LMON_fe_sendUsrDataBe ( aSession, NULL );
-
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
+  if ((getenv("LMON_FE_DETACH_TEST")) != NULL) {
+    if ((rc = LMON_fe_detach(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] LMON_fe_kill FAILED\n");
       return EXIT_FAILURE;
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_detach\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: launcher process(es) must not be "
+              "traced.\n");
+      return EXIT_SUCCESS;
     }
+  }
 
-  sleep (3); /* wait until all BE outputs are printed */
-                                                                                                                                               
-  fprintf ( stdout,
-    "\n[LMON FE] PASS: run through the end\n");
-                                                                                                                                               
+  rc = LMON_fe_recvUsrDataBe(aSession, NULL);
+
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  rc = LMON_fe_sendUsrDataBe(aSession, NULL);
+
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  sleep(3); /* wait until all BE outputs are printed */
+
+  fprintf(stdout, "\n[LMON FE] PASS: run through the end\n");
+
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/fe_jobsnap.cxx
+++ b/test/src/fe_jobsnap.cxx
@@ -1,34 +1,35 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Jun 12 2008 DHA: Added GNU build system support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Aug 15 2006 DHA: Timer support 
+ *        Aug 15 2006 DHA: Timer support
  *        Aug 06 2006 DHA: File created
  */
 
@@ -37,117 +38,92 @@
 #endif
 
 #include <lmon_api/common.h>
-#include <unistd.h>
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_fe.h>
+#include <lmon_api/lmon_proctab.h>
+#include <unistd.h>
 
-#define MAXSTRING      128
+#define MAXSTRING 128
 
 #if MEASURE_TRACING_COST
 extern "C" {
-  int begin_timer ();
-  int time_stamp ( const char* description );
+int begin_timer();
+int time_stamp(const char* description);
 }
 #endif
 
-int 
-main (int argc, char* argv[])
-{
-
+int main(int argc, char* argv[]) {
   int aSession, spid;
   char** daemon_opts = NULL;
   lmon_rc_e rc;
 
-  if ( argc < 3 )
-    {
-      fprintf ( stderr, 
-	"Usage: fe_jshot srunpid be_jshot \n");
+  if (argc < 3) {
+    fprintf(stderr, "Usage: fe_jshot srunpid be_jshot \n");
 
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
-  if ( access(argv[2], X_OK) < 0 )
-    {
-      fprintf ( stderr, 
-        "[JOBSNAP] %s cannot be executed\n", argv[2] );
+  if (access(argv[2], X_OK) < 0) {
+    fprintf(stderr, "[JOBSNAP] %s cannot be executed\n", argv[2]);
 
-      return EXIT_FAILURE;	      
-    }
+    return EXIT_FAILURE;
+  }
 
-  if ( argc > 3 )
-    {
-      daemon_opts = argv+3;
-    }
+  if (argc > 3) {
+    daemon_opts = argv + 3;
+  }
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
+  begin_timer();
 #endif
 
-  if ( ( rc = LMON_fe_init (LMON_VERSION)) 
-              != LMON_OK )
-    {
-      fprintf ( stderr, 
-        "[JOBSNAP] LMON_fe_init FAILED\n");
+  if ((rc = LMON_fe_init(LMON_VERSION)) != LMON_OK) {
+    fprintf(stderr, "[JOBSNAP] LMON_fe_init FAILED\n");
 
-      return EXIT_FAILURE;
-    }
-  
-  if ( ( rc = LMON_fe_createSession (&aSession)) 
-              != LMON_OK)
-    {
-      fprintf ( stderr, 
-        "[JOBSNAP] LMON_fe_createFEBESession FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_createSession(&aSession)) != LMON_OK) {
+    fprintf(stderr, "[JOBSNAP] LMON_fe_createFEBESession FAILED\n");
+
+    return EXIT_FAILURE;
+  }
 
   spid = atoi(argv[1]);
-  if ( spid < 0 )
-    {
-      fprintf( stderr, 
-	"[JOBSNAP] invalid srun pid: %d \n", spid);
+  if (spid < 0) {
+    fprintf(stderr, "[JOBSNAP] invalid srun pid: %d \n", spid);
 
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
+  if ((rc = LMON_fe_attachAndSpawnDaemons(aSession, NULL, spid, argv[2],
+                                          daemon_opts, NULL, NULL)) !=
+      LMON_OK) {
+    fprintf(stderr, "[JOBSNAP] LMON_fe_attachAndSpawnDaemons FAILED\n");
 
-  if ( ( rc = LMON_fe_attachAndSpawnDaemons( 
-                aSession, 
-                NULL,
-		spid,
-		argv[2],
-		daemon_opts,
-		NULL,
-	        NULL ))
-	      != LMON_OK )
-    {
-      fprintf( stderr, 
-	"[JOBSNAP] LMON_fe_attachAndSpawnDaemons FAILED\n");
-
-      return EXIT_FAILURE;
-    }
+    return EXIT_FAILURE;
+  }
 
 #if MEASURE_TRACING_COST
-  time_stamp ( "LMON_fe_init to LMON_fe_attachAndSpawnDaemons return" );
+  time_stamp("LMON_fe_init to LMON_fe_attachAndSpawnDaemons return");
 
-  LMON_fe_recvUsrDataBe ( aSession, NULL );
+  LMON_fe_recvUsrDataBe(aSession, NULL);
 
-  time_stamp ( "LMON_fe_attachAndSpawnDaemons to jobsnap completion" );
+  time_stamp("LMON_fe_attachAndSpawnDaemons to jobsnap completion");
 #endif
 
-  if ( ( rc = LMON_fe_detach ( aSession ) )
-              != LMON_OK )
-    {
-      fprintf( stderr, 
-	"[JOBSNAP] LMON_fe_detach FAILED\n");
+  if ((rc = LMON_fe_detach(aSession)) != LMON_OK) {
+    fprintf(stderr, "[JOBSNAP] LMON_fe_detach FAILED\n");
 
-      return EXIT_FAILURE;
-    }
-  
-  if ( getenv ("JOBSNAP_TEST") != NULL )
-    {
-      fprintf( stdout, "[JOBSNAP] PASS\n");
-    }
-  
+    return EXIT_FAILURE;
+  }
+
+  if (getenv("JOBSNAP_TEST") != NULL) {
+    fprintf(stdout, "[JOBSNAP] PASS\n");
+  }
+
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/fe_launch_middleware.cxx
+++ b/test/src/fe_launch_middleware.cxx
@@ -1,29 +1,36 @@
 /*
  * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008-2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2008-2010, Lawrence Livermore National Security, LLC. Produced
+ *at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ *<ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ *License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ *the
+ * terms of the GNU General Public License (as published by the Free Software
  * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ *ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ *along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ *Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *
  *
@@ -37,64 +44,60 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <lmon_api/common.h>
 #include <unistd.h>
-#include <limits.h>
 #include <string>
 #include <vector>
 
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_fe.h>
 #include <lmon_api/lmon_mw.h>
+#include <lmon_api/lmon_proctab.h>
 
 #define MIN_NARGS 7
 
 extern "C" {
-  int begin_timer ();
-  int time_stamp ( const char* description );
-  int statusFunc ( int *status );
+int begin_timer();
+int time_stamp(const char *description);
+int statusFunc(int *status);
 }
 
-
 /*
- * OUR PARALLEL JOB LAUNCHER  
+ * OUR PARALLEL JOB LAUNCHER
  */
 char mylauncher[PATH_MAX] = {0};
 
-int
-main (int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   using namespace std;
 
-  int aSession             = 0;
-  unsigned int psize       = 0;
+  int aSession = 0;
+  unsigned int psize = 0;
   unsigned int proctabsize = 0;
-  int jobidsize            = 0;
-  int i                    = 0;
-  char jobid[PATH_MAX]     = {0};
-  char **launcher_argv     = NULL;
-  char **daemon_opts       = NULL;
-  char *application        = NULL;
-  char *nP                 = NULL;
-  char *nN                 = NULL;
-  char *part               = NULL;
-  char *mw_daemon          = NULL;
-  char *be_daemon          = NULL;
+  int jobidsize = 0;
+  int i = 0;
+  char jobid[PATH_MAX] = {0};
+  char **launcher_argv = NULL;
+  char **daemon_opts = NULL;
+  char *application = NULL;
+  char *nP = NULL;
+  char *nN = NULL;
+  char *part = NULL;
+  char *mw_daemon = NULL;
+  char *be_daemon = NULL;
 
   string numprocs_opt;
   string numnodes_opt;
   string partition_opt;
 
-  lmon_rc_e rc             = LMON_OK;
+  lmon_rc_e rc = LMON_OK;
 
-  if ( argc < MIN_NARGS )
-    {
-      fprintf ( stderr,
-        "Usage: fe_launch_smoketest application numprocs numnodes partition mw_daemon be_daemon [be_daemonargs]\n" );
-      fprintf ( stderr,
-        "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if (argc < MIN_NARGS) {
+    fprintf(stderr,
+            "Usage: fe_launch_smoketest application numprocs numnodes "
+            "partition mw_daemon be_daemon [be_daemonargs]\n");
+    fprintf(stderr, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
   application = argv[1];
   nP = argv[2];
@@ -103,405 +106,337 @@ main (int argc, char *argv[])
   mw_daemon = argv[5];
   be_daemon = argv[6];
 
-  if ( argc > MIN_NARGS )
-    {
-      daemon_opts = argv+MIN_NARGS;
-    }
+  if (argc > MIN_NARGS) {
+    daemon_opts = argv + MIN_NARGS;
+  }
 
-  if ( access(argv[1], X_OK) < 0 )
-    {
-      fprintf ( stderr,
-        "%s cannot be executed\n",
-        argv[1] );
-      fprintf ( stderr,
-        "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if (access(argv[1], X_OK) < 0) {
+    fprintf(stderr, "%s cannot be executed\n", argv[1]);
+    fprintf(stderr, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
   char *rmenv = getenv("MPI_JOB_LAUNCHER_PATH");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "MPI_JOB_LAUNCHER_PATH envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "MPI_JOB_LAUNCHER_PATH envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   snprintf(mylauncher, PATH_MAX, "%s", rmenv);
 
   rmenv = getenv("RM_TYPE");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "RM_TYPE envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "RM_TYPE envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   std::string rmenv_str = rmenv;
 
-  if ((rmenv_str == std::string("RC_bgqrm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("--verbose");
-      launcher_argv[2] = strdup("5");
-      launcher_argv[3] = strdup("--np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("--exe"); 
-      launcher_argv[6] = strdup(argv[1]); 
-      // manually fill the block
-      // launcher_argv[7] = strdup("--block");
-      // launcher_argv[8] = strdup("R00-M0-N04"); 
-      // manually fill the corner
-      // launcher_argv[9] = strdup("--corner");
-      // launcher_argv[10] = strdup("R00-M0-N04-J07");
-      // manually fill the shape 
-      // launcher_argv[11] = strdup("--shape");
-      // launcher_argv[12] = strdup("1x1x1x1x1");
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-        "[LMON_FE] launching the job/daemons via %s\n",
-        mylauncher);
-    }
-  else if ((rmenv_str == std::string("RC_bgq_slurm")))
-    {
-      launcher_argv = (char **) malloc(7*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-N");
-      launcher_argv[2] = strdup(argv[3]);
-      launcher_argv[3] = strdup("-n");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-      fprintf (stdout,
-        "[LMON_FE] launching the job/daemons via %s\n",
-        "mylauncher");
-    }
-  else if ((rmenv_str == std::string("RC_bglrm")) 
-      || (rmenv_str == std::string("RC_bgprm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-verbose");
-      launcher_argv[2] = strdup("1");
-      launcher_argv[3] = strdup("-np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("-exe"); 
-      launcher_argv[6] = strdup(argv[1]); 
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-                "[LMON_FE] launching the job/daemons via %s\n",
-                mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_slurm"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      numnodes_opt     = string("-N") + string(argv[3]);
-      partition_opt    = string("-p") + string(argv[4]);
-      launcher_argv    = (char **) malloc (7*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(numnodes_opt.c_str());
-      launcher_argv[3] = strdup(partition_opt.c_str());
-      launcher_argv[4] = strdup("-l");
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_alps"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      launcher_argv    = (char**) malloc(4*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(argv[1]);
-      launcher_argv[3] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_orte"))
-    {
-      launcher_argv    = (char **) malloc(8*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-mca");
-      launcher_argv[2] = strdup("debugger");
-      launcher_argv[3] = strdup("mpirx");
-      launcher_argv[4] = strdup("-np");
-      launcher_argv[5] = strdup(argv[2]);
-      launcher_argv[6] = strdup(argv[1]);
-      launcher_argv[7] = NULL;
-      fprintf (stdout,
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_mpiexec_hydra"))
-    {
-      launcher_argv    = (char **) malloc(5*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-n");
-      launcher_argv[2] = strdup(argv[2]);
-      launcher_argv[3] = strdup(argv[1]);
-      launcher_argv[4] = NULL;
-      fprintf (stdout,
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
+  if ((rmenv_str == std::string("RC_bgqrm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("--verbose");
+    launcher_argv[2] = strdup("5");
+    launcher_argv[3] = strdup("--np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("--exe");
+    launcher_argv[6] = strdup(argv[1]);
+    // manually fill the block
+    // launcher_argv[7] = strdup("--block");
+    // launcher_argv[8] = strdup("R00-M0-N04");
+    // manually fill the corner
+    // launcher_argv[9] = strdup("--corner");
+    // launcher_argv[10] = strdup("R00-M0-N04-J07");
+    // manually fill the shape
+    // launcher_argv[11] = strdup("--shape");
+    // launcher_argv[12] = strdup("1x1x1x1x1");
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if ((rmenv_str == std::string("RC_bgq_slurm"))) {
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-N");
+    launcher_argv[2] = strdup(argv[3]);
+    launcher_argv[3] = strdup("-n");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n",
+            "mylauncher");
+  } else if ((rmenv_str == std::string("RC_bglrm")) ||
+             (rmenv_str == std::string("RC_bgprm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-verbose");
+    launcher_argv[2] = strdup("1");
+    launcher_argv[3] = strdup("-np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("-exe");
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_slurm")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    numnodes_opt = string("-N") + string(argv[3]);
+    partition_opt = string("-p") + string(argv[4]);
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(numnodes_opt.c_str());
+    launcher_argv[3] = strdup(partition_opt.c_str());
+    launcher_argv[4] = strdup("-l");
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+  } else if (rmenv_str == std::string("RC_alps")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    launcher_argv = (char **)malloc(4 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(argv[1]);
+    launcher_argv[3] = NULL;
+  } else if (rmenv_str == std::string("RC_orte")) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-mca");
+    launcher_argv[2] = strdup("debugger");
+    launcher_argv[3] = strdup("mpirx");
+    launcher_argv[4] = strdup("-np");
+    launcher_argv[5] = strdup(argv[2]);
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_mpiexec_hydra")) {
+    launcher_argv = (char **)malloc(5 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-n");
+    launcher_argv[2] = strdup(argv[2]);
+    launcher_argv[3] = strdup(argv[1]);
+    launcher_argv[4] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  }
 
-  fprintf (stderr, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  fprintf(stderr, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
 
   //
   // Init the front-end library
   //
-  if ( ( rc = LMON_fe_init ( LMON_VERSION ) )
-              != LMON_OK )
-    {
-      fprintf ( stderr, "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_init(LMON_VERSION)) != LMON_OK) {
+    fprintf(stderr, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
   //
   // Create a tool session
   //
-  if ( ( rc = LMON_fe_createSession (&aSession))
-              != LMON_OK)
-    {
-      fprintf ( stderr, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_createSession(&aSession)) != LMON_OK) {
+    fprintf(stderr, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
+  begin_timer();
 #endif
 
   //
   // Under that session, launch app tasks and
   // co-locate back ends with it
   //
-  rc = LMON_fe_launchAndSpawnDaemons(aSession,
-                                     NULL,
-                                     launcher_argv[0],
-                                     launcher_argv,
-                                     be_daemon,
-                                     daemon_opts,
-                                     NULL,
-                                     NULL);
+  rc = LMON_fe_launchAndSpawnDaemons(aSession, NULL, launcher_argv[0],
+                                     launcher_argv, be_daemon, daemon_opts,
+                                     NULL, NULL);
 
-  if ( rc != LMON_OK )
-    {
-      fprintf ( stderr, "[LMON FE] LMON_fe_launchAndSpawnDaemons FAILED\n" );
-      return EXIT_FAILURE;
-    }
-
+  if (rc != LMON_OK) {
+    fprintf(stderr, "[LMON FE] LMON_fe_launchAndSpawnDaemons FAILED\n");
+    return EXIT_FAILURE;
+  }
 
 #if MEASURE_TRACING_COST
   //
   // LMON_fe_launchAndSpawnDaemons done
   //
   //
-  time_stamp ( "LMON_fe_launchAndSpawnDaemons perf" );
+  time_stamp("LMON_fe_launchAndSpawnDaemons perf");
 #endif
 
   dist_request_t *req = NULL;
   int nreq = 0;
 
-  if (getenv("LMON_MW_HOSTLIST_TEST"))
-    {
-      nreq = 1;
-      req = (dist_request_t *) malloc (sizeof(dist_request_t)*nreq);
+  if (getenv("LMON_MW_HOSTLIST_TEST")) {
+    nreq = 1;
+    req = (dist_request_t *)malloc(sizeof(dist_request_t) * nreq);
 
-      //
-      // HOSTLIST Volume
-      //
-      char *hl = getenv("LMON_MW_HOSTLIST");
-      if (!hl)
-        {
-          fprintf ( stderr, "[LMON FE] FAILED: LMON_MW_HOSTLIST is needed for this test\n" );
-          return EXIT_FAILURE;
-        }
-      std::vector<std::string> hostvect;
-      char delim[] = ":";
-      char *hlcp = strdup (hl);
-      char *token = strtok (hlcp, delim);
-      while (token)
-        {
-          hostvect.push_back(token);
-          token = strtok (NULL, delim);
-        }
-      req[0].md = LMON_MW_HOSTLIST;
-      req[0].mw_daemon_path = strdup (mw_daemon);
-      req[0].d_argv = (char **) malloc(3*sizeof(char *));
-      req[0].d_argv[0] = strdup("testarg1");
-      req[0].d_argv[1] = strdup("testarg2");
-      req[0].d_argv[2] = NULL;
-      req[0].ndaemon = -1;
-      req[0].block = -1;
-      req[0].cyclic = -1;
-      req[0].optkind = hostlists;
-      req[0].option.hl = (char **) malloc (sizeof(char *) * (hostvect.size() + 1));
-      std::vector<std::string>::const_iterator it;
-      for (it=hostvect.begin(); it != hostvect.end(); ++it)
-        {
-          req[0].option.hl[i] = strdup((*it).c_str());
-          i++;
-        }
-      req[0].option.hl[i] = NULL;
-    }
-  else if (getenv("LMON_MW_COLOC_TEST"))
-    {
-      nreq = 1;
-      req = (dist_request_t *) malloc (sizeof(dist_request_t)*nreq);
-
-      //
-      // COLOC Volume
-      //
-      req[0].md = LMON_MW_COLOC;
-      req[0].mw_daemon_path = strdup (mw_daemon);
-      req[0].d_argv = (char **) malloc(3*sizeof(char *));
-      req[0].d_argv[0] = strdup("testarg1");
-      req[0].d_argv[1] = strdup("testarg2");
-      req[0].d_argv[2] = NULL;
-      req[0].ndaemon = -1;
-      req[0].block = -1;
-      req[0].cyclic = -1;
-      req[0].optkind = req_none;
-    }
-  else if (getenv("LMON_MW_MIX_TEST"))
-    {
-      nreq = 2;
-      req = (dist_request_t *) malloc (sizeof(dist_request_t)*nreq);
-
-      //
-      // COLOC Volume
-      //
-      req[1].md = LMON_MW_COLOC;
-      req[1].mw_daemon_path = strdup (mw_daemon);
-      req[1].d_argv = NULL;
-      req[1].ndaemon = -1;
-      req[1].block = -1;
-      req[1].cyclic = -1;
-      req[1].optkind = req_none;
-
-      //
-      // HOSTLIST Volume
-      //
-      char *hl = getenv("LMON_MW_HOSTLIST");
-      if (!hl)
-        {
-          fprintf ( stderr, "[LMON FE] FAILED: LMON_MW_HOSTLIST is needed for this test\n" );
-          return EXIT_FAILURE;
-        }
-      std::vector<std::string> hostvect;
-      char delim[] = ":";
-      char *hlcp = strdup (hl);
-      char *token = strtok (hlcp, delim);
-      while (token)
-        {
-          hostvect.push_back(token);
-          token = strtok (NULL, delim);
-        }
-      req[0].md = LMON_MW_HOSTLIST;
-      req[0].mw_daemon_path = strdup (mw_daemon);
-      req[0].d_argv = NULL;
-      req[0].ndaemon = -1;
-      req[0].block = -1;
-      req[0].cyclic = -1;
-      req[0].optkind = hostlists;
-      req[0].option.hl = (char **) malloc (sizeof(char *) * (hostvect.size() + 1));
-      std::vector<std::string>::const_iterator it;
-      for (it=hostvect.begin(); it != hostvect.end(); ++it)
-        {
-          req[0].option.hl[i] = strdup((*it).c_str());
-          i++;
-        }
-      req[0].option.hl[i] = NULL;
-
-    }
-  else
-    {
-      fprintf ( stderr, "[LMON FE] envVar isn't given to select a test\n" );
+    //
+    // HOSTLIST Volume
+    //
+    char *hl = getenv("LMON_MW_HOSTLIST");
+    if (!hl) {
+      fprintf(stderr,
+              "[LMON FE] FAILED: LMON_MW_HOSTLIST is needed for this test\n");
       return EXIT_FAILURE;
     }
+    std::vector<std::string> hostvect;
+    char delim[] = ":";
+    char *hlcp = strdup(hl);
+    char *token = strtok(hlcp, delim);
+    while (token) {
+      hostvect.push_back(token);
+      token = strtok(NULL, delim);
+    }
+    req[0].md = LMON_MW_HOSTLIST;
+    req[0].mw_daemon_path = strdup(mw_daemon);
+    req[0].d_argv = (char **)malloc(3 * sizeof(char *));
+    req[0].d_argv[0] = strdup("testarg1");
+    req[0].d_argv[1] = strdup("testarg2");
+    req[0].d_argv[2] = NULL;
+    req[0].ndaemon = -1;
+    req[0].block = -1;
+    req[0].cyclic = -1;
+    req[0].optkind = hostlists;
+    req[0].option.hl = (char **)malloc(sizeof(char *) * (hostvect.size() + 1));
+    std::vector<std::string>::const_iterator it;
+    for (it = hostvect.begin(); it != hostvect.end(); ++it) {
+      req[0].option.hl[i] = strdup((*it).c_str());
+      i++;
+    }
+    req[0].option.hl[i] = NULL;
+  } else if (getenv("LMON_MW_COLOC_TEST")) {
+    nreq = 1;
+    req = (dist_request_t *)malloc(sizeof(dist_request_t) * nreq);
 
- sleep(5);
+    //
+    // COLOC Volume
+    //
+    req[0].md = LMON_MW_COLOC;
+    req[0].mw_daemon_path = strdup(mw_daemon);
+    req[0].d_argv = (char **)malloc(3 * sizeof(char *));
+    req[0].d_argv[0] = strdup("testarg1");
+    req[0].d_argv[1] = strdup("testarg2");
+    req[0].d_argv[2] = NULL;
+    req[0].ndaemon = -1;
+    req[0].block = -1;
+    req[0].cyclic = -1;
+    req[0].optkind = req_none;
+  } else if (getenv("LMON_MW_MIX_TEST")) {
+    nreq = 2;
+    req = (dist_request_t *)malloc(sizeof(dist_request_t) * nreq);
+
+    //
+    // COLOC Volume
+    //
+    req[1].md = LMON_MW_COLOC;
+    req[1].mw_daemon_path = strdup(mw_daemon);
+    req[1].d_argv = NULL;
+    req[1].ndaemon = -1;
+    req[1].block = -1;
+    req[1].cyclic = -1;
+    req[1].optkind = req_none;
+
+    //
+    // HOSTLIST Volume
+    //
+    char *hl = getenv("LMON_MW_HOSTLIST");
+    if (!hl) {
+      fprintf(stderr,
+              "[LMON FE] FAILED: LMON_MW_HOSTLIST is needed for this test\n");
+      return EXIT_FAILURE;
+    }
+    std::vector<std::string> hostvect;
+    char delim[] = ":";
+    char *hlcp = strdup(hl);
+    char *token = strtok(hlcp, delim);
+    while (token) {
+      hostvect.push_back(token);
+      token = strtok(NULL, delim);
+    }
+    req[0].md = LMON_MW_HOSTLIST;
+    req[0].mw_daemon_path = strdup(mw_daemon);
+    req[0].d_argv = NULL;
+    req[0].ndaemon = -1;
+    req[0].block = -1;
+    req[0].cyclic = -1;
+    req[0].optkind = hostlists;
+    req[0].option.hl = (char **)malloc(sizeof(char *) * (hostvect.size() + 1));
+    std::vector<std::string>::const_iterator it;
+    for (it = hostvect.begin(); it != hostvect.end(); ++it) {
+      req[0].option.hl[i] = strdup((*it).c_str());
+      i++;
+    }
+    req[0].option.hl[i] = NULL;
+
+  } else {
+    fprintf(stderr, "[LMON FE] envVar isn't given to select a test\n");
+    return EXIT_FAILURE;
+  }
+
+  sleep(5);
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
+  begin_timer();
 #endif
 
-  rc = LMON_fe_launchMwDaemons( aSession, req, nreq, NULL, NULL );
+  rc = LMON_fe_launchMwDaemons(aSession, req, nreq, NULL, NULL);
 
   free(req);
 
-  if ( rc != LMON_OK )
-    {
-      fprintf ( stderr, "[LMON FE] LMON_fe_launchMwDaemons FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if (rc != LMON_OK) {
+    fprintf(stderr, "[LMON FE] LMON_fe_launchMwDaemons FAILED\n");
+    return EXIT_FAILURE;
+  }
 
 #if MEASURE_TRACING_COST
   //
   // LMON_fe_launchMwDaemons done
   //
   //
-  time_stamp ( "LMON_fe_launchMwDaemons perf" );
+  time_stamp("LMON_fe_launchMwDaemons perf");
 #endif
-
 
   unsigned int mwsize = 0;
   LMON_fe_getMwHostlistSize(aSession, &mwsize);
-  if ( rc != LMON_OK)
-    {
-      fprintf ( stderr, "[LMON FE] LMON_fe_getMwHostlistSize FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if (rc != LMON_OK) {
+    fprintf(stderr, "[LMON FE] LMON_fe_getMwHostlistSize FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-  char **mwhostlist = (char **) malloc (mwsize * sizeof(char *));
+  char **mwhostlist = (char **)malloc(mwsize * sizeof(char *));
   rc = LMON_fe_getMwHostlist(aSession, mwhostlist, &mwsize, mwsize);
-  if ( rc != LMON_OK)
-    {
-      fprintf ( stderr, "[LMON FE] LMON_fe_getMwHostlist FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if (rc != LMON_OK) {
+    fprintf(stderr, "[LMON FE] LMON_fe_getMwHostlist FAILED\n");
+    return EXIT_FAILURE;
+  }
 
   fprintf(stdout, "[LMON FE] **************************\n");
-  for (i=0; i < mwsize; i++)
-    {
-      fprintf( stdout, "[LMON FE] MW rank %5d: %s\n", i, mwhostlist[i]);
-      free(mwhostlist[i]);
-      mwhostlist[i] = NULL;
-    }
+  for (i = 0; i < mwsize; i++) {
+    fprintf(stdout, "[LMON FE] MW rank %5d: %s\n", i, mwhostlist[i]);
+    free(mwhostlist[i]);
+    mwhostlist[i] = NULL;
+  }
   fprintf(stdout, "[LMON FE] **************************\n");
 
   free(mwhostlist);
 
-  rc = LMON_fe_recvUsrDataMw ( aSession, NULL );
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stderr, "[LMON FE] FAILED in LMON_fe_recvUsrDataMw\n");
-      return EXIT_FAILURE;
-    }
+  rc = LMON_fe_recvUsrDataMw(aSession, NULL);
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stderr, "[LMON FE] FAILED in LMON_fe_recvUsrDataMw\n");
+    return EXIT_FAILURE;
+  }
 
   //
   // Send an empty user msg saying MW daemons are up
   //
-  rc = LMON_fe_sendUsrDataBe ( aSession, NULL );
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stderr, "[LMON FE] FAILED in LMON_fe_sendUsrDataBe\n");
-      return EXIT_FAILURE;
-    }
+  rc = LMON_fe_sendUsrDataBe(aSession, NULL);
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stderr, "[LMON FE] FAILED in LMON_fe_sendUsrDataBe\n");
+    return EXIT_FAILURE;
+  }
 
-  rc = LMON_fe_recvUsrDataBe ( aSession, NULL );
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED in LMON_fe_recvUsrDataBe\n");
-      return EXIT_FAILURE;
-    }
+  rc = LMON_fe_recvUsrDataBe(aSession, NULL);
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED in LMON_fe_recvUsrDataBe\n");
+    return EXIT_FAILURE;
+  }
 
-  fprintf ( stderr,
-    "\n[LMON FE] PASS: run through the end\n");
+  fprintf(stderr, "\n[LMON FE] PASS: run through the end\n");
 
   sleep(1);
 

--- a/test/src/fe_launch_smoketest.cxx
+++ b/test/src/fe_launch_smoketest.cxx
@@ -1,46 +1,47 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008 ~ 2012, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
- *
+ *--------------------------------------------------------------------------------
  *
  *  ./fe_launch_smoketest.debug /bin/hostname 9 5 pdebug `pwd`/be_kicker.debug
  *
  *  Update Log:
  *        Oct 25 2011 DHA: Added BGQ support.
  *        Oct 21 2011 DHA: Added dynamic RM support.
- *        Nov 12 2009 DHA: Change BG mpirun options to cover /P running under IBM LL
+ *        Nov 12 2009 DHA: Change BG mpirun options to cover /P running under
+ *                         IBM LL
  *        Mar 04 2009 DHA: Added generic BlueGene support.
- *        Jun 16 2008 DHA: Added LMON_fe_recvUsrDataBe at the end to 
- *                         coordinate the testing result with back-end 
- *                         daemons better. 
+ *        Jun 16 2008 DHA: Added LMON_fe_recvUsrDataBe at the end to
+ *                         coordinate the testing result with back-end
+ *                         daemons better.
  *        Jun 12 2008 DHA: Added GNU build system support.
  *        Mar 18 2008 DHA: Added BlueGene support.
  *        Mar 05 2008 DHA: Added invalid daemon path test.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *        Jul 30 2007 DHA: Adjust this case for minor API changes  
+ *        Jul 30 2007 DHA: Adjust this case for minor API changes
  *        Dec 27 2006 DHA: Created file.
  */
 
@@ -48,19 +49,19 @@
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <lmon_api/common.h>
 #include <unistd.h>
-#include <limits.h>
 
 #include <string>
 
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_fe.h>
+#include <lmon_api/lmon_proctab.h>
 
-#if MEASURE_TRACING_COST 
+#if MEASURE_TRACING_COST
 extern "C" {
-  int begin_timer ();
-  int time_stamp ( const char* description );
+int begin_timer();
+int time_stamp(const char *description);
 }
 #endif
 
@@ -69,10 +70,9 @@ extern "C" {
  */
 char mylauncher[PATH_MAX] = {0};
 
-int statusFunc ( int *status )
-{
+int statusFunc(int *status) {
   int stcp = *status;
-  fprintf (stdout, "**** status callback routine is invoked:0x%x ****\n", stcp);
+  fprintf(stdout, "**** status callback routine is invoked:0x%x ****\n", stcp);
   if (WIFREGISTERED(stcp))
     fprintf(stdout, "* session registered\n");
   else
@@ -90,478 +90,371 @@ int statusFunc ( int *status )
 
   if (WIFDETACHED(stcp))
     fprintf(stdout, "* the job is detached\n");
-  else
-    {
-      if (WIFKILLED(stcp))
-        fprintf(stdout, "* the job is killed\n");
-      else
-        fprintf(stdout, "* the job has not been killed\n");
-    }
+  else {
+    if (WIFKILLED(stcp))
+      fprintf(stdout, "* the job is killed\n");
+    else
+      fprintf(stdout, "* the job has not been killed\n");
+  }
 
   return 0;
 }
 
-
-int 
-main (int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
   using namespace std;
 
-  int aSession    = 0;
-  unsigned int psize       = 0;
+  int aSession = 0;
+  unsigned int psize = 0;
   unsigned int proctabsize = 0;
-  int jobidsize   = 0;
-  int i           = 0;
-  char jobid[PATH_MAX]        = {0};
-  char **launcher_argv        = NULL;
-  char **daemon_opts          = NULL;
-  MPIR_PROCDESC_EXT *proctab  = NULL;
+  int jobidsize = 0;
+  int i = 0;
+  char jobid[PATH_MAX] = {0};
+  char **launcher_argv = NULL;
+  char **daemon_opts = NULL;
+  MPIR_PROCDESC_EXT *proctab = NULL;
 
   lmon_rc_e rc;
   string numprocs_opt;
   string numnodes_opt;
   string partition_opt;
 
-  if ( argc < 6 )
-    {
-      fprintf ( stdout,
-        "Usage: fe_launch_smoketest appcode numprocs numnodes partition daemonpath [daemonargs]\n" );
-      fprintf ( stdout,
-        "[LMON FE] FAILED\n" );
+  if (argc < 6) {
+    fprintf(stdout,
+            "Usage: fe_launch_smoketest appcode numprocs numnodes partition "
+            "daemonpath [daemonargs]\n");
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (access(argv[1], X_OK) < 0) {
+    fprintf(stdout, "%s cannot be executed\n", argv[1]);
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (getenv("LMON_INVALIDDAEMON_TEST") == NULL) {
+    if (access(argv[5], X_OK) < 0) {
+      fprintf(stdout, "%s cannot be executed\n", argv[5]);
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
+  }
 
-  if ( access(argv[1], X_OK) < 0 )
-    {
-      fprintf ( stdout,
-        "%s cannot be executed\n",
-        argv[1] );
-      fprintf ( stdout,
-        "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;
-    }
-
-  if ( getenv ("LMON_INVALIDDAEMON_TEST") == NULL )
-    {
-      if ( access(argv[5], X_OK) < 0 )
-        {
-          fprintf(stdout,
-            "%s cannot be executed\n",
-            argv[5]);
-          fprintf(stdout,
-            "[LMON FE] FAILED\n");
-          return EXIT_FAILURE;
-        }
-    }
-
-  if ( argc > 6 )
-    daemon_opts = argv+6;
+  if (argc > 6) daemon_opts = argv + 6;
 
   char *rmenv = getenv("MPI_JOB_LAUNCHER_PATH");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "MPI_JOB_LAUNCHER_PATH envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "MPI_JOB_LAUNCHER_PATH envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   snprintf(mylauncher, PATH_MAX, "%s", rmenv);
 
   rmenv = getenv("RM_TYPE");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "RM_TYPE envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "RM_TYPE envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   std::string rmenv_str = rmenv;
 
-  if ((rmenv_str == std::string("RC_bgqrm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("--verbose");
-      launcher_argv[2] = strdup("5");
-      launcher_argv[3] = strdup("--np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("--exe"); 
-      launcher_argv[6] = strdup(argv[1]); 
-      // manually fill the block
-      //launcher_argv[7] = strdup("--block");
-      //launcher_argv[8] = strdup("R00-M0-N04"); 
-      // manually fill the corner
-      //launcher_argv[9] = strdup("--corner");
-      //launcher_argv[10] = strdup("R00-M0-N04-J07");
-      // manually fill the shape 
-      //launcher_argv[11] = strdup("--shape");
-      //launcher_argv[12] = strdup("1x1x1x1x1");
-      //launcher_argv[13] = NULL;
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-        "[LMON_FE] launching the job/daemons via %s\n",
-        mylauncher);
-    }
-  else if ((rmenv_str == std::string("RC_bgq_slurm")))
-    {
-      launcher_argv = (char **) malloc(7*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-N");
-      launcher_argv[2] = strdup(argv[3]);
-      launcher_argv[3] = strdup("-n");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-      fprintf (stdout,
-        "[LMON_FE] launching the job/daemons via %s\n",
-        "mylauncher");
-    }
-  else if ((rmenv_str == std::string("RC_bglrm")) 
-      || (rmenv_str == std::string("RC_bgprm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-verbose");
-      launcher_argv[2] = strdup("1");
-      launcher_argv[3] = strdup("-np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("-exe"); 
-      launcher_argv[6] = strdup(argv[1]); 
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-                "[LMON_FE] launching the job/daemons via %s\n",
-                mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_slurm"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      numnodes_opt     = string("-N") + string(argv[3]);
-      partition_opt    = string("-p") + string(argv[4]);
-      launcher_argv    = (char **) malloc (7*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(numnodes_opt.c_str());
-      launcher_argv[3] = strdup(partition_opt.c_str());
-      launcher_argv[4] = strdup("-l");
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_alps"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      launcher_argv    = (char**) malloc(4*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(argv[1]);
-      launcher_argv[3] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_orte"))
-    {
-      launcher_argv    = (char **) malloc(8*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-mca");
-      launcher_argv[2] = strdup("debugger");
-      launcher_argv[3] = strdup("mpirx");
-      launcher_argv[4] = strdup("-np");
-      launcher_argv[5] = strdup(argv[2]);
-      launcher_argv[6] = strdup(argv[1]);
-      launcher_argv[7] = NULL;
-      fprintf (stdout,
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_mpiexec_hydra"))
-    {
-      launcher_argv    = (char **) malloc(5*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-n");
-      launcher_argv[2] = strdup(argv[2]);
-      launcher_argv[3] = strdup(argv[1]);
-      launcher_argv[4] = NULL;
-      fprintf (stdout,
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
+  if ((rmenv_str == std::string("RC_bgqrm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("--verbose");
+    launcher_argv[2] = strdup("5");
+    launcher_argv[3] = strdup("--np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("--exe");
+    launcher_argv[6] = strdup(argv[1]);
+    // manually fill the block
+    // launcher_argv[7] = strdup("--block");
+    // launcher_argv[8] = strdup("R00-M0-N04");
+    // manually fill the corner
+    // launcher_argv[9] = strdup("--corner");
+    // launcher_argv[10] = strdup("R00-M0-N04-J07");
+    // manually fill the shape
+    // launcher_argv[11] = strdup("--shape");
+    // launcher_argv[12] = strdup("1x1x1x1x1");
+    // launcher_argv[13] = NULL;
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if ((rmenv_str == std::string("RC_bgq_slurm"))) {
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-N");
+    launcher_argv[2] = strdup(argv[3]);
+    launcher_argv[3] = strdup("-n");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n",
+            "mylauncher");
+  } else if ((rmenv_str == std::string("RC_bglrm")) ||
+             (rmenv_str == std::string("RC_bgprm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-verbose");
+    launcher_argv[2] = strdup("1");
+    launcher_argv[3] = strdup("-np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("-exe");
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_slurm")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    numnodes_opt = string("-N") + string(argv[3]);
+    partition_opt = string("-p") + string(argv[4]);
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(numnodes_opt.c_str());
+    launcher_argv[3] = strdup(partition_opt.c_str());
+    launcher_argv[4] = strdup("-l");
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+  } else if (rmenv_str == std::string("RC_alps")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    launcher_argv = (char **)malloc(4 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(argv[1]);
+    launcher_argv[3] = NULL;
+  } else if (rmenv_str == std::string("RC_orte")) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-mca");
+    launcher_argv[2] = strdup("debugger");
+    launcher_argv[3] = strdup("mpirx");
+    launcher_argv[4] = strdup("-np");
+    launcher_argv[5] = strdup(argv[2]);
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_mpiexec_hydra")) {
+    launcher_argv = (char **)malloc(5 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-n");
+    launcher_argv[2] = strdup(argv[2]);
+    launcher_argv[3] = strdup(argv[1]);
+    launcher_argv[4] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  }
 
-  if ( ( rc = LMON_fe_init ( LMON_VERSION ) ) 
-              != LMON_OK )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_init(LMON_VERSION)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-  if ( ( rc = LMON_fe_createSession (&aSession)) 
-              != LMON_OK)
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_fe_createSession(&aSession)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
   lmon_rm_info_t rminfo;
-  rc = LMON_fe_getRMInfo ( aSession, &rminfo);
-  if (rc != LMON_EDUNAV)
-    {
-      fprintf ( stdout, "[LMON FE] FAILED, rc: %d\n", rc);
+  rc = LMON_fe_getRMInfo(aSession, &rminfo);
+  if (rc != LMON_EDUNAV) {
+    fprintf(stdout, "[LMON FE] FAILED, rc: %d\n", rc);
+    return EXIT_FAILURE;
+  } else {
+    fprintf(stdout, "\n[LMON FE] %d RM types are supported\n",
+            rminfo.num_supported_types);
+  }
+
+  if (getenv("LMON_STATUS_CB_TEST")) {
+    if (LMON_fe_regStatusCB(aSession, statusFunc) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
-  else
-   {
-      fprintf ( stdout,
-         "\n[LMON FE] %d RM types are supported\n",
-         rminfo.num_supported_types);
-   }
-
-  if ( getenv ("LMON_STATUS_CB_TEST"))
-    {
-       if ( LMON_fe_regStatusCB(aSession, statusFunc) != LMON_OK )
-         {
-            fprintf ( stdout, "[LMON FE] FAILED\n");
-            return EXIT_FAILURE;
-         }
-    }
+  }
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
-#endif 
+  begin_timer();
+#endif
 
-  if ( getenv ("FEN_RM_DISTRIBUTED") )
-    {
-      /*
-       * If the third argument is not null, the launchMON engine
-       * gets invoked via ssh or rsh. 
-       */
-      char hn[1024];
-      gethostname ( hn, 1024);
-      if ( ( rc = LMON_fe_launchAndSpawnDaemons( 
-                    aSession, 
-   	            hn,
-	    	    launcher_argv[0],
-		    launcher_argv,
-		    argv[5],
-		    daemon_opts,
-		    NULL,
-		    NULL)) 
-                  != LMON_OK )
-        {
-          if ( getenv ("LMON_INVALIDDAEMON_TEST") != NULL )
-            {
-              if ( rc == LMON_ETOUT )
-                {
-                  fprintf ( stdout,
+  if (getenv("FEN_RM_DISTRIBUTED")) {
+    /*
+     * If the third argument is not null, the launchMON engine
+     * gets invoked via ssh or rsh.
+     */
+    char hn[1024];
+    gethostname(hn, 1024);
+    if ((rc = LMON_fe_launchAndSpawnDaemons(aSession, hn, launcher_argv[0],
+                                            launcher_argv, argv[5], daemon_opts,
+                                            NULL, NULL)) != LMON_OK) {
+      if (getenv("LMON_INVALIDDAEMON_TEST") != NULL) {
+        if (rc == LMON_ETOUT) {
+          fprintf(stdout,
                   "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
-                  return EXIT_SUCCESS;
-                }
-            }
-
-          fprintf ( stdout, "[LMON FE] FAILED\n" );
-          return EXIT_FAILURE;
+          return EXIT_SUCCESS;
+        }
       }
-    }
-  else
-    {
-      if ( ( rc = LMON_fe_launchAndSpawnDaemons( 
-                    aSession, 
-   	            NULL,
-		    launcher_argv[0],
-		    launcher_argv,
-		    argv[5],
-		    daemon_opts,
-		    NULL,
-		    NULL)) 
-                  != LMON_OK )
-        {
-          if ( getenv ("LMON_INVALIDDAEMON_TEST") != NULL )
-            {
-              if ( rc == LMON_ETOUT )
-                {
-                  fprintf ( stdout,
-                    "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
-                  return EXIT_SUCCESS;
-                }
-            }
 
-          fprintf ( stdout, "[LMON FE] FAILED\n" );
-          return EXIT_FAILURE;
-        }
-    }
-
-#if MEASURE_TRACING_COST
-  time_stamp ( "LMON_fe_launchAndSpawnDaemons perf" );
-#endif
- 
-  if ( ( rc = LMON_fe_getProctableSize ( 
-                aSession, 
-                &proctabsize ))
-              !=  LMON_OK )
-    {
-       fprintf ( stdout, 
-         "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
-       return EXIT_FAILURE;
-    }
-
-  if (proctabsize != atoi(argv[2])) 
-    {
-      fprintf ( stdout, 
-        "[LMON FE] FAILED, proctabsize is not equal to the given: %ud\n", 
-        proctabsize);
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
+  } else {
+    if ((rc = LMON_fe_launchAndSpawnDaemons(aSession, NULL, launcher_argv[0],
+                                            launcher_argv, argv[5], daemon_opts,
+                                            NULL, NULL)) != LMON_OK) {
+      if (getenv("LMON_INVALIDDAEMON_TEST") != NULL) {
+        if (rc == LMON_ETOUT) {
+          fprintf(stdout,
+                  "[LMON FE] PASS: returned the LMON_ETOUT error code\n");
+          return EXIT_SUCCESS;
+        }
+      }
 
-  proctab = (MPIR_PROCDESC_EXT*) malloc (
-                proctabsize*sizeof (MPIR_PROCDESC_EXT) );
-  
-  if ( !proctab )
-    {
-       fprintf ( stdout, "[LMON FE] malloc returned null\n");
-       return EXIT_FAILURE;
+      fprintf(stdout, "[LMON FE] FAILED\n");
+      return EXIT_FAILURE;
     }
+  }
 
 #if MEASURE_TRACING_COST
-  begin_timer ();
-#endif 
-  if ( ( rc = LMON_fe_getProctable ( 
-                aSession, 
-                proctab,
-                &psize,
-                proctabsize )) 
-              !=  LMON_OK )
-    {
-       fprintf ( stdout, "[LMON FE] FAILED\n");
-       return EXIT_FAILURE;
-    }
-
-#if MEASURE_TRACING_COST
-  time_stamp ( "LMON_fe_getProctable perf" );
+  time_stamp("LMON_fe_launchAndSpawnDaemons perf");
 #endif
 
-  fprintf ( stdout, 
-    "[LMON FE] Please check the correctness of the following proctable\n");
+  if ((rc = LMON_fe_getProctableSize(aSession, &proctabsize)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
+    return EXIT_FAILURE;
+  }
 
-  for(i=0; i < psize; i++)
-    {
-      fprintf ( stdout, 
-        "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
-      fprintf ( stdout, 
-        "[LMON FE] executable_name: %s\n", proctab[i].pd.executable_name);
-      fprintf ( stdout, 
-        "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid, proctab[i].mpirank);      
-      fprintf ( stdout, "[LMON FE] \n");
-    }
+  if (proctabsize != atoi(argv[2])) {
+    fprintf(stdout,
+            "[LMON FE] FAILED, proctabsize is not equal to the given: %ud\n",
+            proctabsize);
+    return EXIT_FAILURE;
+  }
 
-  rc = LMON_fe_getResourceHandle ( aSession, jobid,
-                	         &jobidsize, PATH_MAX);
-  if ((rc != LMON_OK) && (rc != LMON_EDUNAV))
-    {
-      if ( rc != LMON_EDUNAV ) 
-        {
-          fprintf ( stdout, "[LMON FE] FAILED\n");
-           return EXIT_FAILURE;
-        }
-    }
-  else
-    { 
-      if (rc != LMON_EDUNAV)
-        { 	
-          fprintf ( stdout, 
-            "\n[LMON FE] Please check the correctness of the following resource handle\n");
-          fprintf ( stdout, 
-            "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n", jobid);
-          fprintf ( stdout, 
-            "[LMON FE]");
-       }
-    }
+  proctab =
+      (MPIR_PROCDESC_EXT *)malloc(proctabsize * sizeof(MPIR_PROCDESC_EXT));
 
-  rc = LMON_fe_getRMInfo ( aSession, &rminfo);
-  if (rc != LMON_OK)
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
+  if (!proctab) {
+    fprintf(stdout, "[LMON FE] malloc returned null\n");
+    return EXIT_FAILURE;
+  }
+
+#if MEASURE_TRACING_COST
+  begin_timer();
+#endif
+  if ((rc = LMON_fe_getProctable(aSession, proctab, &psize, proctabsize)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+#if MEASURE_TRACING_COST
+  time_stamp("LMON_fe_getProctable perf");
+#endif
+
+  fprintf(
+      stdout,
+      "[LMON FE] Please check the correctness of the following proctable\n");
+
+  for (i = 0; i < psize; i++) {
+    fprintf(stdout, "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
+    fprintf(stdout, "[LMON FE] executable_name: %s\n",
+            proctab[i].pd.executable_name);
+    fprintf(stdout, "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid,
+            proctab[i].mpirank);
+    fprintf(stdout, "[LMON FE] \n");
+  }
+
+  rc = LMON_fe_getResourceHandle(aSession, jobid, &jobidsize, PATH_MAX);
+  if ((rc != LMON_OK) && (rc != LMON_EDUNAV)) {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
-  else
-   {
-      fprintf ( stdout, 
-         "\n[LMON FE] RM type is %d\n",
-           rminfo.rm_supported_types[rminfo.index_to_cur_instance]);
-      fprintf ( stdout, 
-         "\n[LMON FE] RM launcher's pid is %d\n", rminfo.rm_launcher_pid);
-   }
-
-  if ( (getenv ("LMON_FE_SHUTDOWNBE_TEST")) != NULL )
-    {
-      if ( ( rc = LMON_fe_shutdownDaemons ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE]LMON_fe_shutdownBe FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: you must not see the launcher process(es) that control(s) kicker daemons\n");
-           return EXIT_SUCCESS;
-        }
+  } else {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout,
+              "\n[LMON FE] Please check the correctness of the following "
+              "resource handle\n");
+      fprintf(stdout,
+              "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n",
+              jobid);
+      fprintf(stdout, "[LMON FE]");
     }
+  }
 
-  if ( (getenv ("LMON_FE_KILL_TEST")) != NULL )
-    {
-      sleep(10);
-      if ( ( rc = LMON_fe_kill ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE] LMON_fe_kill FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: you must not see the launcher process(es) nor the launchmon process.\n");
-           return EXIT_SUCCESS;
-        }
-    }
+  rc = LMON_fe_getRMInfo(aSession, &rminfo);
+  if (rc != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  } else {
+    fprintf(stdout, "\n[LMON FE] RM type is %d\n",
+            rminfo.rm_supported_types[rminfo.index_to_cur_instance]);
+    fprintf(stdout, "\n[LMON FE] RM launcher's pid is %d\n",
+            rminfo.rm_launcher_pid);
+  }
 
-  if ( (getenv ("LMON_FE_DETACH_TEST")) != NULL )
-    {
-      if ( ( rc = LMON_fe_detach ( aSession ) ) != LMON_OK )
-        {
-           fprintf ( stdout, "[LMON FE] LMON_fe_kill FAILED\n");
-           return EXIT_FAILURE;
-        }
-      else
-        {
-           system ("ps x");
-           fprintf ( stdout, "[LMON FE] CHECK for LMON_fe_detach\n");
-           fprintf ( stdout, "[LMON FE] PASS Criteria: launcher process(es) must not be traced.\n");
-        }
-    }
-
-  rc = LMON_fe_recvUsrDataBe ( aSession, NULL );
-
-  if ( (rc == LMON_EBDARG ) 
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
+  if ((getenv("LMON_FE_SHUTDOWNBE_TEST")) != NULL) {
+    if ((rc = LMON_fe_shutdownDaemons(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE]LMON_fe_shutdownBe FAILED\n");
       return EXIT_FAILURE;
-    } 
-
-  rc = LMON_fe_sendUsrDataBe ( aSession, NULL );
-
-  if ( (rc == LMON_EBDARG ) 
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    } 
-
-  if (getenv ("LMON_ADDITIONAL_FE_STALL"))
-    {
-      sleep (120);
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: you must not see the launcher "
+              "process(es) that control(s) kicker daemons\n");
+      return EXIT_SUCCESS;
     }
+  }
 
-  fprintf ( stdout, 
-    "\n[LMON FE] PASS: run through the end\n");
+  if ((getenv("LMON_FE_KILL_TEST")) != NULL) {
+    sleep(10);
+    if ((rc = LMON_fe_kill(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] LMON_fe_kill FAILED\n");
+      return EXIT_FAILURE;
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_kill\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: you must not see the launcher "
+              "process(es) nor the launchmon process.\n");
+      return EXIT_SUCCESS;
+    }
+  }
+
+  if ((getenv("LMON_FE_DETACH_TEST")) != NULL) {
+    if ((rc = LMON_fe_detach(aSession)) != LMON_OK) {
+      fprintf(stdout, "[LMON FE] LMON_fe_kill FAILED\n");
+      return EXIT_FAILURE;
+    } else {
+      system("ps x");
+      fprintf(stdout, "[LMON FE] CHECK for LMON_fe_detach\n");
+      fprintf(stdout,
+              "[LMON FE] PASS Criteria: launcher process(es) must not be "
+              "traced.\n");
+    }
+  }
+
+  rc = LMON_fe_recvUsrDataBe(aSession, NULL);
+
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  rc = LMON_fe_sendUsrDataBe(aSession, NULL);
+
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if (getenv("LMON_ADDITIONAL_FE_STALL")) {
+    sleep(120);
+  }
+
+  fprintf(stdout, "\n[LMON FE] PASS: run through the end\n");
 
   return EXIT_SUCCESS;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/fe_launch_usrpayload_test.cxx
+++ b/test/src/fe_launch_usrpayload_test.cxx
@@ -1,495 +1,383 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
  *--------------------------------------------------------------------------------
  *
- *  Update Log: 
+ *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
- *        Jun 17 2008 DHA: Added BlueGene support 
+ *        Jun 17 2008 DHA: Added BlueGene support
  *        Jun 12 2008 DHA: Added GNU build system support
- *        Feb 09 2008 DHA: Added LLNS Copyright. 
- *        Aug 06 2007 DHA: Created file   
+ *        Feb 09 2008 DHA: Added LLNS Copyright.
+ *        Aug 06 2007 DHA: Created file
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
 #include "config.h"
 #endif
 
+#include <limits.h>
 #include <lmon_api/common.h>
 #include <unistd.h>
-#include <limits.h>
-#include <string>
 #include <map>
+#include <string>
 
-#include <lmon_api/lmon_proctab.h>
 #include <lmon_api/lmon_fe.h>
+#include <lmon_api/lmon_proctab.h>
 
-const int MAXPROCOUNT  = 12000;
+const int MAXPROCOUNT = 12000;
 
 /*
  * OUR PARALLEL JOB LAUNCHER
  */
 char mylauncher[PATH_MAX];
 
-std::map<std::string, int> usrdata; // this will have "hostname," "port" pair
-std::map<std::string, int> recvdata; // this will have "hostname," "port" pair echoed back from BE
+std::map<std::string, int> usrdata;  // this will have "hostname," "port" pair
+std::map<std::string, int>
+    recvdata;  // this will have "hostname," "port" pair echoed back from BE
 
-
-static int
-fill_usrdata ( )
-{
+static int fill_usrdata() {
   using namespace std;
 
   int i;
 
   //
-  // 128 is an arbitrary number; i.e. emulating 
+  // 128 is an arbitrary number; i.e. emulating
   // 128 ip/port pair vector
   //
-  for ( i=0; i < 128; ++i )
-    {
-      char hnconcat[128];
+  for (i = 0; i < 128; ++i) {
+    char hnconcat[128];
 
-      if ( i < 0 )
-        break;
+    if (i < 0) break;
 
-      if ( i < 10 )
-        {
-          sprintf ( hnconcat, 
-            "myhostname00%d.llnl.gov", i); // faking a hostname 
-        }
-      else if ( i < 100 )
-        {
-          sprintf ( hnconcat, 
-            "myhostname0%d.llnl.gov", i); // faking a hostname
-        }
-      else if ( i < 1000 )
-        {
-          sprintf ( hnconcat, 
-            "myhostname%d.llnl.gov", i);  // faking a hostname
-        }
-
-      usrdata[string(hnconcat)] = i+1024; // faking a port 
+    if (i < 10) {
+      sprintf(hnconcat, "myhostname00%d.llnl.gov", i);  // faking a hostname
+    } else if (i < 100) {
+      sprintf(hnconcat, "myhostname0%d.llnl.gov", i);  // faking a hostname
+    } else if (i < 1000) {
+      sprintf(hnconcat, "myhostname%d.llnl.gov", i);  // faking a hostname
     }
+
+    usrdata[string(hnconcat)] = i + 1024;  // faking a port
+  }
 
   return 0;
 }
 
-
-static int 
-packfebe_cb ( void *udata, 
-              void *msgbuf, 
-              int msgbufmax, 
-              int *msgbuflen )
-{
+static int packfebe_cb(void *udata, void *msgbuf, int msgbufmax,
+                       int *msgbuflen) {
   using namespace std;
 
-  char *trav  = (char *) msgbuf;
+  char *trav = (char *)msgbuf;
   int usedbuf = 0;
-  int trun    = 0;
+  int trun = 0;
 
-  map<string, int>* u = ( map<string, int>* ) udata; 
-  map<string, int>& myudata =  *u;
-  map<string, int>::const_iterator iter; 
+  map<string, int> *u = (map<string, int> *)udata;
+  map<string, int> &myudata = *u;
+  map<string, int>::const_iterator iter;
 
-  if ( ( msgbuf == NULL ) || ( msgbufmax < 0) )
-    return -1; 
+  if ((msgbuf == NULL) || (msgbufmax < 0)) return -1;
 
-  for ( iter = myudata.begin(); iter != myudata.end(); iter++)
-    {
-      int accum_len = usedbuf + iter->first.size() + + sizeof(int);
-      if ( accum_len > msgbufmax )
-        {
-          trun = 1; 
-          break;
-        } 
-
-      memcpy ( (void*) trav, iter->first.c_str(), iter->first.size()+1); 
-      trav += iter->first.size()+1; 
-      memcpy ( (void*) trav, (void*) &(iter->second), sizeof (int) );
-      trav += sizeof (int); 
-      usedbuf += iter->first.size()+1+sizeof (int);
+  for (iter = myudata.begin(); iter != myudata.end(); iter++) {
+    int accum_len = usedbuf + iter->first.size() + +sizeof(int);
+    if (accum_len > msgbufmax) {
+      trun = 1;
+      break;
     }
 
-   (*msgbuflen) = usedbuf;
+    memcpy((void *)trav, iter->first.c_str(), iter->first.size() + 1);
+    trav += iter->first.size() + 1;
+    memcpy((void *)trav, (void *)&(iter->second), sizeof(int));
+    trav += sizeof(int);
+    usedbuf += iter->first.size() + 1 + sizeof(int);
+  }
 
-   return ((trun == 0) ? 0 : -1);
+  (*msgbuflen) = usedbuf;
+
+  return ((trun == 0) ? 0 : -1);
 }
 
-
-static int
-unpackbefe_cb  ( void* udatabuf, 
-		 int udatabuflen, 
-		 void* udata )
-{
+static int unpackbefe_cb(void *udatabuf, int udatabuflen, void *udata) {
   using namespace std;
 
-  char *trav  = (char*) udatabuf;
+  char *trav = (char *)udatabuf;
   int usedbuf = 0;
-  map<string, int> *u = ( map<string, int> *) udata; 
+  map<string, int> *u = (map<string, int> *)udata;
   map<string, int> &myudata = *u;
 
-  while ( usedbuf < udatabuflen )
-    {
-      myudata[string(trav)] = (int) *(trav+strlen(trav)+1);
-      usedbuf += strlen(trav)+1+sizeof(int);
-      trav += strlen(trav)+1+sizeof(int);
-    }
-  
+  while (usedbuf < udatabuflen) {
+    myudata[string(trav)] = (int)*(trav + strlen(trav) + 1);
+    usedbuf += strlen(trav) + 1 + sizeof(int);
+    trav += strlen(trav) + 1 + sizeof(int);
+  }
+
   return 0;
 }
 
-
-int 
-main (int argc, char* argv[])
-{
+int main(int argc, char *argv[]) {
   using namespace std;
-  
-  int aSession    = 0;
-  unsigned int psize       = 0;
+
+  int aSession = 0;
+  unsigned int psize = 0;
   unsigned int proctabsize = 0;
-  int jobidsize   = 0;
-  int i           = 0;
-  char jobid[PATH_MAX]        = {0};
-  char **launcher_argv        = NULL;
-  char **daemon_opts          = NULL;
-  MPIR_PROCDESC_EXT *proctab  = NULL;
+  int jobidsize = 0;
+  int i = 0;
+  char jobid[PATH_MAX] = {0};
+  char **launcher_argv = NULL;
+  char **daemon_opts = NULL;
+  MPIR_PROCDESC_EXT *proctab = NULL;
 
   lmon_rc_e rc;
   string numprocs_opt;
   string numnodes_opt;
   string partition_opt;
 
-  if ( argc < 6 )
-    {
-      fprintf ( stdout, 
-        "Usage: fe_launch_smoketest appcode numprocs numnodes partition daemonpath [daemonargs]\n" );
-      fprintf ( stdout, 
-        "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;	      
-    }
+  if (argc < 6) {
+    fprintf(stdout,
+            "Usage: fe_launch_smoketest appcode numprocs numnodes partition "
+            "daemonpath [daemonargs]\n");
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-  if ( access(argv[1], X_OK) < 0 )
-    {
-      fprintf ( stdout, 
-        "%s cannot be executed\n", 
-        argv[1] );
-      fprintf ( stdout, 
-        "[LMON FE] FAILED\n" );
-      return EXIT_FAILURE;     
-    }
+  if (access(argv[1], X_OK) < 0) {
+    fprintf(stdout, "%s cannot be executed\n", argv[1]);
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-  if ( access(argv[5], X_OK) < 0 )
-    {
-      fprintf(stdout, 
-        "%s cannot be executed\n", 
-        argv[2]);
-      fprintf(stdout, 
-        "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;	      
-    }
-  if ( argc > 6 )
-    daemon_opts = argv+6;
+  if (access(argv[5], X_OK) < 0) {
+    fprintf(stdout, "%s cannot be executed\n", argv[2]);
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+  if (argc > 6) daemon_opts = argv + 6;
 
-  fill_usrdata (); // filling in user data 
+  fill_usrdata();  // filling in user data
 
   char *rmenv = getenv("MPI_JOB_LAUNCHER_PATH");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "MPI_JOB_LAUNCHER_PATH envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "MPI_JOB_LAUNCHER_PATH envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   snprintf(mylauncher, PATH_MAX, "%s", rmenv);
 
   rmenv = getenv("RM_TYPE");
-  if (!rmenv)
-    {
-      fprintf(stdout,
-        "RM_TYPE envVar must be given\n" );
-      return EXIT_FAILURE;
-    }
+  if (!rmenv) {
+    fprintf(stdout, "RM_TYPE envVar must be given\n");
+    return EXIT_FAILURE;
+  }
 
   std::string rmenv_str = rmenv;
-  if ((rmenv_str == std::string("RC_bgqrm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("--verbose");
-      launcher_argv[2] = strdup("5");
-      launcher_argv[3] = strdup("--np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("--exe"); 
-      launcher_argv[6] = strdup(argv[1]); 
-      // manually fill the block
-      // launcher_argv[7] = strdup("--block");
-      // launcher_argv[8] = strdup("R00-M0-N04"); 
-      // manually fill the corner
-      // launcher_argv[9] = strdup("--corner");
-      // launcher_argv[10] = strdup("R00-M0-N04-J07");
-      // manually fill the shape 
-      // launcher_argv[11] = strdup("--shape");
-      // launcher_argv[12] = strdup("1x1x1x1x1");
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-        "[LMON_FE] launching the job/daemons via %s\n",
-        mylauncher);
-    }
-  else if ((rmenv_str == std::string("RC_bgq_slurm")))
-    {
-      launcher_argv = (char **) malloc(7*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-N");
-      launcher_argv[2] = strdup(argv[3]);
-      launcher_argv[3] = strdup("-n");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-      fprintf (stdout,
-        "[LMON_FE] launching the job/daemons via %s\n",
-        "mylauncher");
-    }
-  else if ((rmenv_str == std::string("RC_bglrm"))
-      || (rmenv_str == std::string("RC_bgprm")))
-    {
-      launcher_argv = (char **) malloc(8*sizeof(char *));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-verbose");
-      launcher_argv[2] = strdup("1");
-      launcher_argv[3] = strdup("-np");
-      launcher_argv[4] = strdup(argv[2]);
-      launcher_argv[5] = strdup("-exe");
-      launcher_argv[6] = strdup(argv[1]);
-      launcher_argv[7] = NULL;
-      fprintf (stdout,
-                "[LMON_FE] launching the job/daemons via %s\n",
-                mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_slurm"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      numnodes_opt     = string("-N") + string(argv[3]);
-      partition_opt    = string("-p") + string(argv[4]);
-      launcher_argv    = (char **) malloc (7*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(numnodes_opt.c_str());
-      launcher_argv[3] = strdup(partition_opt.c_str());
-      launcher_argv[4] = strdup("-l");
-      launcher_argv[5] = strdup(argv[1]);
-      launcher_argv[6] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_alps"))
-    {
-      numprocs_opt     = string("-n") + string(argv[2]);
-      launcher_argv    = (char**) malloc(4*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup(numprocs_opt.c_str());
-      launcher_argv[2] = strdup(argv[1]);
-      launcher_argv[3] = NULL;
-    }
-  else if (rmenv_str == std::string("RC_orte"))
-    {
-      launcher_argv    = (char **) malloc(8*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-mca");
-      launcher_argv[2] = strdup("debugger");
-      launcher_argv[3] = strdup("mpirx");
-      launcher_argv[4] = strdup("-np");
-      launcher_argv[5] = strdup(argv[2]);
-      launcher_argv[6] = strdup(argv[1]);
-      launcher_argv[7] = NULL;
-      fprintf (stdout, 
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
-  else if (rmenv_str == std::string("RC_mpiexec_hydra"))
-    {
-      launcher_argv    = (char **) malloc(5*sizeof(char*));
-      launcher_argv[0] = strdup(mylauncher);
-      launcher_argv[1] = strdup("-n");
-      launcher_argv[2] = strdup(argv[2]);
-      launcher_argv[3] = strdup(argv[1]);
-      launcher_argv[4] = NULL;
-      fprintf (stdout,
-               "[LMON_FE] launching the job/daemons via %s\n",
-               mylauncher);
-    }
+  if ((rmenv_str == std::string("RC_bgqrm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("--verbose");
+    launcher_argv[2] = strdup("5");
+    launcher_argv[3] = strdup("--np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("--exe");
+    launcher_argv[6] = strdup(argv[1]);
+    // manually fill the block
+    // launcher_argv[7] = strdup("--block");
+    // launcher_argv[8] = strdup("R00-M0-N04");
+    // manually fill the corner
+    // launcher_argv[9] = strdup("--corner");
+    // launcher_argv[10] = strdup("R00-M0-N04-J07");
+    // manually fill the shape
+    // launcher_argv[11] = strdup("--shape");
+    // launcher_argv[12] = strdup("1x1x1x1x1");
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if ((rmenv_str == std::string("RC_bgq_slurm"))) {
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-N");
+    launcher_argv[2] = strdup(argv[3]);
+    launcher_argv[3] = strdup("-n");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n",
+            "mylauncher");
+  } else if ((rmenv_str == std::string("RC_bglrm")) ||
+             (rmenv_str == std::string("RC_bgprm"))) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-verbose");
+    launcher_argv[2] = strdup("1");
+    launcher_argv[3] = strdup("-np");
+    launcher_argv[4] = strdup(argv[2]);
+    launcher_argv[5] = strdup("-exe");
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_slurm")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    numnodes_opt = string("-N") + string(argv[3]);
+    partition_opt = string("-p") + string(argv[4]);
+    launcher_argv = (char **)malloc(7 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(numnodes_opt.c_str());
+    launcher_argv[3] = strdup(partition_opt.c_str());
+    launcher_argv[4] = strdup("-l");
+    launcher_argv[5] = strdup(argv[1]);
+    launcher_argv[6] = NULL;
+  } else if (rmenv_str == std::string("RC_alps")) {
+    numprocs_opt = string("-n") + string(argv[2]);
+    launcher_argv = (char **)malloc(4 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup(numprocs_opt.c_str());
+    launcher_argv[2] = strdup(argv[1]);
+    launcher_argv[3] = NULL;
+  } else if (rmenv_str == std::string("RC_orte")) {
+    launcher_argv = (char **)malloc(8 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-mca");
+    launcher_argv[2] = strdup("debugger");
+    launcher_argv[3] = strdup("mpirx");
+    launcher_argv[4] = strdup("-np");
+    launcher_argv[5] = strdup(argv[2]);
+    launcher_argv[6] = strdup(argv[1]);
+    launcher_argv[7] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  } else if (rmenv_str == std::string("RC_mpiexec_hydra")) {
+    launcher_argv = (char **)malloc(5 * sizeof(char *));
+    launcher_argv[0] = strdup(mylauncher);
+    launcher_argv[1] = strdup("-n");
+    launcher_argv[2] = strdup(argv[2]);
+    launcher_argv[3] = strdup(argv[1]);
+    launcher_argv[4] = NULL;
+    fprintf(stdout, "[LMON_FE] launching the job/daemons via %s\n", mylauncher);
+  }
 
-  if ( ( rc = LMON_fe_init ( LMON_VERSION ) ) 
-              != LMON_OK )
-    {
-      fprintf ( stdout, 
-        "[LMON FE] LMON_fe_init FAILED\n" );
+  if ((rc = LMON_fe_init(LMON_VERSION)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] LMON_fe_init FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_createSession(&aSession)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] LMON_fe_createFEBESession FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_regPackForFeToBe(aSession, packfebe_cb)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] LMON_fe_regPackForFeToBe FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_regUnpackForBeToFe(aSession, unpackbefe_cb)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] LMON_fe_regUnpackForBeToFe FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_launchAndSpawnDaemons(aSession, NULL, launcher_argv[0],
+                                          launcher_argv, argv[5], daemon_opts,
+                                          &usrdata, &recvdata)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] LMON_fe_launchAndSpawnDaemons FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_getProctableSize(aSession, &proctabsize)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
+    return EXIT_FAILURE;
+  }
+
+  proctab =
+      (MPIR_PROCDESC_EXT *)malloc(proctabsize * sizeof(MPIR_PROCDESC_EXT));
+
+  if (!proctab) {
+    fprintf(stdout, "[LMON FE] malloc returned null\n");
+    return EXIT_FAILURE;
+  }
+
+  if ((rc = LMON_fe_getProctable(aSession, proctab, &psize, proctabsize)) !=
+      LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
+
+  fprintf(
+      stdout,
+      "[LMON FE] Please check the correctness of the following proctable\n");
+
+  for (i = 0; i < psize; i++) {
+    fprintf(stdout, "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
+    fprintf(stdout, "[LMON FE] executable_name: %s\n",
+            proctab[i].pd.executable_name);
+    fprintf(stdout, "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid,
+            proctab[i].mpirank);
+    fprintf(stdout, "[LMON FE] \n");
+  }
+
+  rc = LMON_fe_getResourceHandle(aSession, jobid, &jobidsize, PATH_MAX);
+  if ((rc != LMON_OK) && (rc != LMON_EDUNAV)) {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout, "[LMON FE] FAILED\n");
       return EXIT_FAILURE;
     }
-
-  if ( ( rc = LMON_fe_createSession (&aSession)) 
-              != LMON_OK)
-    {
-      fprintf ( stdout, 
-        "[LMON FE] LMON_fe_createFEBESession FAILED\n");
-      return EXIT_FAILURE;
+  } else {
+    if (rc != LMON_EDUNAV) {
+      fprintf(stdout,
+              "\n[LMON FE] Please check the correctness of the following "
+              "resource handle\n");
+      fprintf(stdout,
+              "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n",
+              jobid);
+      fprintf(stdout, "[LMON FE]");
     }
+  }
 
-  if ( ( rc = LMON_fe_regPackForFeToBe (
-		aSession,
-                packfebe_cb ))  
-              != LMON_OK )
-     {
-       fprintf ( stdout,
-        "[LMON FE] LMON_fe_regPackForFeToBe FAILED\n");
-       return EXIT_FAILURE;
-     } 
+  if ((LMON_fe_sendUsrDataBe(aSession, (void *)&usrdata)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
 
-  if ( ( rc = LMON_fe_regUnpackForBeToFe (
-                aSession,
-                unpackbefe_cb ))  
-              != LMON_OK )
-     {
-       fprintf ( stdout,
-        "[LMON FE] LMON_fe_regUnpackForBeToFe FAILED\n");
-       return EXIT_FAILURE;
-     }  
+    return EXIT_FAILURE;
+  }
 
-  if ( ( rc = LMON_fe_launchAndSpawnDaemons ( 
-                aSession, 
-                NULL,
-		launcher_argv[0],
-		launcher_argv,
-		argv[5],
-		daemon_opts,
-		&usrdata,
-		&recvdata)) 
-              != LMON_OK )
-    {
-      fprintf ( stdout, 
-        "[LMON FE] LMON_fe_launchAndSpawnDaemons FAILED\n" );
-      return EXIT_FAILURE;
-    }
+  if ((LMON_fe_recvUsrDataBe(aSession, (void *)&recvdata)) != LMON_OK) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
 
-  if ( ( rc = LMON_fe_getProctableSize (
-                aSession,
-                &proctabsize ))
-              !=  LMON_OK )
-    {
-       fprintf ( stdout,
-         "[LMON FE] FAILED in LMON_fe_getProctableSize\n");
-       return EXIT_FAILURE;
-    }
- 
-  proctab = (MPIR_PROCDESC_EXT*) malloc (
-                 proctabsize*sizeof (MPIR_PROCDESC_EXT) );
+    return EXIT_FAILURE;
+  }
 
-  if ( !proctab )
-    {
-       fprintf ( stdout, "[LMON FE] malloc returned null\n");
-       return EXIT_FAILURE;
-    }
+  rc = LMON_fe_recvUsrDataBe(aSession, NULL);
 
-  if ( ( rc = LMON_fe_getProctable ( 
-                aSession, 
-                proctab,
-                &psize,
-                proctabsize )) 
-              !=  LMON_OK )
-    {
-       fprintf ( stdout, 
-         "[LMON FE] FAILED\n");
-       return EXIT_FAILURE;
-    }
+  if ((rc == LMON_EBDARG) || (rc == LMON_ENOMEM) || (rc == LMON_EINVAL)) {
+    fprintf(stdout, "[LMON FE] FAILED\n");
+    return EXIT_FAILURE;
+  }
 
-  fprintf ( stdout, 
-            "[LMON FE] Please check the correctness of the following proctable\n");
+  sleep(3);
 
-  for(i=0; i < psize; i++)
-    {
-      fprintf ( stdout, 
-        "[LMON FE] host_name: %s\n", proctab[i].pd.host_name);
-      fprintf ( stdout, 
-        "[LMON FE] executable_name: %s\n", proctab[i].pd.executable_name);
-      fprintf ( stdout, 
-        "[LMON FE] pid: %d(rank %d)\n", proctab[i].pd.pid, proctab[i].mpirank);      
-      fprintf ( stdout, "[LMON FE] \n");
-    }
+  fprintf(stdout, "\n[LMON FE] PASS: run through the end\n");
 
-  rc = LMON_fe_getResourceHandle ( aSession, jobid,
-                                 &jobidsize, PATH_MAX);
-  if ((rc != LMON_OK) && (rc != LMON_EDUNAV))
-    {
-      if ( rc != LMON_EDUNAV )
-        {
-          fprintf ( stdout, "[LMON FE] FAILED\n");
-           return EXIT_FAILURE;
-        }
-    }
-  else
-    {
-      if (rc != LMON_EDUNAV)
-        {
-          fprintf ( stdout,
-            "\n[LMON FE] Please check the correctness of the following resource handle\n");
-          fprintf ( stdout,
-            "[LMON FE] resource handle[jobid or job launcher's pid]: %s\n", jobid);
-          fprintf ( stdout,
-            "[LMON FE]");
-       }
-    }
-
-  if ( ( LMON_fe_sendUsrDataBe ( aSession, (void*) &usrdata ) ) 
-       != LMON_OK )
-    {
-       fprintf ( stdout, "[LMON FE] FAILED\n");
-    
-       return EXIT_FAILURE;
-    }
-
-  if ( ( LMON_fe_recvUsrDataBe ( aSession, (void*) &recvdata ) ) 
-       != LMON_OK )
-    {
-       fprintf ( stdout, "[LMON FE] FAILED\n");
-    
-       return EXIT_FAILURE;
-    }
-
-  rc = LMON_fe_recvUsrDataBe ( aSession, NULL );
-
-  if ( (rc == LMON_EBDARG )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_EINVAL ) )
-    {
-      fprintf ( stdout, "[LMON FE] FAILED\n");
-      return EXIT_FAILURE;
-    }
-
-
-  sleep (3);
-
-  fprintf ( stdout,
-    "\n[LMON FE] PASS: run through the end\n");
-  
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/hang_on_SIGUSR1.c
+++ b/test/src/hang_on_SIGUSR1.c
@@ -1,37 +1,38 @@
 /*
- * $Header: /usr/gapps/asde/cvs-vault/sdb/testcases/src/linux/hang_on_SIGUSR1.c,v 1.3.2.2 2008/02/21 09:26:38 dahn Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
- *        Jun 13 2008 DHA: Added GNU build system support. 
- *        Mar 21 2008 DHA: Beautified the code a bit.  
- *        Mar 18 2008 DHA: Added BlueGene support. (Fixing a File IO bug) 
+ *        Jun 13 2008 DHA: Added GNU build system support.
+ *        Mar 21 2008 DHA: Beautified the code a bit.
+ *        Mar 18 2008 DHA: Added BlueGene support. (Fixing a File IO bug)
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *          
+ *
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -41,29 +42,29 @@
 #include <lmon_api/common.h>
 
 /*
- * This program may interfere with MPI implementations that 
- * use USR2 signal. 
- */ 
-                                                                  
+ * This program may interfere with MPI implementations that
+ * use USR2 signal.
+ */
+
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
 /* work around for a compiler problem on BlueGene/L */
 #undef SEEK_SET
 #undef SEEK_END
 #undef SEEK_CUR
 #endif
-                                                                  
+
 #include <mpi.h>
 #include <signal.h>
-                                                                  
-#define COMM_TAG              1000
-#define MAX_BUF_LEN           1024
-#define COMPUTE_UNIT          20
+
+#define COMM_TAG 1000
+#define MAX_BUF_LEN 1024
+#define COMPUTE_UNIT 20
 #define SLEEP_FOR_COMPUTE_SEC 3
 
-#include <stdarg.h>
 #include <limits.h>
-#include <time.h>
+#include <stdarg.h>
 #include <sys/time.h>
+#include <time.h>
 
 //
 // For the performance study of 4K-byte block fetching
@@ -75,9 +76,7 @@ double FETCH_ME_DBL_ARRAY[FETCH_ME_ARRAY_SIZE];
 static int global_stall = 1;
 static int global_rank = -1;
 
-static void
-LMON_say_msg ( const char* m, const char* output, ... )
-{
+static void LMON_say_msg(const char* m, const char* output, ...) {
   va_list ap;
   char timelog[PATH_MAX];
   char log[PATH_MAX];
@@ -86,7 +85,7 @@ LMON_say_msg ( const char* m, const char* output, ... )
   const char ei_str[] = "INFO";
 
   time(&t);
-  strftime ( timelog, PATH_MAX, format, localtime(&t));
+  strftime(timelog, PATH_MAX, format, localtime(&t));
   snprintf(log, PATH_MAX, "<%s> %s (%s): %s\n", timelog, m, "INFO", output);
 
   va_start(ap, output);
@@ -94,96 +93,85 @@ LMON_say_msg ( const char* m, const char* output, ... )
   va_end(ap);
 }
 
-static void
-init_FETCH_ME_DBL_ARRAY()
-{
-  int i=0;
-  for (i=0; i < FETCH_ME_ARRAY_SIZE; ++i)
-    {
-      FETCH_ME_DBL_ARRAY[i] = (double) i+1;
-    }
+static void init_FETCH_ME_DBL_ARRAY() {
+  int i = 0;
+  for (i = 0; i < FETCH_ME_ARRAY_SIZE; ++i) {
+    FETCH_ME_DBL_ARRAY[i] = (double)i + 1;
+  }
 #if 0
   char *tmp = (char*)FETCH_ME_DBL_ARRAY;
   fprintf (stdout, "[LMON APP] address: 0x%x\n", FETCH_ME_DBL_ARRAY);
   fprintf (stdout, "[LMON APP] 1st: 0x%x, %f\n", &FETCH_ME_DBL_ARRAY[0], FETCH_ME_DBL_ARRAY[0]);
-  fprintf (stdout, "[LMON APP] 1st: %x %x %x %x %x %x %x %x \n", tmp[0], tmp[1], tmp[2], tmp[3], 
+  fprintf (stdout, "[LMON APP] 1st: %x %x %x %x %x %x %x %x \n", tmp[0], tmp[1], tmp[2], tmp[3],
                                                                  tmp[4], tmp[5], tmp[6], tmp[7]);
   tmp = (char*)&FETCH_ME_DBL_ARRAY[512];
   fprintf (stdout, "[LMON APP] 512th: 0x%x %f\n", &FETCH_ME_DBL_ARRAY[512], FETCH_ME_DBL_ARRAY[512]);
-  fprintf (stdout, "[LMON APP] 1st: %x %x %x %x %x %x %x %x \n", tmp[0], tmp[1], tmp[2], tmp[3], 
+  fprintf (stdout, "[LMON APP] 1st: %x %x %x %x %x %x %x %x \n", tmp[0], tmp[1], tmp[2], tmp[3],
                                                                  tmp[4], tmp[5], tmp[6], tmp[7]);
 #endif
 }
 
-void 
-sighandler (int sig) 
-{
-  if ( sig == SIGUSR1)
-  {
-    global_stall = 0; /* unlock the hang */ 
-    if (!global_rank)
-      {
-        fprintf (stdout, "[LMON APP] * Received SIGUSR1  * \n");
-      }
+void sighandler(int sig) {
+  if (sig == SIGUSR1) {
+    global_stall = 0; /* unlock the hang */
+    if (!global_rank) {
+      fprintf(stdout, "[LMON APP] * Received SIGUSR1  * \n");
+    }
   }
   return;
-} 
+}
 
-
-static void 
-pass_its_neighbor(const int rank, const int size, int* buf)
-{  
+static void pass_its_neighbor(const int rank, const int size, int* buf) {
   MPI_Request request[2];
   MPI_Status status[2];
 
-  MPI_Irecv((void*)buf, 1, MPI_INT, ((rank+size-1)%size), COMM_TAG, MPI_COMM_WORLD, &request[0]);
-  MPI_Isend((void*)&rank, 1, MPI_INT, ((rank+1)%size), COMM_TAG, MPI_COMM_WORLD, &request[1]);
+  MPI_Irecv((void*)buf, 1, MPI_INT, ((rank + size - 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[0]);
+  MPI_Isend((void*)&rank, 1, MPI_INT, ((rank + 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[1]);
   MPI_Waitall(2, request, status);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-
-int 
-main(int argc, char* argv[])
-{
-  int size, rank, i;  
+int main(int argc, char* argv[]) {
+  int size, rank, i;
   int buf;
 
   MPI_Init(&argc, &argv);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  init_FETCH_ME_DBL_ARRAY ();
+  init_FETCH_ME_DBL_ARRAY();
   signal(SIGUSR1, sighandler);
   global_rank = rank;
-  if (rank == 0) 
-    fprintf(stdout, "[LMON APP] singal handler installed for signum=%d\n", SIGUSR1); 
- 
-  while(global_stall == 1 ) {
+  if (rank == 0)
+    fprintf(stdout, "[LMON APP] singal handler installed for signum=%d\n",
+            SIGUSR1);
+
+  while (global_stall == 1) {
     if (rank == 0)
-      LMON_say_msg ( "APP", "stall for %d secs", SLEEP_FOR_COMPUTE_SEC );  
+      LMON_say_msg("APP", "stall for %d secs", SLEEP_FOR_COMPUTE_SEC);
     sleep(SLEEP_FOR_COMPUTE_SEC);
   }
 
-  if (rank == 0)
-    fprintf(stdout, "The hang unlocked\n");
+  if (rank == 0) fprintf(stdout, "The hang unlocked\n");
 
   pass_its_neighbor(rank, size, &buf);
 
   int remain = COMPUTE_UNIT * SLEEP_FOR_COMPUTE_SEC;
-  for (i=0; i < COMPUTE_UNIT; i++)
-    {
-      sleep(SLEEP_FOR_COMPUTE_SEC);
-      remain -= SLEEP_FOR_COMPUTE_SEC;
-      if (rank == 0)
-        LMON_say_msg ( "APP", "%d secs remain", remain);
-    }
+  for (i = 0; i < COMPUTE_UNIT; i++) {
+    sleep(SLEEP_FOR_COMPUTE_SEC);
+    remain -= SLEEP_FOR_COMPUTE_SEC;
+    if (rank == 0) LMON_say_msg("APP", "%d secs remain", remain);
+  }
 
-  if (rank == 0)
-    LMON_say_msg ( "APP", "size of this program is %d\n", size);
+  if (rank == 0) LMON_say_msg("APP", "size of this program is %d\n", size);
 
   MPI_Finalize();
   return EXIT_SUCCESS;
 }
 
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/mw_comm_helper.cxx
+++ b/test/src/mw_comm_helper.cxx
@@ -1,29 +1,30 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
-
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Aug 2 2010 DHA: Created file
@@ -34,11 +35,11 @@
 #endif
 
 #include <lmon_api/common.h>
-#include <iostream>
 #include <lmon_api/lmon_mw.h>
+#include <iostream>
 
-#define COMMUNICATION_UNIT          7 
-#define SLEEP_FOR_COMM_SEC          3
+#define COMMUNICATION_UNIT 7
+#define SLEEP_FOR_COMM_SEC 3
 
 /*
  * Multi-purpose comm helper daemon for testing
@@ -47,41 +48,28 @@
  *
  */
 
-int
-main( int argc, char* argv[] )
-{
+int main(int argc, char* argv[]) {
   lmon_rc_e rc;
   int size, rank;
 
-  if ( (rc = LMON_mw_init(LMON_VERSION, &argc, &argv))
-              != LMON_OK )
-    {
-      fprintf(stderr,
-        "[COMM HELPER] FAILED: LMON_mw_init\n");
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_mw_init(LMON_VERSION, &argc, &argv)) != LMON_OK) {
+    fprintf(stderr, "[COMM HELPER] FAILED: LMON_mw_init\n");
+    return EXIT_FAILURE;
+  }
 
   LMON_mw_getSize(&size);
   LMON_mw_getMyRank(&rank);
 
-  if ( (rc = LMON_mw_handshake(NULL)) 
-              != LMON_OK )
-    {
-      fprintf(stderr,
-        "[COMM HELPER(%d)] FAILED: LMON_mw_handshake\n",
-        rank );
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_mw_handshake(NULL)) != LMON_OK) {
+    fprintf(stderr, "[COMM HELPER(%d)] FAILED: LMON_mw_handshake\n", rank);
+    return EXIT_FAILURE;
+  }
 
-  if ( (rc = LMON_mw_ready(NULL))
-              != LMON_OK )
-    {
-      fprintf(stderr,
-        "[COMM HELPER(%d)] FAILED: LMON_mw_ready\n",
-        rank );
-      LMON_mw_finalize();
-      return EXIT_FAILURE;
-    }
+  if ((rc = LMON_mw_ready(NULL)) != LMON_OK) {
+    fprintf(stderr, "[COMM HELPER(%d)] FAILED: LMON_mw_ready\n", rank);
+    LMON_mw_finalize();
+    return EXIT_FAILURE;
+  }
 
   //
   //
@@ -90,29 +78,28 @@ main( int argc, char* argv[] )
   //
   int remain = COMMUNICATION_UNIT * SLEEP_FOR_COMM_SEC;
   int i;
-  for (i=0; i < COMMUNICATION_UNIT; i++) 
-    {
-      sleep(SLEEP_FOR_COMM_SEC);
-      remain -= SLEEP_FOR_COMM_SEC;
-      if (rank == 0)
-        fprintf(stdout,
-          "[COMM HELPER(%d)] %d secs remain\n", rank, remain);
-    }
+  for (i = 0; i < COMMUNICATION_UNIT; i++) {
+    sleep(SLEEP_FOR_COMM_SEC);
+    remain -= SLEEP_FOR_COMM_SEC;
+    if (rank == 0)
+      fprintf(stdout, "[COMM HELPER(%d)] %d secs remain\n", rank, remain);
+  }
 
-  // sending this to mark the end of the BE session 
-  // This should be used to determine PASS/FAIL criteria 
-  if ( (( rc = LMON_mw_sendUsrData ( NULL )) == LMON_EBDARG)
-       || ( rc == LMON_EINVAL )
-       || ( rc == LMON_ENOMEM )
-       || ( rc == LMON_ENEGCB ))
-     {
-       fprintf(stdout, "[COMM HELPER(%d)] FAILED(%d): LMON_mw_sendUsrData\n",
-               rank, rc );
-       LMON_mw_finalize();
-       return EXIT_FAILURE;
-     }
+  // sending this to mark the end of the BE session
+  // This should be used to determine PASS/FAIL criteria
+  if (((rc = LMON_mw_sendUsrData(NULL)) == LMON_EBDARG) ||
+      (rc == LMON_EINVAL) || (rc == LMON_ENOMEM) || (rc == LMON_ENEGCB)) {
+    fprintf(stdout, "[COMM HELPER(%d)] FAILED(%d): LMON_mw_sendUsrData\n", rank,
+            rc);
+    LMON_mw_finalize();
+    return EXIT_FAILURE;
+  }
 
   LMON_mw_finalize();
 
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/run_3mins.c
+++ b/test/src/run_3mins.c
@@ -1,43 +1,49 @@
 /*
  * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ *<ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ *License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ *the
+ * terms of the GNU General Public License (as published by the Free Software
  * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ *ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ *along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59
+ *Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2008 DHA: Added generic BlueGene support
  *        Jun 13 2008 DHA: Added GNU build system support.
  *        Mar 18 2008 DHA: Added BlueGene support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
- *          
+ *
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
 #include "config.h"
 #endif
 
-#include <lmon_api/common.h> 
+#include <lmon_api/common.h>
 
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
 /* work around for a compiler problem on BlueGene/L */
@@ -49,29 +55,21 @@
 #include <mpi.h>
 #include <signal.h>
 
-#define COMM_TAG    1000
+#define COMM_TAG 1000
 #define MAX_BUF_LEN 1024
 
-static void 
-pass_its_neighbor(const int rank, const int size, int* buf)
-{  
+static void pass_its_neighbor(const int rank, const int size, int* buf) {
   MPI_Request request[2];
   MPI_Status status[2];
-  //char hn[MAX_BUF_LEN];
-  //gethostname (hn, MAX_BUF_LEN);
-  //printf ("%s\n", hn);
+  // char hn[MAX_BUF_LEN];
+  // gethostname (hn, MAX_BUF_LEN);
+  // printf ("%s\n", hn);
 
-  MPI_Irecv((void*)buf, 1, MPI_INT, 
-   	    ((rank+size-1)%size), 
-	    COMM_TAG, 
-	    MPI_COMM_WORLD, 
-	    &request[0]);
+  MPI_Irecv((void*)buf, 1, MPI_INT, ((rank + size - 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[0]);
 
-  MPI_Isend((void*)&rank, 1, MPI_INT, 
-	    ((rank+1)%size), 
-            COMM_TAG, 
-            MPI_COMM_WORLD, 
-            &request[1]);
+  MPI_Isend((void*)&rank, 1, MPI_INT, ((rank + 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[1]);
 
   MPI_Waitall(2, request, status);
 
@@ -79,28 +77,29 @@ pass_its_neighbor(const int rank, const int size, int* buf)
   sleep(180);
 
   if (rank == 0) {
-     fprintf(stdout, "[LMON APP] size of this program is %d\n", size); 
+    fprintf(stdout, "[LMON APP] size of this program is %d\n", size);
   }
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-
-int 
-main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
   int size;
   int rank;
   int buf;
-  int i;  
+  int i;
 
-  MPI_Init (&argc, &argv);
-  MPI_Comm_size (MPI_COMM_WORLD, &size);
-  MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  pass_its_neighbor (rank, size, &buf);
+  pass_its_neighbor(rank, size, &buf);
 
-  MPI_Finalize ();
+  MPI_Finalize();
 
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/simple_MPI.c
+++ b/test/src/simple_MPI.c
@@ -1,37 +1,38 @@
 /*
- * $Header: $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        Mar 04 2009 DHA: Added generic BG support.
  *        Jun 13 2008 DHA: Added GNU build system support.
- *        Mar 18 2008 DHA: Added BlueGene support. 
+ *        Mar 18 2008 DHA: Added BlueGene support.
  *        Feb 09 2008 DHA: Added LLNS Copyright.
  *        Aug 06 2007 DHA: Created file.
- *          
+ *
  */
 
 #ifndef HAVE_LAUNCHMON_CONFIG_H
@@ -39,29 +40,27 @@
 #endif
 
 #include <lmon_api/common.h>
-                                                                                                                                        
+
 #if SUB_ARCH_BGL || SUB_ARCH_BGP
 /* work around for a compiler problem on BlueGene/L */
 #undef SEEK_SET
 #undef SEEK_END
 #undef SEEK_CUR
 #endif
-                                                                                                                                        
+
 #include <mpi.h>
 #include <signal.h>
-                                                                                                                               
-#define COMM_TAG              1000
-#define MAX_BUF_LEN           1024
-#define COMPUTE_UNIT          20
-#define SLEEP_FOR_COMPUTE_SEC 3
-#include <stdarg.h>
-#include <limits.h>
-#include <time.h>
-#include <sys/time.h>
 
-static void 
-LMON_say_msg ( const char* m, const char* output, ... )
-{
+#define COMM_TAG 1000
+#define MAX_BUF_LEN 1024
+#define COMPUTE_UNIT 20
+#define SLEEP_FOR_COMPUTE_SEC 3
+#include <limits.h>
+#include <stdarg.h>
+#include <sys/time.h>
+#include <time.h>
+
+static void LMON_say_msg(const char* m, const char* output, ...) {
   va_list ap;
   char timelog[PATH_MAX];
   char log[PATH_MAX];
@@ -70,7 +69,7 @@ LMON_say_msg ( const char* m, const char* output, ... )
   const char ei_str[] = "INFO";
 
   time(&t);
-  strftime ( timelog, PATH_MAX, format, localtime(&t));
+  strftime(timelog, PATH_MAX, format, localtime(&t));
   snprintf(log, PATH_MAX, "<%s> %s (%s): %s\n", timelog, m, "INFO", output);
 
   va_start(ap, output);
@@ -78,38 +77,32 @@ LMON_say_msg ( const char* m, const char* output, ... )
   va_end(ap);
 }
 
-static void 
-pass_its_neighbor(const int rank, const int size, int* buf)
-{  
+static void pass_its_neighbor(const int rank, const int size, int* buf) {
   int i;
   MPI_Request request[2];
   MPI_Status status[2];
 
-  MPI_Irecv((void*)buf, 1, MPI_INT, ((rank+size-1)%size), COMM_TAG, MPI_COMM_WORLD, &request[0]);
-  MPI_Isend((void*)&rank, 1, MPI_INT, ((rank+1)%size), COMM_TAG, MPI_COMM_WORLD, &request[1]);
+  MPI_Irecv((void*)buf, 1, MPI_INT, ((rank + size - 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[0]);
+  MPI_Isend((void*)&rank, 1, MPI_INT, ((rank + 1) % size), COMM_TAG,
+            MPI_COMM_WORLD, &request[1]);
   MPI_Waitall(2, request, status);
 
   int remain = COMPUTE_UNIT * SLEEP_FOR_COMPUTE_SEC;
-  for (i=0; i < COMPUTE_UNIT; i++) 
-    {
-      sleep(SLEEP_FOR_COMPUTE_SEC);
-      remain -= SLEEP_FOR_COMPUTE_SEC;
-      if (rank == 0) 
-        LMON_say_msg ( "APP", "%d secs remain", remain);
-    }
+  for (i = 0; i < COMPUTE_UNIT; i++) {
+    sleep(SLEEP_FOR_COMPUTE_SEC);
+    remain -= SLEEP_FOR_COMPUTE_SEC;
+    if (rank == 0) LMON_say_msg("APP", "%d secs remain", remain);
+  }
 
-  if (rank == 0) 
-    LMON_say_msg ( "APP", "size of this program is %d\n", size); 
+  if (rank == 0) LMON_say_msg("APP", "size of this program is %d\n", size);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-
-int 
-main(int argc, char* argv[])
-{
-  int size; 
-  int rank;  
+int main(int argc, char* argv[]) {
+  int size;
+  int rank;
   int buf;
   int i;
 
@@ -122,3 +115,7 @@ main(int argc, char* argv[])
   MPI_Finalize();
   return EXIT_SUCCESS;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/test/src/test.LE_model_checker_extreme.in
+++ b/test/src/test.LE_model_checker_extreme.in
@@ -28,7 +28,7 @@
 #--------------------------------------------------------------------------------
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 12 2008 DHA: Created file.
 #

--- a/test/src/test.LE_model_checker_large.in
+++ b/test/src/test.LE_model_checker_large.in
@@ -28,7 +28,7 @@
 #--------------------------------------------------------------------------------
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 12 2008 DHA: Created file.
 #

--- a/test/src/test.LE_model_checker_mainthread.in
+++ b/test/src/test.LE_model_checker_mainthread.in
@@ -28,7 +28,7 @@
 #--------------------------------------------------------------------------------
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 12 2008 DHA: Created file.
 #

--- a/test/src/test.LE_model_checker_pthread.in
+++ b/test/src/test.LE_model_checker_pthread.in
@@ -28,7 +28,7 @@
 #--------------------------------------------------------------------------------
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 12 2008 DHA: Created file.
 #

--- a/test/src/test.attach_1.in
+++ b/test/src/test.attach_1.in
@@ -27,10 +27,10 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Dec 17 2009 DHA: Added minimum WAITAMOUNT
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
@@ -47,10 +47,10 @@ fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
 
-WAITAMOUNT=$NUMNODES 
-if test $NUMNODES -lt 20 ; then 
+WAITAMOUNT=$NUMNODES
+if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
-fi 
+fi
 
 SIGNUM=10
 MPI_JOB_LAUNCHER_PATH=@TJLPATH@
@@ -85,14 +85,14 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
 
-PID=`echo $!` 
+PID=`echo $!`
 
-sleep $WAITAMOUNT #wait until the job gets stalled 
+sleep $WAITAMOUNT #wait until the job gets stalled
 
-fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 
+fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM
 
 sleep $WAITAMOUNT
 

--- a/test/src/test.attach_1_mem_fetcher.in
+++ b/test/src/test.attach_1_mem_fetcher.in
@@ -27,10 +27,10 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Dec 17 2009 DHA: Added minimum WAITAMOUNT
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
@@ -47,10 +47,10 @@ fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
 
-WAITAMOUNT=$NUMNODES 
-if test $NUMNODES -lt 10 ; then 
+WAITAMOUNT=$NUMNODES
+if test $NUMNODES -lt 10 ; then
   WAITAMOUNT=20
-fi 
+fi
 
 SIGNUM=10
 MPI_JOB_LAUNCHER_PATH=@TJLPATH@
@@ -83,14 +83,14 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
 
-PID=`echo $!` 
+PID=`echo $!`
 
-sleep $WAITAMOUNT #wait until the job gets stalled 
+sleep $WAITAMOUNT #wait until the job gets stalled
 
-fe_attach_smoketest@EXE@ $PID `pwd`/be_mem_fetcher@EXE@ $SIGNUM 
+fe_attach_smoketest@EXE@ $PID `pwd`/be_mem_fetcher@EXE@ $SIGNUM
 
 sleep $WAITAMOUNT
 

--- a/test/src/test.attach_1_pdebugmax.in
+++ b/test/src/test.attach_1_pdebugmax.in
@@ -27,18 +27,18 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 16 2008 DHA: Created file.
 #
- 
+
 NUMNODES=16
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 10 ; then
   WAITAMOUNT=20
 fi
@@ -57,7 +57,7 @@ if test "x$RM_TYPE" = "xRC_bglrm" -o "x$RM_TYPE" = "xRC_bgprm"; then
   echo "[LMON FE] Test Not Implemented Yet"
   exit 1
 fi
- 
+
 if test "x$RM_TYPE" = "xRC_slurm" ; then
   $MPI_JOB_LAUNCHER_PATH -n$NUMTASKS -N$NUMNODES -ppdebug `pwd`/hang_on_SIGUSR1@EXE@ &
 elif test "x$RM_TYPE" = "xRC_bglrm" -o "x$RM_TYPE" = "xRC_bgprm"; then
@@ -72,13 +72,13 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
-fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 
- 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
+fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM
+
 sleep $WAITAMOUNT

--- a/test/src/test.attach_1_remote.in
+++ b/test/src/test.attach_1_remote.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a remote RM process and unlock the hang 
+#  Attach the tool to a remote RM process and unlock the hang
 #  of its associated job.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Dec 17 2009 DHA: Added minimum waittime
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
@@ -80,11 +80,11 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
 else
   echo "This RM is not supported yet"
 fi
- 
+
 PID=`echo $!`
- 
+
 sleep $WAITAMOUNT #wait until the job gets stalled
- 
+
 fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM -k 20
 
 sleep $WAITAMOUNT

--- a/test/src/test.attach_2_uneven.in
+++ b/test/src/test.attach_2_uneven.in
@@ -28,16 +28,16 @@
 #--------------------------------------------------------------------------------
 #
 #  Attach the tool to a running program that occupies an uneven number
-#  number of processors per node, and unlock the hang. 
+#  number of processors per node, and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES
 #        Jun 16 2008 DHA: Created file.
 #
- 
+
 RM_TYPE=@TEST_RMTP@
 NUMNODES=@NNODES@
 
@@ -46,7 +46,7 @@ if test "x$RM_TYPE" = "xRC_bglrm" -o "x$RM_TYPE" = "xRC_bgprm"; then
 fi
 
 NUMTASKS=`expr $NUMNODES / 2 \* @SMP@ + 2`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
 fi
@@ -60,7 +60,7 @@ else
     export LMON_RM_CONFIG_DIR=@RMCONFIGDIR@
     export LMON_COLOC_UTIL_DIR=@COLOCDIR@
 fi
- 
+
 if test "x$RM_TYPE" = "xRC_slurm" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n$NUMTASKS -N$NUMNODES -ppdebug `pwd`/hang_on_SIGUSR1@EXE@ &
@@ -83,13 +83,13 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
-fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
+fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM
 
 sleep $WAITAMOUNT

--- a/test/src/test.attach_3_callsafterfail.in
+++ b/test/src/test.attach_3_callsafterfail.in
@@ -27,13 +27,13 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 16 2008 DHA: Created file.
 #
- 
+
 SIGNUM=10
 
 export LMON_LAUNCHMON_ENGINE_PATH=@LMON@

--- a/test/src/test.attach_3_invalidpid.in
+++ b/test/src/test.attach_3_invalidpid.in
@@ -27,10 +27,10 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Check if attachAndSpawnDaemons can handle an invalid pid case correctly. 
+#  Check if attachAndSpawnDaemons can handle an invalid pid case correctly.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 16 2008 DHA: Created file.
 #
 

--- a/test/src/test.attach_3_invalidpid_remote.in
+++ b/test/src/test.attach_3_invalidpid_remote.in
@@ -27,13 +27,13 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 17 2008 DHA: Created file.
 #
- 
+
 export LMON_LAUNCHMON_ENGINE_PATH=@LMON@
 if test "x@LMONPREFIX@" != "x0"; then
     export LMON_PREFIX=@LMONPREFIX@

--- a/test/src/test.attach_4_detach.in
+++ b/test/src/test.attach_4_detach.in
@@ -27,19 +27,19 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program, unlock the hang. 
+#  Attach the tool to a running program, unlock the hang.
 #  and kill the BE daemons.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Aug 02 2012 DHA: Created file.
 #
- 
+
 RM_TYPE=@TEST_RMTP@
 NUMNODES=@NNODES@
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
 fi
@@ -76,14 +76,14 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
 fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 1
- 
+
 sleep $WAITAMOUNT
 

--- a/test/src/test.attach_4_kill.in
+++ b/test/src/test.attach_4_kill.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program, unlock the hang. 
+#  Attach the tool to a running program, unlock the hang.
 #  and kill the BE daemons.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 05 2012 DHA: Added subtest support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Dec 17 2009 DHA: Added tminimum waittime
@@ -39,12 +39,12 @@
 #        Dec 14 2008 DHA: configurable NUMNODES
 #        Jun 17 2008 DHA: Created file.
 #
- 
+
 RM_TYPE=@TEST_RMTP@
 NUMNODES=@NNODES@
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
 fi
@@ -81,14 +81,14 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
 fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 1
- 
+
 sleep $WAITAMOUNT
 

--- a/test/src/test.attach_4_shutdownbe.in
+++ b/test/src/test.attach_4_shutdownbe.in
@@ -27,18 +27,18 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program, unlock the hang and 
+#  Attach the tool to a running program, unlock the hang and
 #  shut down BE daemons .
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 05 2012 DHA: Added subtest support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES
 #        Jun 16 2008 DHA: Created file.
 #
- 
+
 RM_TYPE=@TEST_RMTP@
 NUMNODES=@NNODES@
 
@@ -54,7 +54,7 @@ if test "x$RM_TYPE" = "xRC_bglrm" \
 fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
 fi
@@ -71,7 +71,7 @@ export LMON_FE_SHUTDOWNBE_TEST=1
 
 if test "x$RM_TYPE" = "xRC_slurm" ; then
   $MPI_JOB_LAUNCHER_PATH -n$NUMTASKS -N$NUMNODES -ppdebug `pwd`/hang_on_SIGUSR1@EXE@ &
-elif test "x$RM_TYPE" = "xRC_bglrm" -o "x$RM_TYPE" = "xRC_bgprm"; then 
+elif test "x$RM_TYPE" = "xRC_bglrm" -o "x$RM_TYPE" = "xRC_bgprm"; then
   $MPI_JOB_LAUNCHER_PATH -verbose 0 -np $NUMTASKS -exe `pwd`/hang_on_SIGUSR1@EXE@ -cwd `pwd` &
 elif test "x$RM_TYPE" = "xRC_alps" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
@@ -83,13 +83,13 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
 fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 1
- 
+
 sleep $WAITAMOUNT

--- a/test/src/test.fe_regErrorCB.in
+++ b/test/src/test.fe_regErrorCB.in
@@ -27,12 +27,12 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Check if attachAndSpawnDaemons can handle an invalid pid case correctly 
-#  and report the error message through a previously registered callback 
+#  Check if attachAndSpawnDaemons can handle an invalid pid case correctly
+#  and report the error message through a previously registered callback
 #  function.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        May 19 2009 DHA: Created file.
 #
 

--- a/test/src/test.fe_regStatusCB.in
+++ b/test/src/test.fe_regStatusCB.in
@@ -27,10 +27,10 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Attach the tool to a running program and unlock the hang. 
+#  Attach the tool to a running program and unlock the hang.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Jun 02 2009 DHA: Created file.
 #
@@ -43,7 +43,7 @@ if test "x$RM_TYPE" = "xRC_bgrm" ; then
 fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 if test $NUMNODES -lt 20 ; then
   WAITAMOUNT=20
 fi
@@ -78,14 +78,14 @@ elif test "x$RM_TYPE" = "xRC_mpiexec_hydra" ; then
   WAITAMOUNT=`expr $WAITAMOUNT`
   $MPI_JOB_LAUNCHER_PATH -n $NUMTASKS `pwd`/hang_on_SIGUSR1@EXE@ &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
 
-PID=`echo $!` 
+PID=`echo $!`
 
-sleep $WAITAMOUNT #wait until the job gets stalled 
+sleep $WAITAMOUNT #wait until the job gets stalled
 
-fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM 
+fe_attach_smoketest@EXE@ $PID `pwd`/be_kicker@EXE@ $SIGNUM
 
 sleep $WAITAMOUNT
 

--- a/test/src/test.jobsnap_1.in
+++ b/test/src/test.jobsnap_1.in
@@ -30,7 +30,7 @@
 #  Attach the tool to a running program and collect jobsnap data.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Jun 17 2008 DHA: Created file.
@@ -45,7 +45,7 @@ if test "x$RM_TYPE" = "xRC_bgrm" ; then
 fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
-WAITAMOUNT=$NUMNODES 
+WAITAMOUNT=$NUMNODES
 SIGNUM=10
 MPI_JOB_LAUNCHER_PATH=@TJLPATH@
 export LMON_LAUNCHMON_ENGINE_PATH=@LMON@
@@ -56,20 +56,20 @@ else
     export LMON_COLOC_UTIL_DIR=@COLOCDIR@
 fi
 export JOBSNAP_TEST=1
- 
+
 if test "x$RM_TYPE" = "xRC_slurm" ; then
   $MPI_JOB_LAUNCHER_PATH -n$NUMTASKS -N$NUMNODES -ppdebug `pwd`/hang_on_SIGUSR1@EXE@ &
-elif test "x$RM_TYPE" = "xRC_bgrm" ; then 
+elif test "x$RM_TYPE" = "xRC_bgrm" ; then
   $MPI_JOB_LAUNCHER_PATH -verbose 1 -np $NUMTASKS -exe `pwd`/hang_on_SIGUSR1@EXE@ -cwd `pwd` &
 else
-  echo "This RM is not supported yet" 
+  echo "This RM is not supported yet"
 fi
- 
-PID=`echo $!` 
- 
-sleep $WAITAMOUNT #wait until the job gets stalled 
- 
-fe_jobsnap@EXE@ $PID `pwd`/be_jobsnap@EXE@ $SIGNUM 
- 
+
+PID=`echo $!`
+
+sleep $WAITAMOUNT #wait until the job gets stalled
+
+fe_jobsnap@EXE@ $PID `pwd`/be_jobsnap@EXE@ $SIGNUM
+
 sleep $WAITAMOUNT
 

--- a/test/src/test.launch_1.in
+++ b/test/src/test.launch_1.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a fully populated job at $NUMTASK and co-locate daemons, 
-#  one daemon per node, which unlocks the initial hang of all tasks. 
+#  Launch a fully populated job at $NUMTASK and co-locate daemons,
+#  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: NUMTASKS=32
 #        Mar 06 2009 DHA: Changed bglrm to bgrm

--- a/test/src/test.launch_1_remote.in
+++ b/test/src/test.launch_1_remote.in
@@ -27,13 +27,13 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a fully populated job at $NUMTASK and co-locate daemons, 
-#  one daemon per node, which unlocks the initial hang of all tasks. 
-#  A difference with test.launch_1 is that this case locates a launcthmon 
+#  Launch a fully populated job at $NUMTASK and co-locate daemons,
+#  one daemon per node, which unlocks the initial hang of all tasks.
+#  A difference with test.launch_1 is that this case locates a launcthmon
 #  engine remotely on a node in which the job launcher process runs.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES

--- a/test/src/test.launch_2_half.in
+++ b/test/src/test.launch_2_half.in
@@ -32,7 +32,7 @@
 #  hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES

--- a/test/src/test.launch_2_uneven.in
+++ b/test/src/test.launch_2_uneven.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a unevenly populated job at $NUMTASK and co-locate daemons, 
+#  Launch a unevenly populated job at $NUMTASK and co-locate daemons,
 #  one daemon per node, which unlock the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES

--- a/test/src/test.launch_3_invalid_dmonpath.in
+++ b/test/src/test.launch_3_invalid_dmonpath.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Providing an invalid daemon path, this test checks if launchAndSpawnDaemons 
-#  can gracefully handle this case. 
+#  Providing an invalid daemon path, this test checks if launchAndSpawnDaemons
+#  can gracefully handle this case.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES
 #        Jun 13 2008 DHA: Created file.

--- a/test/src/test.launch_5_usrpayload.in
+++ b/test/src/test.launch_5_usrpayload.in
@@ -27,10 +27,10 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  LaunchMON's user payload shipping functionality test 
+#  LaunchMON's user payload shipping functionality test
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Oct 21 2011 DHA: Added dynamic RM detection support.
 #        Mar 06 2009 DHA: Changed bglrm to bgrm
 #        Dec 14 2008 DHA: configurable NUMNODES

--- a/test/src/test.launch_7_detach.in
+++ b/test/src/test.launch_7_detach.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a fully populated job at $NUMTASK and co-locate daemons, 
-#  one daemon per node, which unlocks the initial hang of all tasks. 
+#  Launch a fully populated job at $NUMTASK and co-locate daemons,
+#  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Aug 2 2012 DHA: Created file.
 #
 

--- a/test/src/test.launch_7_kill.in
+++ b/test/src/test.launch_7_kill.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a fully populated job at $NUMTASK and co-locate daemons, 
-#  one daemon per node, which unlocks the initial hang of all tasks. 
+#  Launch a fully populated job at $NUMTASK and co-locate daemons,
+#  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Aug 1 2012 DHA: Created file.
 #
 

--- a/test/src/test.launch_7_shutdownbe.in
+++ b/test/src/test.launch_7_shutdownbe.in
@@ -27,11 +27,11 @@
 # Place, Suite 330, Boston, MA 02111-1307 USA
 #--------------------------------------------------------------------------------
 #
-#  Launch a fully populated job at $NUMTASK and co-locate daemons, 
-#  one daemon per node, which unlocks the initial hang of all tasks. 
+#  Launch a fully populated job at $NUMTASK and co-locate daemons,
+#  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Aug 01 2012 DHA: Created the file
 #
 

--- a/test/src/test.launch_mw_1_hostlist.in
+++ b/test/src/test.launch_mw_1_hostlist.in
@@ -31,7 +31,7 @@
 #  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 04 2012 DHA: Adjust the test script to 1.0 testing environment.
 #        Aug 03 2010 DHA: Created file.
 #
@@ -58,7 +58,7 @@ fi
 
 NUMTASKS=`expr $NUMNODES \* @SMP@`
 
-$NOHUP fe_launch_middleware@EXE@ `pwd`/simple_MPI@EXE@ $NUMTASKS $NUMNODES pdebug `pwd`/mw_comm_helper@EXE@ `pwd`/be_kicker@EXE@ 
+$NOHUP fe_launch_middleware@EXE@ `pwd`/simple_MPI@EXE@ $NUMTASKS $NUMNODES pdebug `pwd`/mw_comm_helper@EXE@ `pwd`/be_kicker@EXE@
 
 if test -f nohup.out; then
   sleep $NUMNODES

--- a/test/src/test.launch_mw_2_coloc.in
+++ b/test/src/test.launch_mw_2_coloc.in
@@ -31,7 +31,7 @@
 #  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 05 2012 DHA: Added subtest support.
 #        Jun 04 2012 DHA: Adjust the test script to 1.0 testing environment.
 #        Aug 04 2010 DHA: Created file.

--- a/test/src/test.launch_mw_5_mixall.in
+++ b/test/src/test.launch_mw_5_mixall.in
@@ -31,7 +31,7 @@
 #  one daemon per node, which unlocks the initial hang of all tasks.
 #
 #  Update Log:
-#        May 04 2016 DHA: Add test in-tree and installed support 
+#        May 04 2016 DHA: Add test in-tree and installed support
 #        Jun 05 2012 DHA: Added subtest support.
 #        Jun 04 2012 DHA: Adjust the test script to 1.0 testing environment.
 #        Aug 05 2010 DHA: Created file.

--- a/test/src/util.c
+++ b/test/src/util.c
@@ -1,32 +1,33 @@
 /*
- * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
- * LLNL-CODE-409469. All rights reserved.
+ * Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn
+ * <ahn1@llnl.gov>. LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
- * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
+ * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public
+ * License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
- * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License (as published by the Free
+ * Software Foundation) version 2.1 dated February 1999.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------			
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
- *        Jun 12 2008 DHA: Added GNU build system support. 
+ *        Jun 12 2008 DHA: Added GNU build system support.
  *        Feb 09 2008 DHA: Added LLNS Copyright
  *        Aug 15 2006 DHA: File created
  */
@@ -38,47 +39,36 @@
 #include <lmon_api/common.h>
 
 #if TIME_WITH_SYS_TIME
-# include <time.h>
-# include <sys/time.h>
+#include <sys/time.h>
+#include <time.h>
 #else
-# error ctime and sys_time.h is required
+#error ctime and sys_time.h is required
 #endif
 
 static struct timeval st, et;
 
-int 
-begin_timer ()
-{
-  return (gettimeofday ( &st, NULL ));
-}
+int begin_timer() { return (gettimeofday(&st, NULL)); }
 
-
-int 
-time_stamp ( const char* description )
-{
+int time_stamp(const char* description) {
   int rc;
 
-  if ( ! (timerisset (&st)) )
-    return -1;
+  if (!(timerisset(&st))) return -1;
 
-  rc = gettimeofday ( &et, NULL ); 
+  rc = gettimeofday(&et, NULL);
 
-  if ( et.tv_usec >= st.tv_usec ) 
-    {
-      fprintf ( stdout, 
-		"%s: %ld (%ld - %ld) seconds %ld (%ld - %ld) usec \n",
-		description, 
-		(et.tv_sec - st.tv_sec), et.tv_sec, st.tv_sec,
-		(et.tv_usec - st.tv_usec), et.tv_usec, st.tv_usec);
-    }
-  else
-    {
-      fprintf ( stdout, 
-		"%s: %ld (%ld - %ld) seconds %ld (%ld - %ld) usec \n",
-		description,
-		( ( et.tv_sec - 1 ) - st.tv_sec), et.tv_sec, st.tv_sec,
-		( (et.tv_usec+1000000) - st.tv_usec), et.tv_usec, st.tv_usec );
-    } 
+  if (et.tv_usec >= st.tv_usec) {
+    fprintf(stdout, "%s: %ld (%ld - %ld) seconds %ld (%ld - %ld) usec \n",
+            description, (et.tv_sec - st.tv_sec), et.tv_sec, st.tv_sec,
+            (et.tv_usec - st.tv_usec), et.tv_usec, st.tv_usec);
+  } else {
+    fprintf(stdout, "%s: %ld (%ld - %ld) seconds %ld (%ld - %ld) usec \n",
+            description, ((et.tv_sec - 1) - st.tv_sec), et.tv_sec, st.tv_sec,
+            ((et.tv_usec + 1000000) - st.tv_usec), et.tv_usec, st.tv_usec);
+  }
 
   return rc;
 }
+
+/*
+ * ts=2 sw=2 expandtab
+ */

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at

--- a/tools/alps/Makefile.am
+++ b/tools/alps/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
@@ -31,4 +31,4 @@
 ##        Jun 12 2010 DHA: Copied from the old Makefile.
 ##
 
-SUBDIRS         = src 
+SUBDIRS         = src

--- a/tools/alps/src/Makefile.am
+++ b/tools/alps/src/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
@@ -28,10 +28,10 @@
 ##--------------------------------------------------------------------------------
 ##
 ##  Update Log:
-##        May 05 2016 DHA: Adapt @agontarek's Cray port patch 
+##        May 05 2016 DHA: Adapt @agontarek's Cray port patch
 ##        Apr 29 2016 DHA: Mondernize build support
 ##        Nov 23 2010 DHA: Changed bin_SCRIPTS to etc_SCRIPTS for CLE dso list
-##        Nov 04 2010 DHA: Added lib_SCRIPTS 
+##        Nov 04 2010 DHA: Added lib_SCRIPTS
 ##        Jun 10 2010 DHA: Added alps_fe_colocator support
 ##        May 13 2010 DHA: Made for alps_be_starter
 ##
@@ -39,16 +39,16 @@
 AM_CPPFLAGS = \
   -I$(abs_top_srcdir) \
   -I$(abs_top_srcdir)/launchmon/src \
-  -I$(abs_top_srcdir)/@LMONAPILOC@ 
+  -I$(abs_top_srcdir)/@LMONAPILOC@
 
-bin_PROGRAMS = alps_be_starter alps_fe_colocator 
-alps_be_starter_SOURCES = alps_be_starter.c 
+bin_PROGRAMS = alps_be_starter alps_fe_colocator
+alps_be_starter_SOURCES = alps_be_starter.c
 alps_fe_colocator_SOURCES = alps_fe_colocator.cxx
 alps_fe_colocator_CXXFLAGS = @LNCHR_BIT_FLAGS@ $(CRAY_ALPS_CFLAGS)
 alps_fe_colocator_LDADD = @LIBELF@ $(CRAY_ALPS_LIBS)
 
 alps_be_starter$(EXEEXT): alps_be_starter.c Makefile
-	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) $(AM_CFLAGS) $(CFLAGS) -o $@ $<   
+	$(MPICC) $(DEFS) $(DEFAULT_INCLUDES) $(AM_CFLAGS) $(CFLAGS) -o $@ $<
 
 etcdir = ${prefix}/etc
 etc_SCRIPTS = \

--- a/tools/alps/src/alps_be_starter.c
+++ b/tools/alps/src/alps_be_starter.c
@@ -1,33 +1,33 @@
 /*
  * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
  * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License (as published by the Free Software
  * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
- *        May 12 2010 DHA: Created based on UW's daemon_launcher. Credit to 
- *                         Ramya Olichandran 
+ *        May 12 2010 DHA: Created based on UW's daemon_launcher. Credit to
+ *                         Ramya Olichandran
  */
 
 #include <stdio.h>
@@ -39,7 +39,7 @@
 int main(int argc,char **argv)
 {
   /*
-   * This BE starter stub for ALPS must be invoked with 
+   * This BE starter stub for ALPS must be invoked with
    * alps_be_starter alpsJobId toolDaemonPath <args>
    *
    */
@@ -55,25 +55,25 @@ int main(int argc,char **argv)
   }
 
   snprintf (reloc_ld_lib_path, PATH_MAX,
-	   "/var/spool/alps/%d/toolhelper%d", 
+	   "/var/spool/alps/%d/toolhelper%d",
            my_apid, my_apid);
 
   if ( access (reloc_ld_lib_path, R_OK) < 0 ) {
     fprintf(stderr, "access to %s failed\n", reloc_ld_lib_path);
     exit(1);
   }
-  
+
   if ( lib_path = getenv("LD_LIBRARY_PATH") ) {
     sprintf(add_lib_path, "%s:%s", lib_path, reloc_ld_lib_path);
   }
   else {
     sprintf(add_lib_path, "%s", reloc_ld_lib_path);
-  }  
-  
+  }
+
   if ( setenv("LD_LIBRARY_PATH", (const char *) add_lib_path, 1) < 0 ) {
     fprintf(stderr, "setenv return neg");
     exit(1);
-  } 
+  }
 
   daemon_argv = &argv[2];
 

--- a/tools/alps/src/alps_fe_colocator.cxx
+++ b/tools/alps/src/alps_fe_colocator.cxx
@@ -1,38 +1,38 @@
 /*
  * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
- * This file is part of LaunchMON. For details, see 
+ * This file is part of LaunchMON. For details, see
  * https://computing.llnl.gov/?set=resources&page=os_projects
  *
  * Please also read LICENSE.txt -- Our Notice and GNU Lesser General Public License.
  *
- * 
- * This program is free software; you can redistribute it and/or modify it under the 
- * terms of the GNU General Public License (as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License (as published by the Free Software
  * Foundation) version 2.1 dated February 1999.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY 
- * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or 
- * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU 
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the IMPLIED WARRANTY OF MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the terms and conditions of the GNU
  * General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public License along 
- * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple 
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 59 Temple
  * Place, Suite 330, Boston, MA 02111-1307 USA
- *--------------------------------------------------------------------------------                      
+ *--------------------------------------------------------------------------------
  *
  *  Update Log:
  *        May 05 2016 DHA: Applied @agontarek's Cray patch
- *        Nov 05 2010 DHA: Support for excluding existing system DSOs from 
+ *        Nov 05 2010 DHA: Support for excluding existing system DSOs from
  *                         being broadcast. Credit to Andrew Gontarek at Cray
  *                         for providing DSO list for CLE3.1 and CLE2.2
- *                         (ID: 3103796) 
+ *                         (ID: 3103796)
  *        Nov 04 2010 DHA: Support for base executable relocation
- *        Jun 10 2010 DHA: File created 
+ *        Jun 10 2010 DHA: File created
  */
 
 
@@ -102,7 +102,7 @@ enum CLE_version_e {
   cle_ver_2_2,
   cle_ver_3_1,
   cle_ver_unknown
-}; 
+};
 
 const char XTRELEASE_FILE_PATH[] = "/etc/opt/cray/release/xtrelease";
 const char DSO_CONFIG_FILE[] = "CLE-dso.conf";
@@ -128,7 +128,7 @@ ALPS_say_msg ( const char* m, bool is_err, const char* output, ... )
 }
 
 
-static void 
+static void
 sighandler (int sig)
 {
   if (sig == SIGINT)
@@ -143,14 +143,14 @@ sighandler (int sig)
 
 //
 // get_CLE_ver return an enumerator indicating
-// what DSO list file you sould use at run-time 
-// As other CLE lists are added, the logic of 
+// what DSO list file you sould use at run-time
+// As other CLE lists are added, the logic of
 // detecting CLE versions need to be added here.
 //
-static CLE_version_e 
+static CLE_version_e
 get_CLE_ver()
 {
-  try 
+  try
     {
       CLE_version_e rc = cle_ver_unknown;
       std::ifstream xtrelease_file(XTRELEASE_FILE_PATH);
@@ -159,10 +159,10 @@ get_CLE_ver()
         {
           rc = cle_ver_2_2;
         }
-      else 
+      else
         {
           std::ostringstream oss;
-          oss << xtrelease_file.rdbuf();  
+          oss << xtrelease_file.rdbuf();
           std::string::size_type pos = oss.str().find_first_of("=", 0);
           const std::string vstr("3.1.");
           if (oss.str().compare(pos+1, 4, vstr) == 0)
@@ -179,37 +179,37 @@ get_CLE_ver()
 }
 
 
-static 
+static
 void
-build_DSO_mask (std::map<std::string, int> &dontShipIt, 
+build_DSO_mask (std::map<std::string, int> &dontShipIt,
                 std::ifstream &listFstream)
 {
   char apath[PATH_MAX];
 
   //note new line is not stored in apath
-  while (!listFstream.getline(apath, PATH_MAX).eof()) 
+  while (!listFstream.getline(apath, PATH_MAX).eof())
     {
-      std::map<std::string, int>::iterator iter; 
+      std::map<std::string, int>::iterator iter;
       iter = dontShipIt.find(apath);
-      if (iter == dontShipIt.end())      
+      if (iter == dontShipIt.end())
         {
-          dontShipIt[apath] = 1;  
+          dontShipIt[apath] = 1;
         }
       else
         {
           iter->second++;
-        } 
+        }
     }
-}  
+}
 
 
 //
-// Function that actually launches daemons using APLS tool helper 
-// services 
+// Function that actually launches daemons using APLS tool helper
+// services
 //
 //
 static int
-launch_daemons(int apid, 
+launch_daemons(int apid,
   std::vector<std::string> &dlibs, std::string &bestarter,
   std::string &daemonpath, std::string &dargs)
 {
@@ -234,8 +234,8 @@ launch_daemons(int apid,
      return -1;
   }
 
-  if (alps_get_appinfo(my_apid, &appinfo, &cmdDetail, &places) < 0) 
-    {	
+  if (alps_get_appinfo(my_apid, &appinfo, &cmdDetail, &places) < 0)
+    {
       ALPS_say_msg(MSGPREFIX, true, "error in alps_get_appinfo");
       return -1;
     }
@@ -243,7 +243,7 @@ launch_daemons(int apid,
   int pe0Node = places[0].nid;
 
   //
-  // building dontshipit map 
+  // building dontshipit map
   //
   std::map<std::string, int> dontShipIt;
   std::string dsoListPath;
@@ -258,17 +258,17 @@ launch_daemons(int apid,
     {
       dsoListDir = std::string("./");
       dsoListPath = dsoListDir + DSO_CONFIG_FILE;
-      ALPS_say_msg(MSGPREFIX, 
-                   false, 
+      ALPS_say_msg(MSGPREFIX,
+                   false,
                    "LMON_PREFIX envVar not found");
     }
 
   std::ifstream dsofstream(dsoListPath.c_str());
   if (!dsofstream)
     {
-      ALPS_say_msg(MSGPREFIX, 
-                   false, 
-                   "%s not found... selective DSO bcast will not work", 
+      ALPS_say_msg(MSGPREFIX,
+                   false,
+                   "%s not found... selective DSO bcast will not work",
                    dsoListPath.c_str());
     }
   else
@@ -280,10 +280,10 @@ launch_daemons(int apid,
           if ((aLine[0] != '-') && (aLine[1] != 'i'))
             {
               continue;
-            } 
+            }
 
           std::string aLineStr(aLine);
-          std::string::size_type pos = aLineStr.find_first_of(" \t", 0); 
+          std::string::size_type pos = aLineStr.find_first_of(" \t", 0);
           pos = aLineStr.find_first_not_of(" \t", pos);
           std::string::size_type lastpos = aLineStr.find_first_of(" \t", pos);
           std::string verstr = aLineStr.substr(pos, lastpos-pos);
@@ -300,7 +300,7 @@ launch_daemons(int apid,
               filename = aLineStr.substr(pos, lastpos-pos);
             }
 
-          confMap[verstr] = filename; 
+          confMap[verstr] = filename;
         }
 
       CLE_version_e ver = get_CLE_ver();
@@ -308,17 +308,17 @@ launch_daemons(int apid,
         {
         case cle_ver_2_2:
           {
-            std::map<std::string, std::string>::const_iterator citer 
+            std::map<std::string, std::string>::const_iterator citer
               = confMap.find(std::string("2.2"));
             if (citer != confMap.end())
-              { 
+              {
                 std::string confPath = dsoListDir + citer->second;
                 std::ifstream confFile(confPath.c_str());
                 if (!confFile)
                   {
                     ALPS_say_msg(MSGPREFIX,
                       true,
-                      "can't open %s", 
+                      "can't open %s",
                       confPath.c_str());
                   }
                 else
@@ -330,17 +330,17 @@ launch_daemons(int apid,
           }
         case cle_ver_3_1:
           {
-            std::map<std::string, std::string>::const_iterator citer 
+            std::map<std::string, std::string>::const_iterator citer
               = confMap.find(std::string("3.1"));
             if (citer != confMap.end())
-              { 
+              {
                 std::string confPath = dsoListDir + citer->second;
                 std::ifstream confFile(confPath.c_str());
                 if (!confFile)
                   {
                     ALPS_say_msg(MSGPREFIX,
                       true,
-                      "can't open %s", 
+                      "can't open %s",
                       confPath.c_str());
                   }
                 else
@@ -353,7 +353,7 @@ launch_daemons(int apid,
         case cle_ver_unknown:
           {
             //
-	    // In this case, DSOs from combined list are used 
+	    // In this case, DSOs from combined list are used
             //
             std::map<std::string, std::string>::const_iterator citer;
             for (citer = confMap.begin(); citer != confMap.end(); ++citer)
@@ -364,13 +364,13 @@ launch_daemons(int apid,
                   {
                     ALPS_say_msg(MSGPREFIX,
                       true,
-                      "can't open %s", 
+                      "can't open %s",
                       confPath.c_str());
                   }
                 else
                   {
                     build_DSO_mask(dontShipIt,confFile);
-                  } 
+                  }
               }
             break;
           }
@@ -403,7 +403,7 @@ launch_daemons(int apid,
 
       //
       // Transfering a shared library here
-      // 
+      //
       err_str = alps_launch_tool_helper(my_apid,pe0Node,true,false,1,&libname);
       if (err_str)
         {
@@ -430,37 +430,37 @@ launch_daemons(int apid,
       // If the executable relocation failed, we should use the original
       // be daemon path
       //
-      snprintf(lcmdtmp, ALPS_STRING_MAX, "%s %d %s %s", 
-      bestarter.c_str(), my_apid, daemonpath.c_str(), dargs.c_str());  
+      snprintf(lcmdtmp, ALPS_STRING_MAX, "%s %d %s %s",
+      bestarter.c_str(), my_apid, daemonpath.c_str(), dargs.c_str());
     }
   else
     {
       //
       // Otherwise, the relocated daemon path is passed to ALPS tool helper
-      //  
+      //
       char reloc_exec[PATH_MAX];
       char *bncp = strdup(daemonpath.c_str());
       char *bn = basename(bncp);
-      
+
       snprintf (reloc_exec, PATH_MAX,
          "/var/spool/alps/%d/toolhelper%d/%s",
          my_apid, my_apid, bn);
 
-      snprintf(lcmdtmp, ALPS_STRING_MAX, "%s %d %s %s", 
-      bestarter.c_str(), my_apid, reloc_exec, dargs.c_str());  
+      snprintf(lcmdtmp, ALPS_STRING_MAX, "%s %d %s %s",
+      bestarter.c_str(), my_apid, reloc_exec, dargs.c_str());
       free(bncp);
     }
 
   char *lcmd = lcmdtmp;
   //
-  // Launching backend daemons here 
-  // 
+  // Launching backend daemons here
+  //
   ALPS_say_msg(MSGPREFIX, false, "%s", lcmd );
   err_str = alps_launch_tool_helper(my_apid, pe0Node,true, true, 1, &lcmd);
   if (err_str)
     {
       ALPS_say_msg(MSGPREFIX, true, "error in alps_launch_tool_helper: %s", err_str);
-      rc = -1;	
+      rc = -1;
     }
 
   return rc;
@@ -470,42 +470,42 @@ launch_daemons(int apid,
 // Function that fetches, resolves and fills dependent shared libraries
 //
 //
-static int 
+static int
 get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
 {
   Elf_Kind kind;
-  Elf *arf;  
+  Elf *arf;
   Elf *elf_handler;
   int fd;
 
-  if ( elf_version(EV_CURRENT) == EV_NONE ) 
+  if ( elf_version(EV_CURRENT) == EV_NONE )
     {
       ALPS_say_msg(MSGPREFIX, true, "error in elf_version");
-      return -1; 
+      return -1;
     }
 
-  if ( ( fd = open (daemonpath.c_str(), O_RDONLY)) == -1 ) 
+  if ( ( fd = open (daemonpath.c_str(), O_RDONLY)) == -1 )
     {
       ALPS_say_msg(MSGPREFIX, true, "error in openning %s", daemonpath.c_str());
-      return -1; 
+      return -1;
     }
 
-  if ( ( arf = elf_begin (fd, ELF_C_READ, NULL)) == NULL ) 
+  if ( ( arf = elf_begin (fd, ELF_C_READ, NULL)) == NULL )
     {
       ALPS_say_msg(MSGPREFIX, true, "error in elf_begin");
-      return -1; 
+      return -1;
     }
 
   if ( ( kind = elf_kind (arf)) != ELF_K_ELF )
     {
       ALPS_say_msg(MSGPREFIX, true, "error in elf_kind");
-      return -1; 
+      return -1;
     }
 
   if ( ( elf_handler = elf_begin (fd, ELF_C_READ, arf)) == NULL )
     {
       ALPS_say_msg(MSGPREFIX, true, "error in elf_begin");
-      return -1; 
+      return -1;
     }
 
   Elf_Scn *sect = NULL;
@@ -515,26 +515,26 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
   std::vector<myElf_Addr> dynstrtab_offsets_libs;
   std::vector<myElf_Addr> dynstrtab_offsets_rpaths;
 
-  while ( (sect = elf_nextscn(elf_handler, sect)) != NULL ) 
+  while ( (sect = elf_nextscn(elf_handler, sect)) != NULL )
     {
       if ( (shdr = myelf_getshdr (sect)) == NULL )
         continue;
 
-      if ( shdr->sh_type == SHT_DYNAMIC ) 
+      if ( shdr->sh_type == SHT_DYNAMIC )
         {
           int ix;
           Elf_Data *sectdata;
 	  if (!(sectdata = elf_getdata ( sect, NULL)) )
     	    {
               ALPS_say_msg(MSGPREFIX, true, "elf_data returned null");
-              return -1; 
+              return -1;
             }
 
-          for (ix=0; ix < (shdr->sh_size/shdr->sh_entsize); ++ix) 
+          for (ix=0; ix < (shdr->sh_size/shdr->sh_entsize); ++ix)
             {
               myElf_Dyn *dyndata = (myElf_Dyn *) sectdata->d_buf;
               dyndata += ix;
-              switch (dyndata->d_tag) 
+              switch (dyndata->d_tag)
                 {
                 case DT_NEEDED:
 		  dynstrtab_offsets_libs.push_back(dyndata->d_un.d_ptr);
@@ -547,7 +547,7 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
 		case DT_STRTAB:
 		  dynstrtab = (char *) dyndata->d_un.d_ptr;
 		  break;
-	
+
 		default:
 		  break;
 		}
@@ -562,32 +562,32 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
                return -1;
              }
 
-	   std::string shname((char*)strsectd->d_buf+shdr->sh_name); 
+	   std::string shname((char*)strsectd->d_buf+shdr->sh_name);
 	   if (std::string(".shstrtab") == shname)
             sh_strtab = (char*) strsectd->d_buf;
          }
     }
 
-  if (!sh_strtab) 
+  if (!sh_strtab)
     {
       ALPS_say_msg(MSGPREFIX, true, "section header string table is not found");
       //
       // This is just outright wrong returning -1
       //
-      return -1; 
+      return -1;
     }
 
   //
   // searching for the interpreter
   //
-  while ( (sect = elf_nextscn(elf_handler, sect)) != NULL ) 
+  while ( (sect = elf_nextscn(elf_handler, sect)) != NULL )
     {
       if ( (shdr = myelf_getshdr (sect)) == NULL )
         continue;
 
-      if ( shdr->sh_type == SHT_PROGBITS) 
+      if ( shdr->sh_type == SHT_PROGBITS)
         {
-          if (std::string(".interp") == std::string(sh_strtab + shdr->sh_name)) 
+          if (std::string(".interp") == std::string(sh_strtab + shdr->sh_name))
             {
               Elf_Data *elfdata;
 	      if (!(elfdata = elf_getdata(sect, NULL)))
@@ -599,7 +599,7 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
               std::string interppath ((char *) elfdata->d_buf);
               if (access (interppath.c_str(), R_OK | X_OK) >= 0 )
                 dlibs.push_back(interppath);
-            }            
+            }
          }
        else if (shdr->sh_type == SHT_STRTAB && shdr->sh_flags == SHF_ALLOC)
          {
@@ -614,7 +614,7 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
                return -1;
              }
 
-	   std::string shname((char*)sh_strtab+shdr->sh_name); 
+	   std::string shname((char*)sh_strtab+shdr->sh_name);
 	   if (std::string(".dynstr") == shname)
             {
               dynstrtab = (char*) strsectd->d_buf;
@@ -629,12 +629,12 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
     {
       ALPS_say_msg(MSGPREFIX, true, "no dynamic library dependency?");
       //
-      // Maybe no libraries need to be shipped returning 0 
+      // Maybe no libraries need to be shipped returning 0
       //
-      return 0; 
+      return 0;
     }
 
-  // 
+  //
   // Library search path order is RPATH, LD_LIBRARY_PATH and DFLT_LIB_PATH
   //
   std::vector<std::string> ld_lib_path;
@@ -642,26 +642,26 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
   //
   // So RPATH
   //
-  char *llp, *tllp, *t, *tok; 
+  char *llp, *tllp, *t, *tok;
   std::vector<myElf_Addr>::iterator iter;
   for (iter = dynstrtab_offsets_rpaths.begin(); iter != dynstrtab_offsets_rpaths.end(); ++iter)
     {
-      tllp = strdup((char *)dynstrtab + (*iter)); 
+      tllp = strdup((char *)dynstrtab + (*iter));
       t = tllp;
       while ( (tok = strtok(t, ":")) != NULL )
         {
-          std::string apath((char *)tok);  
+          std::string apath((char *)tok);
           if (std::find(ld_lib_path.begin(), ld_lib_path.end(), apath) == ld_lib_path.end())
             ld_lib_path.push_back(apath);
 	  t = NULL;
         }
-      free(tllp); 
+      free(tllp);
     }
-  
+
   //
   // So LD_LIBRARY_PATH
   //
-  if ( (llp = getenv("LD_LIBRARY_PATH")) != NULL) 
+  if ( (llp = getenv("LD_LIBRARY_PATH")) != NULL)
     {
       tllp = strdup(llp);
       t = tllp;
@@ -670,15 +670,15 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
          std::string apath(tok);
          if (std::find(ld_lib_path.begin(), ld_lib_path.end(), apath) == ld_lib_path.end())
            ld_lib_path.push_back(apath);
-         t = NULL; 
-       } 
-      free(tllp); 
-    }	
+         t = NULL;
+       }
+      free(tllp);
+    }
 
   //
   // Next DFLT_LIB_PATH
   //
-  tllp = strdup(DFLT_LIB_PATH);  
+  tllp = strdup(DFLT_LIB_PATH);
   t = tllp;
   while ( (tok = strtok(t, ":")) != NULL)
     {
@@ -686,8 +686,8 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
       if (std::find(ld_lib_path.begin(), ld_lib_path.end(), apath) == ld_lib_path.end())
         ld_lib_path.push_back(apath);
       t = NULL;
-    } 
-  free(tllp); 
+    }
+  free(tllp);
 
   //
   // Time to resolve libraries
@@ -696,19 +696,19 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
   for (iter = dynstrtab_offsets_libs.begin(); iter != dynstrtab_offsets_libs.end(); ++iter)
     {
       bool resolved = false;
-      std::string alib(dynstrtab + (*iter));   
+      std::string alib(dynstrtab + (*iter));
       if (alib.find('/') == alib.npos)
         {
           //
           // Base name only
-          // 
+          //
           for (pathiter = ld_lib_path.begin(); pathiter != ld_lib_path.end(); ++pathiter)
             {
               std::string pathtry = (*pathiter) + std::string("/") + alib;
               if (access(pathtry.c_str(), R_OK | X_OK) >= 0)
                 {
-                  dlibs.push_back(pathtry); 
-                  resolved = true; 
+                  dlibs.push_back(pathtry);
+                  resolved = true;
                   break;
                 }
             }
@@ -722,7 +722,7 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
             {
               dlibs.push_back(alib);
               resolved = true;
-            } 
+            }
         }
 
       if (!resolved)
@@ -737,9 +737,9 @@ get_dep_DSO (const std::string &daemonpath, std::vector<std::string> &dlibs)
       return -1;
     }
 
-  close(fd); 
+  close(fd);
 
-  return 0; 
+  return 0;
 }
 
 
@@ -749,14 +749,14 @@ main (int argc, char *argv[])
   int c;
   int optix;
   int apid;
-  std::string apidstr = ""; 
+  std::string apidstr = "";
   std::string bestarter = "";
   std::string daemonpath = "";
   std::string dargs = "";
   std::vector<std::string> dlibs;
   char optstring[] = "";
-   
-  opterr = 0; 
+
+  opterr = 0;
   while ( (c=getopt_long(argc, argv, optstring, lopts, &optix)) != -1)
     {
       switch (c)
@@ -776,7 +776,7 @@ main (int argc, char *argv[])
 
           case '?':
           default:
-            dargs += std::string(argv[optind-1]) + std::string(" "); 
+            dargs += std::string(argv[optind-1]) + std::string(" ");
             break;
         }
     }
@@ -785,34 +785,34 @@ main (int argc, char *argv[])
   for (ix=optind; ix < argc; ix++)
     {
       dargs = argv[ix] + std::string(" ") + dargs;
-    } 
+    }
 
   if (access(bestarter.c_str(), R_OK | X_OK) < 0)
     {
       ALPS_say_msg(MSGPREFIX, true, "Can't access %s", bestarter.c_str());
-      return EXIT_FAILURE; 
+      return EXIT_FAILURE;
     }
 
   if (access(daemonpath.c_str(), R_OK | X_OK) < 0)
     {
       ALPS_say_msg(MSGPREFIX, true, "Can't access %s", daemonpath.c_str());
-      return EXIT_FAILURE; 
+      return EXIT_FAILURE;
     }
 
   if (get_dep_DSO (daemonpath, dlibs) < 0)
     {
       ALPS_say_msg(MSGPREFIX, true, "Error in get_dep_DSO");
-      return EXIT_FAILURE; 
+      return EXIT_FAILURE;
     }
 
   if (launch_daemons(apid, dlibs, bestarter, daemonpath, dargs) != 0)
     {
       ALPS_say_msg(MSGPREFIX, true, "Error in launch_daemons");
-      return EXIT_FAILURE; 
+      return EXIT_FAILURE;
     }
 
   //
-  // TODO: There is no monitoring service in the ALPS tool helper launcher  
+  // TODO: There is no monitoring service in the ALPS tool helper launcher
   // determine the strategy to overcome this constraint
   //
   // For now, sleep with SIGINT signal handler installed

--- a/tools/ciod/Makefile.am
+++ b/tools/ciod/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at

--- a/tools/cobo/Makefile.am
+++ b/tools/cobo/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
@@ -32,4 +32,4 @@
 ##        Jun 06 2007 DHA: Copied from the old Makefile.
 ##
 
-SUBDIRS         = src 
+SUBDIRS         = src

--- a/tools/cobo/src/Makefile.am
+++ b/tools/cobo/src/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
@@ -33,10 +33,10 @@
 ##        Dec 16 2009 DHA: Made for COBO
 ##
 
-lib_LTLIBRARIES    = libcobo.la 
+lib_LTLIBRARIES    = libcobo.la
 libcobo_la_SOURCES = cobo.c \
                      cobo.h
-noinst_HEADERS     = cobo.h 
+noinst_HEADERS     = cobo.h
 libcobo_la_LDFLAGS = -version-info @LMON_CURRENT@:@LMON_REVISION@:@LMON_AGE@
 libcobo_la_CFLAGS  = -I$(top_srcdir)/tools/handshake
 libcobo_la_LIBADD  = $(top_builddir)/tools/handshake/libhandshake.la

--- a/tools/cobo/src/cobo.c
+++ b/tools/cobo/src/cobo.c
@@ -24,13 +24,13 @@
 #define ENV_OPTIONAL (1)
 
 /* set env variable to configure socket timeout parameters */
-#ifndef COBO_CONNECT_TIMEOUT       
+#ifndef COBO_CONNECT_TIMEOUT
 #define COBO_CONNECT_TIMEOUT (10) /* milliseconds -- wait this long before a connect() call times out*/
 #endif
 #ifndef COBO_CONNECT_BACKOFF
 #define COBO_CONNECT_BACKOFF (2) /* exponential backoff factor for timeout */
 #endif
-#ifndef COBO_CONNECT_SLEEP  
+#ifndef COBO_CONNECT_SLEEP
 #define COBO_CONNECT_SLEEP   (10) /* milliseconds -- wait this long before trying a new round of connects() */
 #endif
 #ifndef COBO_CONNECT_TIMELIMIT
@@ -55,7 +55,7 @@
 /*
  * DHA 4/11/2014: Security protocol blurb
  * cobo_sec_protocol should be set properly by
- * the upper layer. 
+ * the upper layer.
  *
  */
 handshake_protocol_t cobo_sec_protocol;
@@ -462,7 +462,7 @@ done:
 */
         return -1;
     }
- 
+
     return 0;
 }
 
@@ -506,7 +506,7 @@ static int cobo_connect_hostname(char* hostname, int rank)
     /* lookup host address by name */
     struct hostent* he = gethostbyname(hostname);
     if (!he) {
-       /* gethostbyname doesn't know how to resolve hostname, trying inet_addr */ 
+       /* gethostbyname doesn't know how to resolve hostname, trying inet_addr */
        saddr.s_addr = inet_addr(hostname);
        if (saddr.s_addr == -1) {
            cobo_error("Hostname lookup failed (gethostbyname(%s) %s h_errno=%d) @ file %s:%d",
@@ -700,7 +700,7 @@ static int cobo_send_hostlist(int s, char* hostname, int rank, int ranks, void* 
     return COBO_SUCCESS;
 }
 
-/* 
+/*
  * =============================
  * Functions to open/close the TCP/socket tree.
  * =============================
@@ -1012,7 +1012,7 @@ static int cobo_close_tree()
     return COBO_SUCCESS;
 }
 
-/* 
+/*
  * =============================
  * Functions to bcast/gather/scatter with root as rank 0 using the TCP/socket tree.
  * =============================
@@ -1196,7 +1196,7 @@ int cobo_get_parent_socket(int* fd)
         return COBO_SUCCESS;
     }
 
-    return -1; /* failure RCs? */ 
+    return -1; /* failure RCs? */
 }
 
 /* Perform barrier, each task writes an int then waits for an int */
@@ -1481,7 +1481,7 @@ int cobo_open(unsigned int sessionid, int* portlist, int num_ports, int* rank, i
     );
 
     /* DHA 4/11/2014: enable security handshake timeout */
-    handshake_enable_read_timeout(cobo_connect_timeout); 
+    handshake_enable_read_timeout(cobo_connect_timeout);
 
     /* copy port list from user */
     cobo_num_ports = num_ports;

--- a/tools/cti/Makefile.am
+++ b/tools/cti/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2010, Lawrence Livermore National Security, LLC. Produced at
@@ -36,8 +36,8 @@ AM_CPPFLAGS                	= -I$(top_srcdir) \
                            	  -I$(top_srcdir)/launchmon/src \
                               -I$(top_srcdir)/@LMONAPILOC@
 
-bin_PROGRAMS                = cti_fe_colocator 
-cti_fe_colocator_SOURCES    = cti_fe_colocator.cxx 
+bin_PROGRAMS                = cti_fe_colocator
+cti_fe_colocator_SOURCES    = cti_fe_colocator.cxx
 cti_fe_colocator_CXXFLAGS   = @LNCHR_BIT_FLAGS@ $(CRAY_CTI_CFLAGS)
 cti_fe_colocator_LDADD      = $(CRAY_CTI_LIBS)
 

--- a/tools/handshake/Makefile.am
+++ b/tools/handshake/Makefile.am
@@ -1,6 +1,6 @@
 ## $Header: $
 ##
-## Makefile.am -- Process this file with automake to produce Makefile.in 
+## Makefile.am -- Process this file with automake to produce Makefile.in
 ##
 ##--------------------------------------------------------------------------------
 ## Copyright (c) 2008, Lawrence Livermore National Security, LLC. Produced at
@@ -38,7 +38,7 @@
 ##        Mar 10 2014 MPL: Add secure handshake
 ##
 
-noinst_LTLIBRARIES = libhandshake.la 
+noinst_LTLIBRARIES = libhandshake.la
 libhandshake_la_SOURCES = handshake.c handshake.h
 libhandshake_la_LIBADD = $(MUNGE_LIBS)
 

--- a/tools/handshake/handshake.c
+++ b/tools/handshake/handshake.c
@@ -1,8 +1,8 @@
 /*
  * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2014, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2014, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
@@ -135,15 +135,15 @@ static int encode_packet(handshake_packet_t *packet, uint64_t session_id,
 /** Routines for turning a handshake_packet_t into an encrypted buffer **/
 static int encrypt_packet(handshake_protocol_t *hdata, handshake_packet_t *packet,
                           unsigned char **packet_buffer, size_t *packet_buffer_size);
-static int none_encrypt_packet(handshake_packet_t *packet, 
+static int none_encrypt_packet(handshake_packet_t *packet,
                                unsigned char **packet_buffer, size_t *packet_buffer_size);
-static int munge_encrypt_packet(handshake_packet_t *packet, 
+static int munge_encrypt_packet(handshake_packet_t *packet,
                                 unsigned char **packet_buffer, size_t *packet_buffer_size);
 static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
-                                  handshake_packet_t *packet, 
+                                  handshake_packet_t *packet,
                                   unsigned char **packet_buffer, size_t *packet_buffer_size);
 static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
-                              handshake_packet_t *packet, 
+                              handshake_packet_t *packet,
                               unsigned char **packet_buffer, size_t *packet_buffer_size);
 
 /** Routines for decrypting and validating a handshake_packet_t **/
@@ -256,7 +256,7 @@ static int handshake_wrapper(int sockfd, handshake_protocol_t *hdata, uint64_t s
       return_result = result;
       goto done;
    }
-   
+
    for (;;) {
       result = handshake_main(sockfd, hdata, session_id, is_server);
       if (result != HSHAKE_AGAIN) {
@@ -315,7 +315,7 @@ static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t sess
    packet.signature = is_server ? SERVER_TO_CLIENT_SIG : CLIENT_TO_SERVER_SIG;
    debug_printf("Encoded packet: server_port = %d, client_port = %d, "
                 "uid = %d, gid = %d, session_id = %llu, signature = %lx\n",
-                (int) packet.server_port, (int) packet.client_port, (int) packet.uid, (int) packet.gid, 
+                (int) packet.server_port, (int) packet.client_port, (int) packet.uid, (int) packet.gid,
                 (unsigned long long) packet.session_id, (unsigned long) packet.signature);
 
    /**
@@ -363,7 +363,7 @@ static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t sess
       goto done;
    }
    expected_packet.signature = is_server ? CLIENT_TO_SERVER_SIG : SERVER_TO_CLIENT_SIG;
-  
+
    /**
     * Decrypt the packet recieved on the network and compare
     * it to the expected handshake_packet_t
@@ -382,9 +382,9 @@ static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t sess
 
   done:
 
-   /** 
+   /**
     * Send to peer the result of our connection attempt.  Only share whether
-    * we're accepting, dropping, or asking for a re-try.  
+    * we're accepting, dropping, or asking for a re-try.
     **/
    if (!socket_error) {
       peer_result = share_result(sockfd, return_result);
@@ -434,23 +434,23 @@ static int encode_packet(handshake_packet_t *packet, uint64_t session_id,
    packet->uid = getuid();
    packet->gid = getgid();
    packet->session_id = session_id;
-   
+
    result = encode_addr(server_addr, packet->server_addr, &packet->server_port);
    if (result < 0) {
       debug_printf("Error encoding server addr\n");
       return result;
    }
-   
+
    result = encode_addr(client_addr, packet->client_addr, &packet->client_port);
    if (result < 0) {
       debug_printf("Error encoding client addr\n");
       return result;
    }
-   
+
    return 0;
 }
 
-static int encrypt_packet(handshake_protocol_t *hdata, handshake_packet_t *packet, 
+static int encrypt_packet(handshake_protocol_t *hdata, handshake_packet_t *packet,
                           unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
    switch (hdata->mechanism) {
@@ -478,7 +478,7 @@ static int encrypt_packet(handshake_protocol_t *hdata, handshake_packet_t *packe
    return HSHAKE_INTERNAL_ERROR;
 }
 
-static int none_encrypt_packet(handshake_packet_t *packet, 
+static int none_encrypt_packet(handshake_packet_t *packet,
                                unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
 #if defined(ENABLE_NULL_ENCRYPTION)
@@ -503,25 +503,25 @@ static int munge_create_context(munge_ctx_t *output_ctx)
       error_printf("Problem creating munge context\n");
       return HSHAKE_INTERNAL_ERROR;
    }
-   
+
    result = munge_ctx_set(ctx, MUNGE_OPT_CIPHER_TYPE, MUNGE_CIPHER_AES128);
    if (result != EMUNGE_SUCCESS) {
       error_printf("Unable to set cipher type in munge: %s", munge_ctx_strerror(ctx) ? : "NO ERROR");
       return HSHAKE_INTERNAL_ERROR;
    }
-   
+
    result = munge_ctx_set(ctx, MUNGE_OPT_TTL, MUNGE_TTL_TIMEOUT_SEC);
    if (result != EMUNGE_SUCCESS) {
       error_printf("Unable to set TTL in munge: %s", munge_ctx_strerror(ctx) ? : "NO ERROR");
       return HSHAKE_INTERNAL_ERROR;
-   } 
-   
+   }
+
    *output_ctx = ctx;
    return 0;
 }
 #endif
 
-static int munge_encrypt_packet(handshake_packet_t *packet, 
+static int munge_encrypt_packet(handshake_packet_t *packet,
                                 unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
 #if defined(MUNGE)
@@ -535,7 +535,7 @@ static int munge_encrypt_packet(handshake_packet_t *packet,
       return_result = result;
       goto done;
    }
-   
+
    result = munge_encode((char **) packet_buffer, ctx, packet, sizeof(*packet));
    if (result != EMUNGE_SUCCESS) {
       error_printf("Munge failed to encrypt packet with error: %s\n", munge_ctx_strerror(ctx));
@@ -576,7 +576,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
       debug_printf("Reusing saved key at %s\n", key_filepath);
       return 0;
    }
-   
+
    if (saved_key) {
       memset(saved_key, 0, saved_key_len);
       free(saved_key);
@@ -596,16 +596,16 @@ static int read_key(char *key_filepath, int key_length_bytes)
       return_result = HSHAKE_ABORT;
       goto done;
    }
-   
+
    if (st.st_uid != uid) {
-      security_error_printf("UID on key file %s (%d) does not match my UID (%d)\n", 
+      security_error_printf("UID on key file %s (%d) does not match my UID (%d)\n",
                             key_filepath, st.st_uid, uid);
       return_result = HSHAKE_ABORT;
       goto done;
    }
 
    if (st.st_gid != gid) {
-      security_error_printf("GID on key file %s (%d) does not match my GID (%d)\n", 
+      security_error_printf("GID on key file %s (%d) does not match my GID (%d)\n",
                             key_filepath, st.st_gid, gid);
       return_result = HSHAKE_ABORT;
       goto done;
@@ -617,7 +617,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
       return_result = HSHAKE_ABORT;
       goto done;
    }
-   
+
    if (st.st_size != key_length_bytes) {
       security_error_printf("Size on key file %s is %lu and does not match expected size of %lu\n",
                             key_filepath, (unsigned long) st.st_size, (unsigned long) key_length_bytes);
@@ -649,7 +649,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
 }
 
 static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
-                                  handshake_packet_t *packet, 
+                                  handshake_packet_t *packet,
                                   unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
    int result;
@@ -659,7 +659,7 @@ static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
       debug_printf("Error reading key from %s\n", key_filepath);
       return result;
    }
-   
+
    result = key_encrypt_packet(saved_key, key_length_bytes, packet,
                                packet_buffer, packet_buffer_size);
    if (result < 0) {
@@ -683,7 +683,7 @@ static int get_hash_of_buffer(unsigned char *buffer, size_t buffer_size,
    debug_printf("Encrypting with GCRY_MD_SHA256\n");
    algo = GCRY_MD_SHA256;
    *hash_result_size = 32;
-   
+
    gcry_result = gcry_md_open(&md, algo, GCRY_MD_FLAG_HMAC);
    if (gcry_result != GPG_ERR_NO_ERROR) {
       error_printf("Error initializing gcrypt: %s (%d)\n", gpg_strerror(gcry_result), (int) gcry_result);
@@ -706,7 +706,7 @@ static int get_hash_of_buffer(unsigned char *buffer, size_t buffer_size,
 
    *hash_result = malloc(*hash_result_size);
    memcpy(*hash_result, temp_result, *hash_result_size);
-   
+
    gcry_md_close(md);
 
    return 0;
@@ -715,7 +715,7 @@ static int get_hash_of_buffer(unsigned char *buffer, size_t buffer_size,
 #endif
 
 static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
-                              handshake_packet_t *packet, 
+                              handshake_packet_t *packet,
                               unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
 #if defined(GCRYPT)
@@ -729,7 +729,7 @@ static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
       gcry_control(GCRYCTL_INITIALIZATION_FINISHED, 0);
       initialized = 1;
    }
-   
+
    result = get_hash_of_buffer((unsigned char *) packet, sizeof(*packet),
                                key, key_length_bytes,
                                &hash_result, &hash_result_size);
@@ -737,7 +737,7 @@ static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
       debug_printf("Error getting has while encrypting packet\n");
       return result;
    }
-   
+
    debug_printf("Adding packet of size %lu and hash of size %u to buffer\n",
                 (unsigned long) sizeof(*packet), hash_result_size);
    *packet_buffer_size = sizeof(*packet) + hash_result_size;
@@ -747,11 +747,11 @@ static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
 
    free(hash_result);
 
-   return 0;   
+   return 0;
 #else
    error_printf("Handshake not built against gcrypt\n");
    return HSHAKE_INTERNAL_ERROR;
-#endif   
+#endif
 }
 
 static int reliable_write(int fd, const void *buf, size_t size)
@@ -786,7 +786,7 @@ static int reliable_read(int fd, void *buf, size_t size)
          FD_SET(fd, &rfd_set);
          timeout.tv_sec = timeout_seconds;
          timeout.tv_usec = 0;
-         
+
          result = select(fd+1, &rfd_set, NULL, NULL, &timeout);
          if (result == -1) {
             error_printf("Error select'ing on socket fd: %s\n", strerror(errno));
@@ -798,8 +798,8 @@ static int reliable_read(int fd, void *buf, size_t size)
          }
          else if (result != 1) {
             error_printf("Unexpected return code of %d from select\n", result);
-            return HSHAKE_INTERNAL_ERROR;            
-         }        
+            return HSHAKE_INTERNAL_ERROR;
+         }
       }
       result = read(fd, ((unsigned char *) buf) + bytes_read, size - bytes_read);
       if (result <= 0) {
@@ -875,7 +875,7 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
       return_result = iresult;
       goto done;
    }
-   
+
    result = munge_decode((char *) recvd_buffer, ctx, &payload, &payload_size, &uid, &gid);
    switch (result) {
       case EMUNGE_SUCCESS:
@@ -914,8 +914,8 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
          security_error_printf("Unknown error return from munge: %s\n", munge_strerror(result));
          return_result = HSHAKE_ABORT;
          goto done;
-   } 
-     
+   }
+
    if (payload_size != sizeof(*recvd_packet)) {
       security_error_printf("Recieved munge packet with invalid payload size of %d\n", (int) payload_size);
       return_result = HSHAKE_ABORT;
@@ -925,20 +925,20 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
 
    /* Munge provides a UID and GID.  That should match the copy in the payload */
    if (recvd_packet->uid != uid) {
-      security_error_printf("Packet came from uid %d, but payload claimed uid %d\n", 
+      security_error_printf("Packet came from uid %d, but payload claimed uid %d\n",
                             (int) recvd_packet->uid, (int) uid);
       return_result = HSHAKE_ABORT;
       goto done;
    }
    if (recvd_packet->gid != gid) {
-      security_error_printf("Packet came from gid %d, but payload claimed gid %d\n", 
+      security_error_printf("Packet came from gid %d, but payload claimed gid %d\n",
                             (int) recvd_packet->gid, (int) gid);
       return_result = HSHAKE_ABORT;
       goto done;
    }
-      
+
    return_result = compare_packets(expected_packet, recvd_packet);
-      
+
   done:
    if (payload)
       free(payload);
@@ -946,7 +946,7 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
       munge_ctx_destroy(ctx);
 
    return return_result;
-   
+
 #else
    error_printf("Handshake not compiled with munge support\n");
    return HSHAKE_INTERNAL_ERROR;
@@ -962,7 +962,7 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
    unsigned char *calcd_hash_val = NULL, *recvd_hash_val;
    int result, return_result, hash_val_size;
    int i;
-  
+
    if (recvd_buffer_size < sizeof(*expected_packet)) {
       error_printf("Packet was too small.  Size was %d, expected at least %d\n",
                    (int) recvd_buffer_size, (int) sizeof(*expected_packet));
@@ -971,7 +971,7 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
    }
 
    recvd_packet = (handshake_packet_t *) recvd_buffer;
-   
+
    result = get_hash_of_buffer((unsigned char *) recvd_packet, sizeof(*recvd_packet),
                                key, key_len,
                                &calcd_hash_val, &hash_val_size);
@@ -980,7 +980,7 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
       return_result = HSHAKE_INTERNAL_ERROR;
       goto done;
    }
-   
+
    if (recvd_buffer_size != sizeof(*recvd_packet) + hash_val_size) {
       error_printf("Packet was too small.  Size was %d, expected %d\n",
                    (int) recvd_buffer_size, (int) sizeof(*recvd_packet) + hash_val_size);
@@ -998,11 +998,11 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
    }
 
    return_result = compare_packets(expected_packet, recvd_packet);
-   
+
   done:
    if (calcd_hash_val)
       free(calcd_hash_val);
-   
+
    return return_result;
 #else
    error_printf("handshake was not compiled with gcrypt support");
@@ -1090,15 +1090,15 @@ static int share_result(int fd, int handshake_result)
          result_to_send = HSHAKE_AGAIN;
          break;
    }
-    
+
    debug_printf("Sharing handshake result %d with peer\n", result_to_send);
-      
+
    result = reliable_write(fd, &result_to_send, sizeof(result_to_send));
    if (result != sizeof(result_to_send)) {
       error_printf("Failed to send result of connection\n");
       return HSHAKE_INTERNAL_ERROR;
    }
-   
+
    debug_printf("Reading peer result\n");
    result = reliable_read(fd, &peer_result, sizeof(peer_result));
    if (result != sizeof(peer_result)) {
@@ -1122,7 +1122,7 @@ static int get_client_server_addrs(int sockfd, int i_am_server,
    socklen_t addr_len;
    int result;
 
-   debug_printf("Looking up server and client addresses for socket %d\n", sockfd);   
+   debug_printf("Looking up server and client addresses for socket %d\n", sockfd);
    addr_len = sizeof(remote_addr);
    result = getpeername(sockfd, &remote_addr, &addr_len);
    if (result == -1) {
@@ -1148,7 +1148,7 @@ static int get_client_server_addrs(int sockfd, int i_am_server,
    return 0;
 }
 
-static int exchange_sig(int sockfd) 
+static int exchange_sig(int sockfd)
 {
    uint32_t sig = SIG;
    int result;
@@ -1192,8 +1192,8 @@ static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_si
    if (result != packet_size) {
       debug_printf("Problem writing packet on network\n");
       return HSHAKE_INTERNAL_ERROR;
-   }   
-   
+   }
+
    return 0;
 }
 
@@ -1221,7 +1221,7 @@ static int recv_packet(int sockfd, unsigned char **packet, size_t *packet_size)
       return HSHAKE_INTERNAL_ERROR;
    }
    *packet_size = size;
-   debug_printf("Received packet from network\n");   
+   debug_printf("Received packet from network\n");
 
    return 0;
 }
@@ -1234,7 +1234,7 @@ static char *sockaddr_str(struct sockaddr *addr, char *buffer, size_t buffer_siz
          uint32_t ip = addr_in->sin_addr.s_addr;
          uint16_t port = ntohs(addr_in->sin_port);
          unsigned char *ip_bytes = (unsigned char *) &ip;
-         snprintf(buffer, buffer_size, "%u.%u.%u.%u:%u", 
+         snprintf(buffer, buffer_size, "%u.%u.%u.%u:%u",
                   (unsigned) ip_bytes[0], (unsigned) ip_bytes[1],
                   (unsigned) ip_bytes[2], (unsigned) ip_bytes[3],
                   port);
@@ -1273,25 +1273,25 @@ static int log_security_error(const char *format, ...)
    va_list ap;
 
    va_start(ap, format);
-   vasprintf(&message_str, format, ap); 
+   vasprintf(&message_str, format, ap);
    va_end(ap);
-   
+
    assert(saved_conninfo);
    if (saved_conninfo->i_am_server)
       asprintf(&conn_str,
                "COBO/PMGR Handshake Security Error. My uid = %d. "
-               "Client at %s tried to connect to me at %s, but failed with error: ", 
+               "Client at %s tried to connect to me at %s, but failed with error: ",
                getuid(),
-               sockaddr_str(&saved_conninfo->client_addr, client_name, sizeof(client_name)), 
+               sockaddr_str(&saved_conninfo->client_addr, client_name, sizeof(client_name)),
                sockaddr_str(&saved_conninfo->server_addr, server_name, sizeof(server_name)));
-   else 
+   else
       asprintf(&conn_str,
                "COBO/PMGR Handshake Security Error. My uid = %d. "
-               "Server at %s took my connection from %s, but failed with error: ", 
+               "Server at %s took my connection from %s, but failed with error: ",
                getuid(),
-               sockaddr_str(&saved_conninfo->server_addr, server_name, sizeof(server_name)), 
+               sockaddr_str(&saved_conninfo->server_addr, server_name, sizeof(server_name)),
                sockaddr_str(&saved_conninfo->client_addr, client_name, sizeof(client_name)));
-   
+
    if (last_security_message != NULL) {
       free(last_security_message);
    }
@@ -1316,7 +1316,7 @@ void handshake_log_sec_error(const char *msg)
    msg_size = strlen(hshake_msg) + strlen(msg) + 1;
    newmsg = (char *) malloc(msg_size);
    snprintf(newmsg, msg_size, "%s%s", msg, hshake_msg);
-  
+
    openlog("LaunchMON", LOG_CONS, LOG_USER);
    syslog(LOG_AUTHPRIV | LOG_ERR, "%s", newmsg);
    closelog();

--- a/tools/handshake/handshake.h
+++ b/tools/handshake/handshake.h
@@ -1,8 +1,8 @@
 /*
  * $Header: Exp $
  *--------------------------------------------------------------------------------
- * Copyright (c) 2014, Lawrence Livermore National Security, LLC. Produced at 
- * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>. 
+ * Copyright (c) 2014, Lawrence Livermore National Security, LLC. Produced at
+ * the Lawrence Livermore National Laboratory. Written by Dong H. Ahn <ahn1@llnl.gov>.
  * LLNL-CODE-409469. All rights reserved.
  *
  * This file is part of LaunchMON. For details, see
@@ -49,7 +49,7 @@ extern "C" {
 
 typedef enum {
    hs_none,         //No security validation in handshake
-   hs_munge,        //Use munge 
+   hs_munge,        //Use munge
    hs_key_in_file,  //Use gcrypt with key from file
    hs_explicit_key  //Use gcrypt with provided key
 } handshake_security_t;


### PR DESCRIPTION
@lee218llnl: This is still experimental. I need to at least verify this builds on TOSS3 and Sierra systems.

This PR removes trailing whitespaces and applies Google coding style.

This was mostly done automatically using `clang-format -style=Google`.

Then, I manually fixed some of the changes that were just incorrect. 

Resolve Issue #19. 