### PR TITLE
Remove dynamic exception specifiers

### DIFF
--- a/launchmon/src/linux/sdbg_linux_ptracer.hxx
+++ b/launchmon/src/linux/sdbg_linux_ptracer.hxx
@@ -129,92 +129,91 @@ class linux_ptracer_t : public tracer_base_t<SDBG_DEFAULT_TEMPLPARAM> {
   //
   virtual tracer_error_e tracer_setregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_getregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_setfpregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_getfpregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_read(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_read_string(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_get_event_msg(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf,
-      bool use_cxt) throw(tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_write(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, const void *buf,
-      int size, bool use_cxt) throw(linux_tracer_exception_t);
+      int size, bool use_cxt);
 
   virtual tracer_error_e tracer_continue(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_deliver_signal(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_stop(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
                                      bool use_cxt);
 
   virtual tracer_error_e tracer_kill(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_singlestep(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_syscall(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(linux_tracer_exception_t);
+      bool use_cxt);
 
   virtual tracer_error_e tracer_detach(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt);
 
   virtual tracer_error_e tracer_setoptions(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid = -1) throw(linux_tracer_exception_t);
+      pid_t newtid = -1);
 
   virtual tracer_error_e tracer_unsetoptions(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid) throw(linux_tracer_exception_t);
+      pid_t newtid);
 
   virtual tracer_error_e tracer_attach(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid = -1) throw(linux_tracer_exception_t);
+      pid_t newtid = -1);
 
   virtual tracer_error_e status(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
                                 bool use_cxt);
 
-  virtual tracer_error_e tracer_trace_me() throw(linux_tracer_exception_t);
+  virtual tracer_error_e tracer_trace_me();
 
   virtual tracer_error_e enable_breakpoint(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
-      bool use_cxt, bool change_state = true) throw(linux_tracer_exception_t);
+      bool use_cxt, bool change_state = true);
 
   virtual tracer_error_e disable_breakpoint(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
-      bool use_cxt, bool change_state = true) throw(linux_tracer_exception_t);
+      bool use_cxt, bool change_state = true);
 
-  virtual tracer_error_e convert_error_code(int err) throw(
-      linux_tracer_exception_t);
+  virtual tracer_error_e convert_error_code(int err);
 
   tracer_error_e baretracer(int __tag, pid_t __p, VA __addr,
-                            WT *__wd) throw(linux_tracer_exception_t);
+                            WT *__wd);
 
  private:
   bool LEVELCHK(self_trace_verbosity level) {

--- a/launchmon/src/linux/sdbg_linux_ptracer_impl.hxx
+++ b/launchmon/src/linux/sdbg_linux_ptracer_impl.hxx
@@ -97,7 +97,7 @@ linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::linux_ptracer_t(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setregs(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   string e;
@@ -172,7 +172,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setregs(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_getregs(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   string e;
@@ -236,7 +236,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_getregs(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_getfpregs(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   string e;
@@ -301,7 +301,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_getfpregs(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setfpregs(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
 
   return SDBG_TRACE_UNIMPLEMENTED;
 
@@ -315,7 +315,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setfpregs(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_read(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, VA addr, void* buf, int size,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -364,7 +364,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_read(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_read_string(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, VA addr, void* buf, int size,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -427,7 +427,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_read_string(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_get_event_msg(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, VA addr, void* buf,
-    bool use_cxt) throw(tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -451,7 +451,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_get_event_msg(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_write(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, VA addr, const void* buf,
-    int size, bool use_cxt) throw(linux_tracer_exception_t) {
+    int size, bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -502,7 +502,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_write(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_continue(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
   WT r;
   tracer_error_e rc = SDBG_TRACE_OK;
@@ -532,7 +532,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_continue(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_deliver_signal(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, int sig,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -591,7 +591,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_stop(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_kill(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -618,7 +618,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_kill(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_singlestep(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -649,7 +649,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_singlestep(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_syscall(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p,
-    bool use_cxt) throw(linux_tracer_exception_t) {
+    bool use_cxt) {
   using namespace std;
 
   WT r;
@@ -708,7 +708,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_detach(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_unsetoptions(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, bool use_cxt,
-    pid_t newtid) throw(linux_tracer_exception_t) {
+    pid_t newtid) {
   using namespace std;
 
   WT r;
@@ -745,7 +745,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_unsetoptions(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setoptions(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, bool use_cxt,
-    pid_t newtid) throw(linux_tracer_exception_t) {
+    pid_t newtid) {
   using namespace std;
 
   WT r;
@@ -782,7 +782,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_setoptions(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_attach(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, bool use_cxt,
-    pid_t newtid) throw(linux_tracer_exception_t) {
+    pid_t newtid) {
   using namespace std;
 
   WT r;
@@ -863,8 +863,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::status(
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e
-linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_trace_me() throw(
-    linux_tracer_exception_t) {
+linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_trace_me() {
   using namespace std;
 
   WT r;
@@ -888,7 +887,7 @@ linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::tracer_trace_me() throw(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::enable_breakpoint(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, breakpoint_base_t<VA, IT>& bp,
-    bool use_cxt, bool change_state) throw(linux_tracer_exception_t) {
+    bool use_cxt, bool change_state) {
   IT blend;
   IT origInst;
 
@@ -941,7 +940,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::enable_breakpoint(
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::disable_breakpoint(
     process_base_t<SDBG_DEFAULT_TEMPLPARAM>& p, breakpoint_base_t<VA, IT>& bp,
-    bool use_cxt, bool change_state) throw(linux_tracer_exception_t) {
+    bool use_cxt, bool change_state) {
   IT origInst;
 
   if (!bp.is_enabled()) {
@@ -972,7 +971,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::disable_breakpoint(
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::convert_error_code(
-    int en) throw(linux_tracer_exception_t) {
+    int en) {
   tracer_error_e err_code;
 
   switch (en) {
@@ -1012,7 +1011,7 @@ tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::convert_error_code(
 */
 template <SDBG_DEFAULT_TEMPLATE_WIDTH>
 tracer_error_e linux_ptracer_t<SDBG_DEFAULT_TEMPLPARAM>::baretracer(
-    int __tag, pid_t __p, VA __addr, WT* __wd) throw(linux_tracer_exception_t) {
+    int __tag, pid_t __p, VA __addr, WT* __wd) {
   using namespace std;
 
   WT r;

--- a/launchmon/src/linux/sdbg_linux_symtab.hxx
+++ b/launchmon/src/linux/sdbg_linux_symtab.hxx
@@ -142,7 +142,7 @@ class elf_wrapper {
   Elf* get_elf_handler() { return elf_handler; }
 
   symtab_error_e init(std::string& lib);
-  symtab_error_e init() throw(symtab_exception_t);
+  symtab_error_e init();
   symtab_error_e finalize();
 
  private:
@@ -182,12 +182,11 @@ class linux_image_t : public image_base_t<VA, elf_wrapper> {
   elf_wrapper* get_native_exec_handler();
   std::map<std::string, symbol_base_t<VA>*, ltstr>& get_linkage_symtab();
 
-  virtual symtab_error_e init() throw(symtab_exception_t);
-  virtual symtab_error_e read_linkage_symbols() throw(symtab_exception_t);
+  virtual symtab_error_e init();
+  virtual symtab_error_e read_linkage_symbols();
   virtual symtab_error_e fetch_DSO_info(std::string&,
-                                        bool&) throw(symtab_exception_t);
+                                        bool&);
   // virtual symtab_error_e read_debug_symbols() = 0;
-  //   throw ( symtab_exception_t ) = 0;
 
   //
   // Some Util methods.

--- a/launchmon/src/linux/sdbg_linux_symtab_impl.hxx
+++ b/launchmon/src/linux/sdbg_linux_symtab_impl.hxx
@@ -252,7 +252,7 @@ elf_wrapper::~elf_wrapper() {
 
 
 */
-symtab_error_e elf_wrapper::init() throw(symtab_exception_t) {
+symtab_error_e elf_wrapper::init() {
   using namespace std;
 
   string e;
@@ -357,8 +357,7 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::~linux_image_t() {}
 
 */
 template <LINUX_IMAGE_TEMPLATELIST>
-symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::init() throw(
-    symtab_exception_t) {
+symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::init() {
   using namespace std;
 
   elf_wrapper* elfw;
@@ -388,8 +387,7 @@ symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::init() throw(
 */
 template <LINUX_IMAGE_TEMPLATELIST>
 symtab_error_e
-linux_image_t<LINUX_IMAGE_TEMPLPARAM>::read_linkage_symbols() throw(
-    symtab_exception_t) {
+linux_image_t<LINUX_IMAGE_TEMPLPARAM>::read_linkage_symbols() {
   using namespace std;
 
   string e;
@@ -503,7 +501,7 @@ linux_image_t<LINUX_IMAGE_TEMPLPARAM>::read_linkage_symbols() throw(
 template <LINUX_IMAGE_TEMPLATELIST>
 symtab_error_e linux_image_t<LINUX_IMAGE_TEMPLPARAM>::fetch_DSO_info(
     std::string& where_is_interpreter,
-    bool& found_interp) throw(symtab_exception_t) {
+    bool& found_interp) {
   using namespace std;
 
   string e;

--- a/launchmon/src/sdbg_base_symtab.hxx
+++ b/launchmon/src/sdbg_base_symtab.hxx
@@ -194,19 +194,18 @@ class image_base_t {
   // OPs on symtabs
   //
   void print_sorted_linkage_symtab();
-  symtab_error_e compute_reloc() throw(symtab_exception_t);
+  symtab_error_e compute_reloc();
   // void print_sorted_debug_symtab();
 
   //
   // pure virtual methods
   //
-  symtab_error_e init(const std::string &lib) throw(symtab_exception_t);
-  virtual symtab_error_e init() throw(symtab_exception_t) = 0;
-  virtual symtab_error_e read_linkage_symbols() throw(symtab_exception_t) = 0;
+  symtab_error_e init(const std::string &lib);
+  virtual symtab_error_e init() = 0;
+  virtual symtab_error_e read_linkage_symbols() = 0;
   virtual symtab_error_e fetch_DSO_info(std::string &,
-                                        bool &) throw(symtab_exception_t) = 0;
-  // virtual symtab_error_e read_debug_symbols()
-  //   throw ( symtab_exception_t ) = 0;
+                                        bool &) = 0;
+  // virtual symtab_error_e read_debug_symbols() = 0;
 
   //
   // Some Util methods.

--- a/launchmon/src/sdbg_base_symtab_impl.hxx
+++ b/launchmon/src/sdbg_base_symtab_impl.hxx
@@ -290,8 +290,7 @@ const symbol_base_t<BASE_SYMTAB_TEMPLPARAM>
     computes the relocated address for each symbol
 */
 template <BASE_IMAGE_TEMPLATELIST>
-symtab_error_e image_base_t<BASE_IMAGE_TEMPLPARAM>::compute_reloc() throw(
-    symtab_exception_t) {
+symtab_error_e image_base_t<BASE_IMAGE_TEMPLPARAM>::compute_reloc() {
   using namespace std;
   string e;
   string func = "[image_base_t::compute_reloc]";
@@ -334,7 +333,7 @@ void image_base_t<BASE_IMAGE_TEMPLPARAM>::print_sorted_linkage_symtab() {
 
 template <BASE_IMAGE_TEMPLATELIST>
 symtab_error_e image_base_t<BASE_IMAGE_TEMPLPARAM>::init(
-    const std::string &lib) throw(symtab_exception_t) {
+    const std::string &lib) {
   char tempstr[PATH_MAX];
 
   sprintf(tempstr, "%s", lib.c_str());

--- a/launchmon/src/sdbg_base_tracer.hxx
+++ b/launchmon/src/sdbg_base_tracer.hxx
@@ -156,89 +156,88 @@ class tracer_base_t {
   //
   virtual tracer_error_e tracer_setregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_getregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_setfpregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_getfpregs(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_read(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_read_string(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf, int size,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_get_event_msg(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, void *buf,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_write(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, VA addr, const void *buf,
-      int size, bool use_cxt) throw(tracer_exception_t) = 0;
+      int size, bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_continue(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_deliver_signal(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, int sig,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_stop(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
                                      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_kill(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_singlestep(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_syscall(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
-      bool use_cxt) throw(tracer_exception_t) = 0;
+      bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_detach(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt) = 0;
 
   virtual tracer_error_e tracer_setoptions(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid) throw(tracer_exception_t) = 0;
+      pid_t newtid) = 0;
 
   virtual tracer_error_e tracer_unsetoptions(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid) throw(tracer_exception_t) = 0;
+      pid_t newtid) = 0;
 
   virtual tracer_error_e tracer_attach(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, bool use_cxt,
-      pid_t newtid) throw(tracer_exception_t) = 0;
+      pid_t newtid) = 0;
 
   virtual tracer_error_e status(process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p,
                                 bool use_cxt) = 0;
 
-  virtual tracer_error_e tracer_trace_me() throw(tracer_exception_t) = 0;
+  virtual tracer_error_e tracer_trace_me() = 0;
 
   virtual tracer_error_e enable_breakpoint(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
-      bool use_cxt, bool change_state = true) throw(tracer_exception_t) = 0;
+      bool use_cxt, bool change_state = true) = 0;
 
   virtual tracer_error_e disable_breakpoint(
       process_base_t<SDBG_DEFAULT_TEMPLPARAM> &p, breakpoint_base_t<VA, IT> &bp,
-      bool use_cxt, bool change_state = true) throw(tracer_exception_t) = 0;
+      bool use_cxt, bool change_state = true) = 0;
 
-  virtual tracer_error_e convert_error_code(int err) throw(
-      tracer_exception_t) = 0;
+  virtual tracer_error_e convert_error_code(int err) = 0;
 };
 
 #endif  // SDBG_BASE_TRACER_HXX


### PR DESCRIPTION
This language feature was deprecated in C++11 and removed in C++17. Starting with gcc-11 and clang-12, the default C++ standard is C++17- preventing LaunchMON from being built with those compilers without forcing an earlier standard (e.g., -std=c++11).

Fixes #61

@dongahn It's me again! I'm working my way through the tools SDK.