### PR TITLE
enable subdir-objects for automake

### DIFF
--- a/launchmon/src/linux/Makefile.am
+++ b/launchmon/src/linux/Makefile.am
@@ -48,6 +48,7 @@
 ##        Dec 27 2006 DHA: Created file.
 ##
 
+AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS = lmon_api
 BASE_SRC_DIR = $(top_srcdir)/launchmon/src
 API_SRC_DIR = $(srcdir)/lmon_api

--- a/launchmon/src/linux/lmon_api/Makefile.am
+++ b/launchmon/src/linux/lmon_api/Makefile.am
@@ -41,6 +41,7 @@
 ##        Dec 27 2006 DHA: Created file.
 ##
 
+AUTOMAKE_OPTIONS = subdir-objects
 PLAT_SRC_DIR = $(top_srcdir)/launchmon/src/linux
 BASE_SRC_DIR = $(top_srcdir)/launchmon/src
 VPATH = $(PLAT_SRC_DIR):$(BASE_SRC_DIR):$(srcdir)


### PR DESCRIPTION
This should resolve errors like this:

launchmon/src/linux/Makefile.am:58: warning: source file '$(BASE_SRC_DIR)/sdbg_opt.cxx' is in a subdirectory,
launchmon/src/linux/Makefile.am:58: but option 'subdir-objects' is disabled

I was getting this when trying to bootstrap the master branch via spack.