### PR TITLE
Add requirement for libgcrypt-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ LaunchMON requires the following packages to build
 libelf
 boost
 libgcrypt >= 1.4.5
+libgcrypt-devel >= 1.4.5
 libgpg-error >= 1.7.0
 # for secure handshake
 munge


### PR DESCRIPTION
Apparently libgcrypt-devel is required; otherwise the bootstrap step returns the following messages (which disappear after installing libgcrypt-devel and running the. bootstrap step again):

```
Running aclocal ...
configure.ac:146: warning: macro 'AM_PATH_LIBGCRYPT' not found in library
Running libtoolize ...
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, `config'.
libtoolize: copying file `config/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `config'.
libtoolize: copying file `config/libtool.m4'
libtoolize: copying file `config/ltoptions.m4'
libtoolize: copying file `config/ltsugar.m4'
libtoolize: copying file `config/ltversion.m4'
libtoolize: copying file `config/lt~obsolete.m4'
Running autoheader ...
Running automake ...
Running autoconf ...
configure.ac:60: error: possibly undefined macro: AC_SUBST
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:125: error: possibly undefined macro: AC_DEFINE
configure.ac:146: error: possibly undefined macro: AM_PATH_LIBGCRYPT
configure.ac:156: error: possibly undefined macro: AC_MSG_ERROR
```
