### PR TITLE
build tests against src directory instead of install prefix

### DIFF
--- a/test/src/Makefile.am
+++ b/test/src/Makefile.am
@@ -51,20 +51,18 @@ CIOD_INC_FLAGS = -I@ARCHHEADER@ \
 endif
 
 if WITH_TEST_INSTALLED
-API_DIR = $(prefix)/include
-API_LIB_DIR = $(prefix)/lib
 ENGINE_PATH = $(prefix)/bin/launchmon$(EXEEXT)
 LMONPREFIX = $(prefix)
 IN_TREE_RM_CONFIG_DIR = 0
 IN_TREE_COLOC_UTIL_DIR = 0
 else
-API_DIR = ${abs_top_srcdir}/launchmon/src
-API_LIB_DIR = $(abs_top_builddir)/launchmon/src/linux/lmon_api
 ENGINE_PATH = $(abs_top_builddir)/launchmon/src/linux/launchmon$(EXEEXT)
 LMONPREFIX = 0
 IN_TREE_RM_CONFIG_DIR = $(abs_top_srcdir)/etc
 IN_TREE_COLOC_UTIL_DIR = $(abs_top_builddir)/tools/alps/src
 endif
+API_DIR = ${abs_top_srcdir}/launchmon/src
+API_LIB_DIR = $(abs_top_builddir)/launchmon/src/linux/lmon_api
 
 AM_CPPFLAGS = \
   -I$(API_DIR) \


### PR DESCRIPTION
@dongahn Please let me know what you think of this. When trying to install the master branch in Spack, it fails to link the test binaries to the API libraries since the install is staged in a tmpdir and then not moved to the actual prefix until the entire install step is complete. IMHO it is OK to use the headers and libraries in the source directory when building the tests. At runtime, the appropriate libraries should get loaded anyway due to the rpaths.