### PR TITLE
Add requirement for boost-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LaunchMON requires the following packages to build
 ```
 libelf
 boost
+boost-devel
 libgcrypt >= 1.4.5
 libgpg-error >= 1.7.0
 # for secure handshake


### PR DESCRIPTION
Apparently boost-devel is also needed, otherwise you get the following error during the make step:

```
Making all in lmon_api
make[5]: Entering directory `/root/spindle-test/LaunchMON/launchmon/src/linux/lmon_api'
  CXX      libmonfeapi_la-sdbg_rm_map.lo
../../../../launchmon/src/sdbg_rm_map.cxx:58:31: fatal error: boost/tokenizer.hpp: No such file or directory
 #include <boost/tokenizer.hpp>
                               ^
compilation terminated.
```