### PR TITLE
add --overlap to slurm configuration

### DIFF
--- a/etc/rm_slurm.conf
+++ b/etc/rm_slurm.conf
@@ -59,5 +59,5 @@ RM_jobid=RM_launcher|sym|totalview_jobid|string
 RM_launch_helper=srun
 RM_signal_for_kill=SIGINT|SIGINT
 RM_fail_detection=true
-RM_launch_str=--input=none --gres=none --mem-per-cpu=0 --jobid=%j --nodes=%n --ntasks=%n --nodelist=%l %d %o --lmonsharedsec=%s --lmonsecchk=%c
+RM_launch_str=--input=none --gres=none --mem-per-cpu=0 --jobid=%j --overlap --nodes=%n --ntasks=%n --nodelist=%l %d %o --lmonsharedsec=%s --lmonsecchk=%c
 


### PR DESCRIPTION
With newer versions of slurm (i.e., 20.11.8), it looks like the default configuration does not allow simultaneous jobs within an allocation. This causes launchmon to hang when attaching. Adding the "--overlap" flag to LaunchMON's slurm config appears to be the solution.