### PR TITLE
Fix build errors in unused template bodies

### DIFF
--- a/launchmon/src/sdbg_base_launchmon_impl.hxx
+++ b/launchmon/src/sdbg_base_launchmon_impl.hxx
@@ -104,7 +104,7 @@ launchmon_base_t<SDBG_DEFAULT_TEMPLPARAM>
   FE_sockfd = rhs.FE_sockfd;
   API_mode = rhs.API_mode;
   last_seen = rhs.last_seen;
-  warm_period = rhs.iwarm_period;
+  warm_period = rhs.warm_period;
   //
   // This should actually never be called
   //

--- a/launchmon/src/sdbg_base_symtab_impl.hxx
+++ b/launchmon/src/sdbg_base_symtab_impl.hxx
@@ -179,7 +179,7 @@ template <BASE_IMAGE_TEMPLATELIST>
 image_base_t<BASE_IMAGE_TEMPLPARAM>::image_base_t(
     const image_base_t<BASE_IMAGE_TEMPLPARAM> &im) {
   base_image_name = im.base_image_name;
-  path = im.base_path_name;
+  path = im.base_image_name;
   //
   // We are not copying linkage_symtab and debug_symtab
   // because of our use of std::map.


### PR DESCRIPTION
gcc-15 now does syntax analysis on template bodies, even if they are not instantiated.