### PR TITLE
enable subdir-objects for automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ dnl -----------------------------------------------
 dnl Automake support
 dnl -----------------------------------------------
 dnl The new form for AM_INIT_AUTOMAKE takes only one argument 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 dnl If you don't want silent make, make V=1
 AM_SILENT_RULES([yes])
 dnl You don't want configure to rebuild Makefile.ins


### PR DESCRIPTION
This should resolve errors like this:

launchmon/src/linux/Makefile.am:58: warning: source file '$(BASE_SRC_DIR)/sdbg_opt.cxx' is in a subdirectory,
launchmon/src/linux/Makefile.am:58: but option 'subdir-objects' is disabled

I was getting this when trying to bootstrap the master branch via spack.