### PR TITLE
add --overlap for slurm >= 20.11

### DIFF
--- a/config/x_ac_platform_compat.m4
+++ b/config/x_ac_platform_compat.m4
@@ -58,3 +58,20 @@ AC_DEFUN([X_AC_SGI_HOSTNAMES], [
   fi
   AC_MSG_RESULT($enable_sgi_hostnames)
 ])
+
+AC_DEFUN([X_AC_SLURM_OVERLAP], [
+  SRUN_OVERLAP=""
+  AC_CHECK_PROG(SRUN, srun, "yes")
+  if test "$SRUN" = "yes"; then
+    AC_MSG_CHECKING([srun version >= 20.11 and supports --overlap])
+    slurm_version=`srun --version | cut -f 2 -d " "`
+    slurm_min=`printf '%s\n' "20.11" "$slurm_version" | sort -V | head -n 1`
+    if test $slurm_min = "20.11" ; then
+      AC_MSG_RESULT("yes")
+      SRUN_OVERLAP=" --overlap "
+    else
+      AC_MSG_RESULT("no")
+    fi
+  fi
+])
+AC_SUBST(SRUN_OVERLAP)

--- a/config/x_ac_platform_compat.m4
+++ b/config/x_ac_platform_compat.m4
@@ -29,6 +29,7 @@
 #
 #   Update Log:
 #         May 06 2016 DHA: File created
+#         Aug 13 2021 GLL: Add srun version check to see if --overlap needed
 #
 
 AC_DEFUN([X_AC_SLURM_MPAO_WR], [

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,7 @@ dnl Checks for the OS/CPU/RM type
 dnl -----------------------------------------------
 X_AC_PLATFORM
 X_AC_SLURM_MPAO_WR
+X_AC_SLURM_OVERLAP
 
 dnl -----------------------------------------------
 dnl Checks whether to enable SGI hostnames
@@ -307,6 +308,7 @@ AC_CONFIG_FILES([
   launchmon/src/linux/lmon_api/Makefile
   launchmon/man/Makefile
   etc/Makefile
+  etc/rm_slurm.conf
   etc/pkg-specs/Makefile
   etc/pkg-specs/llnl/Makefile
   test/Makefile

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -60,6 +60,6 @@ EXTRA_DIST = \
   rm_bgq_slurm.conf \
   rm_mchecker.conf \
   rm_openrte.conf \
-  rm_slurm.conf \
+  rm_slurm.conf.in \
   rm_mpiexec_hydra.conf
 

--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -31,6 +31,7 @@
 ##  Update Log:
 ##        May 18 2018 ADG: Added Cray CTI support
 ##        Apr 28 2016 DHA: Created file.
+##        Aug 13 2021 GLL: use input file for slurm to allow configure-time options
 ##
 
 SUBDIRS = pkg-specs

--- a/etc/rm_slurm.conf.in
+++ b/etc/rm_slurm.conf.in
@@ -59,5 +59,5 @@ RM_jobid=RM_launcher|sym|totalview_jobid|string
 RM_launch_helper=srun
 RM_signal_for_kill=SIGINT|SIGINT
 RM_fail_detection=true
-RM_launch_str=--input=none --gres=none --mem-per-cpu=0 --jobid=%j --nodes=%n --ntasks=%n --nodelist=%l %d %o --lmonsharedsec=%s --lmonsecchk=%c
+RM_launch_str=@SRUN_OVERLAP@--input=none --gres=none --mem-per-cpu=0 --jobid=%j --nodes=%n --ntasks=%n --nodelist=%l %d %o --lmonsharedsec=%s --lmonsecchk=%c
 

--- a/etc/rm_slurm.conf.in
+++ b/etc/rm_slurm.conf.in
@@ -31,6 +31,7 @@
 ##        Sep 30 2011 DHA: Created file.
 ##        Feb 02 2016 GLL: Added sattach.
 ##        May 18 2018 ADG: Modified launch string to avoid requesting resources.
+##        Aug 13 2021 GLL: Add --overlap to launch_str if configure detects srun version >= 20.11
 ##
 ##
 ## RM: the name of Resource Manager


### PR DESCRIPTION
This is a more proper fix than #57. The "--overlap" option was added to slurm in version 20.11 and is required by default otherwise the srun invocation of the launchmon tool helper will hang as the initial application launched with srun that it attaches to will exclusively hold the resources. Slurm versions less than 20.11 will not recognize this flag and get an error.